### PR TITLE
Fix vanilla imports

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_CONTROLLER_URL=wss://jimm.jujucharms.com/api
+SASS_PATH=node_modules:src

--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
+# API host to allow app to connect and retrieve models
 REACT_APP_CONTROLLER_URL=wss://jimm.jujucharms.com/api
+# Sass path to allow Sass to reference NPM packages directly
 SASS_PATH=node_modules:src

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-scripts": "3.0.1",
     "react-test-renderer": "^16.9.0",
     "redux": "4.0.4",
-    "vanilla-framework": "2.1.0"
+    "vanilla-framework": "2.3.0"
   },
   "devDependencies": {
     "prettier": "1.18.2",

--- a/src/components/SecondaryNav/_secondary-nav.scss
+++ b/src/components/SecondaryNav/_secondary-nav.scss
@@ -1,6 +1,8 @@
+@import "vanilla-framework/scss/settings_colors";
+
 .p-secondary-nav {
   .p-list__link {
-    color: #111;
+    color: $color-dark;
   }
 
   .p-list__item {
@@ -8,7 +10,7 @@
 
     &.is-selected {
       font-weight: 400;
-      border-left: 3px solid #335280;
+      border-left: 3px solid $color-information;
       padding-left: calc(1rem - 3px);
     }
   }

--- a/src/scss/_layout.scss
+++ b/src/scss/_layout.scss
@@ -1,3 +1,5 @@
+@import "vanilla-framework/scss/settings_colors";
+
 .l-container {
   display: grid;
   grid-template-columns: 150px 1fr;
@@ -5,7 +7,7 @@
 }
 
 .l-side {
-  background: #f7f7f7;
+  background: $color-light;
   padding: 0.5rem;
   padding-left: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10244,10 +10244,10 @@ value-equal@^0.4.0:
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
   integrity sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==
 
-vanilla-framework@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.1.0.tgz#2c2d9810f81be4ed2bbee029424b90933df4c12b"
-  integrity sha512-0FprfDwzWHv9LNRe/RNwyV5pXIUz1JOdEsc/6wgKWNk/QUggWpoMmCWrA+asI+XIyLqroxP6bSP+zb0oNOmiLQ==
+vanilla-framework@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.3.0.tgz#420925e905ce451273bc54c8e5792f58fdd0ddf4"
+  integrity sha512-E208jQV9JIYDTciYInoy7gFZgRS9HKfS6TvCGja/pvYekom/zu4O/U4mWsUJ5Yq2vgjpa5w6CCSSAHhHxZ/Vxw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Done

Fix vanilla imports by adding env variable to `node_modules` folder and adding `@import "vanilla-framework/scss/colors_settings";` to each SCSS partial.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify no errors in console
- Verify page loads correctly

## Details

Fixes #13

