### PR TITLE
Add <Suspense> around main content area

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,30 +1,31 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
-// Components
-import ErrorBoundary from "components/ErrorBoundary/ErrorBoundary";
+import Loading from "components/Loading/Loading";
 
 // Pages
-import Controllers from "pages/Controllers/Controllers";
-import Logs from "pages/Logs/Logs";
-import Models from "pages/Models/Models";
-import ModelDetails from "pages/Models/Details/ModelDetails";
-import NotFound from "pages/NotFound/NotFound";
-import Usage from "pages/Usage/Usage";
+const Controllers = React.lazy(() => import("pages/Controllers/Controllers"));
+const Logs = React.lazy(() => import("pages/Logs/Logs"));
+const Models = React.lazy(() => import("pages/Models/Models"));
+const ModelDetails = React.lazy(() =>
+  import("pages/Models/Details/ModelDetails")
+);
+const NotFound = React.lazy(() => import("pages/NotFound/NotFound"));
+const Usage = React.lazy(() => import("pages/Usage/Usage"));
 
 function App() {
   return (
     <Router>
-      <ErrorBoundary>
-        <Switch>
+      <Switch>
+        <Suspense fallback={<Loading />}>
           <Route path="/" exact component={Models} />
           <Route path="/models/:id" exact component={ModelDetails} />
           <Route path="/controllers" exact component={Controllers} />
           <Route path="/usage" exact component={Usage} />
           <Route path="/logs" exact component={Logs} />
           <Route component={NotFound} />
-        </Switch>
-      </ErrorBoundary>
+        </Suspense>
+      </Switch>
     </Router>
   );
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,16 +16,16 @@ const Usage = React.lazy(() => import("pages/Usage/Usage"));
 function App() {
   return (
     <Router>
-      <Switch>
-        <Suspense fallback={<Loading />}>
+      <Suspense fallback={<Loading />}>
+        <Switch>
           <Route path="/" exact component={Models} />
           <Route path="/models/:id" exact component={ModelDetails} />
           <Route path="/controllers" exact component={Controllers} />
           <Route path="/usage" exact component={Usage} />
           <Route path="/logs" exact component={Logs} />
           <Route component={NotFound} />
-        </Suspense>
-      </Switch>
+        </Switch>
+      </Suspense>
     </Router>
   );
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,7 @@
 import React, { Suspense } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
+import Layout from "components/Layout/Layout";
 import Loading from "components/Loading/Loading";
 
 // Pages
@@ -16,16 +17,18 @@ const Usage = React.lazy(() => import("pages/Usage/Usage"));
 function App() {
   return (
     <Router>
-      <Suspense fallback={<Loading />}>
-        <Switch>
-          <Route path="/" exact component={Models} />
-          <Route path="/models/:id" exact component={ModelDetails} />
-          <Route path="/controllers" exact component={Controllers} />
-          <Route path="/usage" exact component={Usage} />
-          <Route path="/logs" exact component={Logs} />
-          <Route component={NotFound} />
-        </Switch>
-      </Suspense>
+      <Layout>
+        <Suspense fallback={<Loading />}>
+          <Switch>
+            <Route path="/" exact component={Models} />
+            <Route path="/models/:id" exact component={ModelDetails} />
+            <Route path="/controllers" exact component={Controllers} />
+            <Route path="/usage" exact component={Usage} />
+            <Route path="/logs" exact component={Logs} />
+            <Route component={NotFound} />
+          </Switch>
+        </Suspense>
+      </Layout>
     </Router>
   );
 }

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -2,81 +2,85 @@
 
 exports[`App renders without crashing and matches snapshot 1`] = `
 <BrowserRouter>
-  <Switch>
+  <Layout
+    sidebar={true}
+  >
     <Suspense
       fallback={<Loading />}
     >
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+      <Switch>
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-        exact={true}
-        path="/"
-      />
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+          exact={true}
+          path="/"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-        exact={true}
-        path="/models/:id"
-      />
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+          exact={true}
+          path="/models/:id"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-        exact={true}
-        path="/controllers"
-      />
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+          exact={true}
+          path="/controllers"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-        exact={true}
-        path="/usage"
-      />
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+          exact={true}
+          path="/usage"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-        exact={true}
-        path="/logs"
-      />
-      <Route
-        component={
-          Object {
-            "$$typeof": Symbol(react.lazy),
-            "_ctor": [Function],
-            "_result": null,
-            "_status": -1,
+          exact={true}
+          path="/logs"
+        />
+        <Route
+          component={
+            Object {
+              "$$typeof": Symbol(react.lazy),
+              "_ctor": [Function],
+              "_result": null,
+              "_status": -1,
+            }
           }
-        }
-      />
+        />
+      </Switch>
     </Suspense>
-  </Switch>
+  </Layout>
 </BrowserRouter>
 `;

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -2,37 +2,81 @@
 
 exports[`App renders without crashing and matches snapshot 1`] = `
 <BrowserRouter>
-  <ErrorBoundary>
-    <Switch>
+  <Switch>
+    <Suspense
+      fallback={<Loading />}
+    >
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
         exact={true}
         path="/"
       />
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
         exact={true}
         path="/models/:id"
       />
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
         exact={true}
         path="/controllers"
       />
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
         exact={true}
         path="/usage"
       />
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
         exact={true}
         path="/logs"
       />
       <Route
-        component={[Function]}
+        component={
+          Object {
+            "$$typeof": Symbol(react.lazy),
+            "_ctor": [Function],
+            "_result": null,
+            "_status": -1,
+          }
+        }
       />
-    </Switch>
-  </ErrorBoundary>
+    </Suspense>
+  </Switch>
 </BrowserRouter>
 `;

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -26,7 +26,13 @@ const Layout = ({ sidebar, children }) => {
         )}
         <div className="l-main">
           <ErrorBoundary>
-            {isLoggedIn ? <main id="main-content">{children}</main> : <Login />}
+            {isLoggedIn ? (
+              <main className="main-content" id="main-content">
+                {children}
+              </main>
+            ) : (
+              <Login />
+            )}
           </ErrorBoundary>
         </div>
       </div>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,11 +1,16 @@
 import React from "react";
 import classNames from "classnames";
+import ErrorBoundary from "components/ErrorBoundary/ErrorBoundary";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 import SecondaryNav from "components/SecondaryNav/SecondaryNav";
+import Login from "components/Login/Login";
 
 import "./_layout.scss";
 
 const Layout = ({ sidebar, children }) => {
+  // Temp circumvent this step until login solution is implemented
+  const isLoggedIn = true;
+
   return (
     <>
       <PrimaryNav />
@@ -20,7 +25,9 @@ const Layout = ({ sidebar, children }) => {
           </div>
         )}
         <div className="l-main">
-          <main id="main-content">{children}</main>
+          <ErrorBoundary>
+            {isLoggedIn ? <main id="main-content">{children}</main> : <Login />}
+          </ErrorBoundary>
         </div>
       </div>
     </>

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -22,7 +22,7 @@ describe("Layout", () => {
   it("should display the children", () => {
     const wrapper = shallow(<Layout>content</Layout>);
     expect(wrapper.find("#main-content").html()).toStrictEqual(
-      `<main id="main-content">content</main>`
+      `<main class="main-content" id="main-content">content</main>`
     );
   });
 });

--- a/src/components/Layout/__snapshots__/Layout.test.js.snap
+++ b/src/components/Layout/__snapshots__/Layout.test.js.snap
@@ -16,6 +16,7 @@ exports[`Layout renders without crashing and matches snapshot 1`] = `
     >
       <ErrorBoundary>
         <main
+          className="main-content"
           id="main-content"
         />
       </ErrorBoundary>

--- a/src/components/Layout/__snapshots__/Layout.test.js.snap
+++ b/src/components/Layout/__snapshots__/Layout.test.js.snap
@@ -14,9 +14,11 @@ exports[`Layout renders without crashing and matches snapshot 1`] = `
     <div
       className="l-main"
     >
-      <main
-        id="main-content"
-      />
+      <ErrorBoundary>
+        <main
+          id="main-content"
+        />
+      </ErrorBoundary>
     </div>
   </div>
 </Fragment>

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -16,3 +16,7 @@
   padding: 0.5rem;
   padding-left: 0;
 }
+
+.main-content {
+  display: grid;
+}

--- a/src/components/Loading/Loading.js
+++ b/src/components/Loading/Loading.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+import "./_loading.scss";
+
+export default function Loading() {
+  return (
+    <div className="loading">
+      <i className="p-icon--spinner u-animation--spin"></i>
+    </div>
+  );
+}

--- a/src/components/Loading/Loading.test.js
+++ b/src/components/Loading/Loading.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import Loading from "./Loading";
+
+describe("Loading", () => {
+  it("renders without crashing and matches snapshot", () => {
+    const wrapper = shallow(<Loading />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Loading/__snapshots__/Loading.test.js.snap
+++ b/src/components/Loading/__snapshots__/Loading.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loading renders without crashing and matches snapshot 1`] = `
+<div
+  className="loading"
+>
+  <img
+    alt="Loading..."
+    className="loading__spinner"
+    src="https://assets.ubuntu.com/v1/60ddfec6-spinner.svg"
+  />
+</div>
+`;

--- a/src/components/Loading/__snapshots__/Loading.test.js.snap
+++ b/src/components/Loading/__snapshots__/Loading.test.js.snap
@@ -4,10 +4,8 @@ exports[`Loading renders without crashing and matches snapshot 1`] = `
 <div
   className="loading"
 >
-  <img
-    alt="Loading..."
-    className="loading__spinner"
-    src="https://assets.ubuntu.com/v1/60ddfec6-spinner.svg"
+  <i
+    className="p-icon--spinner u-animation--spin"
   />
 </div>
 `;

--- a/src/components/Loading/_loading.scss
+++ b/src/components/Loading/_loading.scss
@@ -2,7 +2,7 @@
   align-content: center;
   display: grid;
   grid-template-columns: 1fr;
-  height: 100vh;
+  height: calc(100vh - 48px);
   width: 100vw;
 
   .p-icon--spinner {

--- a/src/components/Loading/_loading.scss
+++ b/src/components/Loading/_loading.scss
@@ -1,0 +1,14 @@
+.loading {
+  align-content: center;
+  display: grid;
+  grid-template-columns: 1fr;
+  height: 100vh;
+  width: 100vw;
+
+  .p-icon--spinner {
+    height: 2rem;
+    margin: auto;
+    transform: rotate(360deg);
+    width: 2rem;
+  }
+}

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -5,7 +5,35 @@ import "./_login.scss";
 export default function Login() {
   return (
     <div className="login">
-      <button className="p-button--positive">Log in to view your models</button>
+      <h1 className="login__heading">
+        <div className="p-media-object">
+          <img
+            alt=""
+            width="50"
+            src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg"
+            className="p-media-object__image"
+          />
+          <div className="p-media-object__details">
+            <h3 className="p-media-object__title">Canonical Candid</h3>
+          </div>
+        </div>
+      </h1>
+      <div className="p-card--highlighted">
+        <h3>Login</h3>
+        <div className="p-media-object">
+          <img
+            alt=""
+            width="50"
+            src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg"
+            className="p-media-object__image"
+          />
+          <div className="p-media-object__details">
+            <h3 className="p-media-object__title">Ubuntu SSO</h3>
+          </div>
+        </div>
+        <p>Will authenticate with Candid in order to log you in.</p>
+        <button className="p-button--positive">Proceed</button>
+      </div>
     </div>
   );
 }

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,13 +1,11 @@
 import React from "react";
 
-import Layout from "components/Layout/Layout";
+import "./_login.scss";
 
 export default function Login() {
   return (
-    <Layout sidebar={false}>
-      <h1>Login</h1>
-      <p>Please log in to view and manage your models.</p>
-      <button className="p-button--positive">Log in</button>
-    </Layout>
+    <div className="login">
+      <button className="p-button--positive">Log in to view your models</button>
+    </div>
   );
 }

--- a/src/components/Login/_login.scss
+++ b/src/components/Login/_login.scss
@@ -1,0 +1,9 @@
+.login {
+  align-content: center;
+  display: grid;
+  height: calc(100vh - 48px);
+
+  .p-button--positive {
+    margin: auto;
+  }
+}

--- a/src/components/Login/_login.scss
+++ b/src/components/Login/_login.scss
@@ -1,7 +1,18 @@
+@import "vanilla-framework/scss/settings_colors";
+
 .login {
   align-content: center;
+  background: $color-mid-light;
   display: grid;
   height: calc(100vh - 48px);
+
+  &__heading {
+    margin: 3rem auto;
+  }
+
+  .p-card--highlighted {
+    margin: auto;
+  }
 
   .p-button--positive {
     margin: auto;

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -1,15 +1,11 @@
 import React from "react";
 
-import Layout from "components/Layout/Layout";
-
 export default function Controllers() {
   return (
-    <Layout>
-      <div className="p-strip">
-        <div className="row">
-          <h2>Controllers</h2>
-        </div>
+    <div className="p-strip">
+      <div className="row">
+        <h2>Controllers</h2>
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/pages/Controllers/__snapshots__/Controllers.test.js.snap
+++ b/src/pages/Controllers/__snapshots__/Controllers.test.js.snap
@@ -1,19 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Controllers page renders without crashing and matches snapshot 1`] = `
-<Layout
-  sidebar={true}
+<div
+  className="p-strip"
 >
   <div
-    className="p-strip"
+    className="row"
   >
-    <div
-      className="row"
-    >
-      <h2>
-        Controllers
-      </h2>
-    </div>
+    <h2>
+      Controllers
+    </h2>
   </div>
-</Layout>
+</div>
 `;

--- a/src/pages/Logs/Logs.js
+++ b/src/pages/Logs/Logs.js
@@ -1,15 +1,11 @@
 import React from "react";
 
-import Layout from "components/Layout/Layout";
-
 export default function Logs() {
   return (
-    <Layout>
-      <div className="p-strip">
-        <div className="row">
-          <h2>Logs</h2>
-        </div>
+    <div className="p-strip">
+      <div className="row">
+        <h2>Logs</h2>
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/pages/Logs/__snapshots__/Logs.test.js.snap
+++ b/src/pages/Logs/__snapshots__/Logs.test.js.snap
@@ -1,19 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Logs page renders without crashing and matches snapshot 1`] = `
-<Layout
-  sidebar={true}
+<div
+  className="p-strip"
 >
   <div
-    className="p-strip"
+    className="row"
   >
-    <div
-      className="row"
-    >
-      <h2>
-        Logs
-      </h2>
-    </div>
+    <h2>
+      Logs
+    </h2>
   </div>
-</Layout>
+</div>
 `;

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -2,7 +2,6 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { Terminal } from "@canonical/juju-react-components";
 
-import Layout from "components/Layout/Layout";
 import Filter from "components/Filter/Filter";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 import MainTable from "components/MainTable/MainTable";
@@ -95,7 +94,7 @@ const ModelDetails = () => {
   const statusFilters = ["all", "maintenance", "blocked"];
 
   return (
-    <Layout sidebar={false}>
+    <>
       <div className="model-details">
         <InfoPanel />
         <div className="model-details__main">
@@ -113,7 +112,7 @@ const ModelDetails = () => {
         creds={credentials}
         WebSocket={WebSocket}
       />
-    </Layout>
+    </>
   );
 };
 

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -5,6 +5,7 @@ import { Terminal } from "@canonical/juju-react-components";
 import Filter from "components/Filter/Filter";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 import MainTable from "components/MainTable/MainTable";
+import Login from "components/Login/Login";
 
 import { isLoggedIn, getUserCredentials } from "app/selectors";
 
@@ -87,7 +88,7 @@ const ModelDetails = () => {
   const isUserLoggedIn = useSelector(isLoggedIn);
 
   if (!isUserLoggedIn) {
-    return <div>Please log in</div>;
+    return <Login />;
   }
 
   const viewFilters = ["all", "apps", "units", "machines", "relations"];

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -798,7 +798,157 @@ exports[`ModelDetail Container renders the details pane when the user is logged 
 `;
 
 exports[`ModelDetail Container renders with a login message when not logged in 1`] = `
-<div>
-  Please log in
-</div>
+Array [
+  <div
+    className="login"
+  >
+    <h1
+      className="login__heading"
+    >
+      <div
+        className="p-media-object"
+      >
+        <img
+          alt=""
+          className="p-media-object__image"
+          src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg"
+          width="50"
+        />
+        <div
+          className="p-media-object__details"
+        >
+          <h3
+            className="p-media-object__title"
+          >
+            Canonical Candid
+          </h3>
+        </div>
+      </div>
+    </h1>
+    <div
+      className="p-card--highlighted"
+    >
+      <h3>
+        Login
+      </h3>
+      <div
+        className="p-media-object"
+      >
+        <img
+          alt=""
+          className="p-media-object__image"
+          src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg"
+          width="50"
+        />
+        <div
+          className="p-media-object__details"
+        >
+          <h3
+            className="p-media-object__title"
+          >
+            Ubuntu SSO
+          </h3>
+        </div>
+      </div>
+      <p>
+        Will authenticate with Candid in order to log you in.
+      </p>
+      <button
+        className="p-button--positive"
+      >
+        Proceed
+      </button>
+    </div>
+  </div>,
+  <div
+    className="p-media-object"
+  >
+    <img
+      alt=""
+      className="p-media-object__image"
+      src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg"
+      width="50"
+    />
+    <div
+      className="p-media-object__details"
+    >
+      <h3
+        className="p-media-object__title"
+      >
+        Canonical Candid
+      </h3>
+    </div>
+  </div>,
+  <div
+    className="p-media-object__details"
+  >
+    <h3
+      className="p-media-object__title"
+    >
+      Canonical Candid
+    </h3>
+  </div>,
+  <div
+    className="p-card--highlighted"
+  >
+    <h3>
+      Login
+    </h3>
+    <div
+      className="p-media-object"
+    >
+      <img
+        alt=""
+        className="p-media-object__image"
+        src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg"
+        width="50"
+      />
+      <div
+        className="p-media-object__details"
+      >
+        <h3
+          className="p-media-object__title"
+        >
+          Ubuntu SSO
+        </h3>
+      </div>
+    </div>
+    <p>
+      Will authenticate with Candid in order to log you in.
+    </p>
+    <button
+      className="p-button--positive"
+    >
+      Proceed
+    </button>
+  </div>,
+  <div
+    className="p-media-object"
+  >
+    <img
+      alt=""
+      className="p-media-object__image"
+      src="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg"
+      width="50"
+    />
+    <div
+      className="p-media-object__details"
+    >
+      <h3
+        className="p-media-object__title"
+      >
+        Ubuntu SSO
+      </h3>
+    </div>
+  </div>,
+  <div
+    className="p-media-object__details"
+  >
+    <h3
+      className="p-media-object__title"
+    >
+      Ubuntu SSO
+    </h3>
+  </div>,
+]
 `;

--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -1,16 +1,12 @@
 import React from "react";
-
-import Layout from "components/Layout/Layout";
 import TableList from "components/TableList/TableList";
 
 export default function Models() {
   return (
-    <Layout sidebar>
-      <div className="p-strip">
-        <div className="row">
-          <TableList />
-        </div>
+    <div className="p-strip">
+      <div className="row">
+        <TableList />
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/pages/Models/__snapshots__/Models.test.js.snap
+++ b/src/pages/Models/__snapshots__/Models.test.js.snap
@@ -1,17 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Models page renders without crashing and matches snapshot 1`] = `
-<Layout
-  sidebar={true}
+<div
+  className="p-strip"
 >
   <div
-    className="p-strip"
+    className="row"
   >
-    <div
-      className="row"
-    >
-      <TableList />
-    </div>
+    <TableList />
   </div>
-</Layout>
+</div>
 `;

--- a/src/pages/NotFound/NotFound.js
+++ b/src/pages/NotFound/NotFound.js
@@ -1,15 +1,11 @@
 import React from "react";
 
-import Layout from "components/Layout/Layout";
-
 export default function NotFound() {
   return (
-    <Layout>
-      <div className="p-strip">
-        <div className="row">
-          <h2>¯\_(ツ)_/¯</h2>
-        </div>
+    <div className="p-strip">
+      <div className="row">
+        <h2>¯\_(ツ)_/¯</h2>
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/pages/NotFound/__snapshots__/NotFound.test.js.snap
+++ b/src/pages/NotFound/__snapshots__/NotFound.test.js.snap
@@ -1,19 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotFound page renders without crashing and matches snapshot 1`] = `
-<Layout
-  sidebar={true}
+<div
+  className="p-strip"
 >
   <div
-    className="p-strip"
+    className="row"
   >
-    <div
-      className="row"
-    >
-      <h2>
-        ¯\\_(ツ)_/¯
-      </h2>
-    </div>
+    <h2>
+      ¯\\_(ツ)_/¯
+    </h2>
   </div>
-</Layout>
+</div>
 `;

--- a/src/pages/Usage/Usage.js
+++ b/src/pages/Usage/Usage.js
@@ -1,14 +1,11 @@
 import React from "react";
-import Layout from "components/Layout/Layout";
 
 export default function Usage() {
   return (
-    <Layout>
-      <div className="p-strip">
-        <div className="row">
-          <h2>Usage</h2>
-        </div>
+    <div className="p-strip">
+      <div className="row">
+        <h2>Usage</h2>
       </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/pages/Usage/__snapshots__/Usage.test.js.snap
+++ b/src/pages/Usage/__snapshots__/Usage.test.js.snap
@@ -1,19 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Usage page renders without crashing and matches snapshot 1`] = `
-<Layout
-  sidebar={true}
+<div
+  className="p-strip"
 >
   <div
-    className="p-strip"
+    className="row"
   >
-    <div
-      className="row"
-    >
-      <h2>
-        Usage
-      </h2>
-    </div>
+    <h2>
+      Usage
+    </h2>
   </div>
-</Layout>
+</div>
 `;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -11,10 +11,12 @@ $increase-font-size-on-larger-screens: false;
 
 @include vf-base;
 @include vf-p-buttons;
+@include vf-p-card;
 @include vf-p-grid;
 @include vf-p-icons;
 @include vf-p-links;
 @include vf-p-lists;
+@include vf-p-media-object;
 @include vf-b-typography;
 @include vf-p-navigation;
 @include vf-p-muted-heading;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -12,6 +12,7 @@ $increase-font-size-on-larger-screens: false;
 @include vf-base;
 @include vf-p-buttons;
 @include vf-p-grid;
+@include vf-p-icons;
 @include vf-p-links;
 @include vf-p-lists;
 @include vf-b-typography;
@@ -24,6 +25,7 @@ $increase-font-size-on-larger-screens: false;
 @include vf-p-table-mobile-card;
 @include vf-p-table-sortable;
 @include vf-u-layout;
+@include vf-u-animations;
 
 // Fix consecutive table bug
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2491


### PR DESCRIPTION
## Done

- Add `<Suspense>` around main content area. This will display a loading component until all lazy-loaded components in the tree beneath it have loaded. 
- Wrap `<ErrorBoundary>` around the main content area so that if a component fails, it'll not lock up the entire app but leave the navigation still visible so other sections can still be accessed.


## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Refresh manically to verify a loading spinner

