### PR TITLE
Add the credential name to the model details table.

### DIFF
--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -11,20 +11,22 @@ import MainTable from "../MainTable/MainTable";
 */
 function generateModelTableData(state) {
   const models = state.juju.models;
+  const modelInfo = state.juju.modelInfo;
   return Object.keys(models).map(modelUUID => {
-    const info = models[modelUUID];
+    const modelListData = models[modelUUID];
+    const modelInfoData = modelInfo[modelUUID];
     const modelStatus = state.juju.modelStatuses[modelUUID];
     return {
       columns: [
-        { content: info.name },
-        { content: info.ownerTag.split("@")[0].replace("user-", "") },
+        { content: modelListData.name },
+        { content: modelListData.ownerTag.split("@")[0].replace("user-", "") },
         { content: getStatusValue(modelStatus, "summary") },
         { content: getStatusValue(modelStatus, "cloudTag") },
         { content: getStatusValue(modelStatus, "region") },
-        // Fetch the credential name from somewhere.
-        { content: "unavailable" },
-        // Fetch the controller name from somewhere.
-        { content: "unavailable" },
+        { content: getStatusValue(modelInfoData, "cloudCredentialTag") },
+        // We're not currently able to get the controller name from the API.
+        // so display the controller UUID instead.
+        { content: getStatusValue(modelInfoData, "controllerUuid") },
         // We're not currently able to get a last-accessed or updated from JAAS.
         { content: "unavailable" }
       ]
@@ -66,6 +68,12 @@ function getStatusValue(status, key) {
         break;
       case "region":
         returnValue = status.model.region;
+        break;
+      case "cloudCredentialTag":
+        returnValue = status.cloudCredentialTag.split("cloudcred-")[1];
+        break;
+      case "controllerUuid":
+        returnValue = status.controllerUuid;
         break;
       default:
         console.log(`unsupported status value key: ${key}`);

--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -67,6 +67,9 @@ function getStatusValue(status, key) {
       case "region":
         returnValue = status.model.region;
         break;
+      default:
+        console.log(`unsupported status value key: ${key}`);
+        break;
     }
   }
   return returnValue;

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ async function connectAndListModels(reduxStore) {
     let continuePolling = true;
     while (continuePolling) {
       await fetchAllModelStatuses(
+        conn,
         reduxStore.getState().juju.models,
         reduxStore.dispatch
       );

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -1,6 +1,7 @@
 // Action labels
 export const actionsList = {
   fetchModelList: "FETCH_MODEL_LIST",
+  updateModelInfo: "UPDATE_MODEL_INFO",
   updateModelStatus: "UPDATE_MODEL_STATUS",
   updateModelList: "UPDATE_MODEL_LIST"
 };

--- a/src/juju/reducers.js
+++ b/src/juju/reducers.js
@@ -4,6 +4,7 @@ import { actionsList } from "./actions";
 
 export default produce(
   (draftState, action) => {
+    const payload = action.payload;
     switch (action.type) {
       case actionsList.updateModelList:
         const modelList = {};
@@ -19,12 +20,20 @@ export default produce(
         draftState.models = modelList;
         break;
       case actionsList.updateModelStatus:
-        const payload = action.payload;
         draftState.modelStatuses[payload.modelUUID] = payload.status;
+        break;
+      case actionsList.updateModelInfo:
+        const modelInfo = payload.results[0].result;
+        draftState.modelInfo[modelInfo.uuid] = modelInfo;
+        break;
+      default:
+        // No default value, fall through.
+        break;
     }
   },
   {
     models: {},
+    modelInfo: {},
     modelStatuses: {}
   }
 );

--- a/src/reducers/root.js
+++ b/src/reducers/root.js
@@ -8,6 +8,9 @@ function rootReducer(state = {}, action) {
       case actionsList.updateControllerConnection:
         draftState.controllerConnection = action.payload;
         break;
+      default:
+        // no default value, fall through.
+        break;
     }
   });
 }


### PR DESCRIPTION
## Done

Request additional model information from the controller and display the credential name in the model table.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- You know how this goes already....It should now show the credential name and the controller uuid in the model table.

## Details

The content will likely wrap and overlay other columns, this needs to be addressed in a follow-up
