### PR TITLE
Create Terminal component on ModelDetails page

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "redux-devtools-extension": "2.13.8",
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "2.3.0",
+    "reselect": "^4.0.0",
     "vanilla-framework": "2.3.0",
     "xterm": "4.0.2",
     "xterm-addon-fit": "0.2.1"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "redux-devtools-extension": "2.13.8",
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "2.3.0",
-    "vanilla-framework": "2.3.0"
+    "vanilla-framework": "2.3.0",
+    "xterm": "4.0.2",
+    "xterm-addon-fit": "0.2.1"
   },
   "devDependencies": {
     "eslint-config-airbnb": "18.0.1",

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -6,18 +6,29 @@ export const isLoggedIn = state =>
   state.root.controllerConnection && state.root.bakery;
 
 /**
-  Pull the users macaroon credentials from state, base64 decode and json parse.
-  @returns {Object} The users macaroons in an object with a `macaroons` key.
-    It's an object because this can be expanded to include user/pass credential
-    keys in the future without changing the data type.
+  Pull the users macaroon credentials from state.
+  @returns {Object} The macaroons extracted from the bakery in state.
 */
 export const getUserCredentials = state => {
-  let decodedMacaroons = {};
+  let storedMacaroons = null;
   if (state.root && state.root.bakery) {
-    const storedMacaroons = state.root.bakery.storage._store._items;
-    Object.keys(storedMacaroons).forEach(key => {
-      decodedMacaroons[key] = JSON.parse(atob(storedMacaroons[key]));
-    });
+    storedMacaroons = state.root.bakery.storage._store._items;
   }
-  return { macaroons: decodedMacaroons };
+  return storedMacaroons;
+};
+
+/**
+  Base64 decode and json parse the supplied macaroons from the bakery.
+  @param {Object} macaroons The macaroons data from the bakery.
+  @returns {Object} The users decoded macaroons.
+*/
+export const getDecodedMacaroons = macaroons => {
+  if (!macaroons) {
+    return null;
+  }
+  let decodedMacaroons = {};
+  Object.keys(macaroons).forEach(key => {
+    decodedMacaroons[key] = JSON.parse(atob(macaroons[key]));
+  });
+  return decodedMacaroons;
 };

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -28,7 +28,11 @@ export const getDecodedMacaroons = macaroons => {
   }
   let decodedMacaroons = {};
   Object.keys(macaroons).forEach(key => {
-    decodedMacaroons[key] = JSON.parse(atob(macaroons[key]));
+    try {
+      decodedMacaroons[key] = JSON.parse(atob(macaroons[key]));
+    } catch (err) {
+      console.error("Unable to decode macaroons", err);
+    }
   });
   return decodedMacaroons;
 };

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Terminal as Xterm } from "xterm";
+import { FitAddon as XtermFitAddon } from "xterm-addon-fit";
+
+import "../../../node_modules/xterm/css/xterm.css";
+import "./_terminal.scss";
+
+let terminalInstance = new Xterm();
+let fitAddon = new XtermFitAddon();
+
+terminalInstance.loadAddon(fitAddon);
+
+const Terminal = () => {
+  const [state, setState] = useState();
+  const terminalElement = useRef(null);
+
+  useEffect(() => {
+    terminalInstance.open(terminalElement.current);
+    fitAddon.fit();
+    terminalInstance.write("Hello from \x1B[1;3;31mxterm.js\x1B[0m $ ");
+  }, []);
+
+  return (
+    <div className="terminal">
+      <div className="terminal-header">Juju Terminal</div>
+      <div className="terminal-shell" ref={terminalElement}></div>
+    </div>
+  );
+};
+
+export default Terminal;

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -1,24 +1,19 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Terminal as Xterm } from "xterm";
-import { FitAddon as XtermFitAddon } from "xterm-addon-fit";
+
+import cleanUpTerminal from "./cleanup-terminal";
+import setupTerminal from "./setup-terminal";
 
 import "../../../node_modules/xterm/css/xterm.css";
 import "./_terminal.scss";
 
-let terminalInstance = new Xterm();
-let fitAddon = new XtermFitAddon();
-
-terminalInstance.loadAddon(fitAddon);
-
-const Terminal = () => {
+const Terminal = ({ address, creds }) => {
   const [state, setState] = useState();
   const terminalElement = useRef(null);
 
   useEffect(() => {
-    terminalInstance.open(terminalElement.current);
-    fitAddon.fit();
-    terminalInstance.write("Hello from \x1B[1;3;31mxterm.js\x1B[0m $ ");
-  }, []);
+    const terminalInstance = setupTerminal(address, creds, terminalElement);
+    return cleanUpTerminal(terminalInstance);
+  }, [address, creds]);
 
   return (
     <div className="terminal">

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, useState } from "react";
 import cleanUpTerminal from "./cleanup-terminal";
 import setupTerminal from "./setup-terminal";
 
-import "../../../node_modules/xterm/css/xterm.css";
 import "./_terminal.scss";
 
 const Terminal = ({ address, creds }) => {

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 
 import cleanUpTerminal from "./cleanup-terminal";
 import setupTerminal from "./setup-terminal";
@@ -6,7 +6,6 @@ import setupTerminal from "./setup-terminal";
 import "./_terminal.scss";
 
 const Terminal = ({ address, creds }) => {
-  const [state, setState] = useState();
   const terminalElement = useRef(null);
 
   useEffect(() => {

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -1,3 +1,5 @@
+@import "xterm/css/xterm";
+
 .terminal {
   position: absolute;
   bottom: 0;

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -1,0 +1,15 @@
+.terminal {
+  position: absolute;
+  bottom: 0;
+  background-color: black;
+  color: white;
+  width: 100%;
+
+  &-header {
+    height: 1.5rem;
+  }
+
+  &-shell {
+    height: 10rem;
+  }
+}

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -1,10 +1,10 @@
 @import "xterm/css/xterm";
 
 .terminal {
-  position: absolute;
-  bottom: 0;
   background-color: black;
+  bottom: 0;
   color: white;
+  position: absolute;
   width: 100%;
 
   &-header {

--- a/src/components/Terminal/cleanup-terminal.js
+++ b/src/components/Terminal/cleanup-terminal.js
@@ -1,0 +1,7 @@
+/**
+  Cleans up the terminal instance
+  @param {Xterm} terminalInstance The terminal instance to tear down.
+ */
+export default function cleanUpTerminal(terminalInstance) {
+  // Disonnect from terminal.
+}

--- a/src/components/Terminal/cleanup-terminal.js
+++ b/src/components/Terminal/cleanup-terminal.js
@@ -3,5 +3,5 @@
   @param {Xterm} terminalInstance The terminal instance to tear down.
  */
 export default function cleanUpTerminal(terminalInstance) {
-  // Disonnect from terminal.
+  // Disconnect from terminal.
 }

--- a/src/components/Terminal/setup-terminal.js
+++ b/src/components/Terminal/setup-terminal.js
@@ -61,7 +61,7 @@ export default function setupTerminal(address, creds, terminalElement) {
     if (resp.code === CODE_ERR) {
       console.error(resp.message);
       terminalInstance.write(
-        "Error talking to the terminal server: " + resp.message
+        `Error talking to the terminal server: ${resp.message}`
       );
       return;
     }

--- a/src/components/Terminal/setup-terminal.js
+++ b/src/components/Terminal/setup-terminal.js
@@ -1,0 +1,98 @@
+import { Terminal as Xterm } from "xterm";
+import { FitAddon as XtermFitAddon } from "xterm-addon-fit";
+
+import XtermTerminadoAddon from "./xterm-addon-terminado";
+
+// Define jujushell API operations and codes.
+const OP_LOGIN = "login";
+const OP_START = "start";
+const CODE_OK = "ok"; // eslint-disable-line no-unused-vars
+const CODE_ERR = "error";
+const UNEXPECTED_CLOSE =
+  "Terminal connection unexpectedly closed. " +
+  "Close and re-open the terminal window to reconnect.";
+
+/**
+  Setup the terminal instance.
+  @param {String} address The address to connect the websocket to.
+  @param {Object} creds The credentials format as extracted from the bakery
+    including username, password, or the macaroons for the active user.
+  @param {Object} terminalElement The element in the DOM to render the xterm
+    instance into.
+  @returns {XTerm} The new Xterm terminal instance.
+*/
+export default function setupTerminal(address, creds, terminalElement) {
+  let terminalInstance = new Xterm({
+    theme: {
+      background: "#111"
+    }
+  });
+
+  const ws = new WebSocket(address);
+
+  ws.onopen = () => {
+    ws.send(
+      JSON.stringify({
+        operation: OP_LOGIN,
+        username: creds.user,
+        password: creds.password,
+        macaroons: creds.macaroons
+      })
+    );
+    ws.send(JSON.stringify({ operation: OP_START }));
+  };
+
+  ws.onerror = err => {
+    terminalInstance.write("Failed to open Websocket connection");
+    console.error(err);
+  };
+
+  ws.onclose = evt => {
+    // 1000 is the code for a normal closure, anything above that is abnormal.
+    if (evt && evt.code > 1000) {
+      // It is not a normal closure so we should issue an error.
+      terminalInstance.writeln(UNEXPECTED_CLOSE);
+      console.log(evt);
+    }
+  };
+
+  ws.onmessage = evt => {
+    const resp = JSON.parse(evt.data);
+    if (resp.code === CODE_ERR) {
+      console.error(resp.message);
+      terminalInstance.write(
+        "Error talking to the terminal server: " + resp.message
+      );
+      return;
+    }
+    switch (resp[0]) {
+      case "disconnect":
+        // Terminado sends a "disconnect" message when the process it's
+        // running exits. When we receive that, we close the terminal.
+        // We also have to overwrite the onclose method because the WebSocket
+        // isn't properly terminated by terminado and instead a 1006 close
+        // code is generated triggering the error notification.
+        this.ws.onclose = () => {};
+        terminalInstance.writeln(UNEXPECTED_CLOSE);
+        break;
+      case "setup":
+        // Terminado sends a "setup" message after it's fully done setting
+        // up on the server side and will be sending the first PS1 to the
+        // client.
+        // XXX Allow the model to be switched to to be passed in
+        const cmd = "juju switch test3";
+        ws.send(JSON.stringify(["stdin", `${cmd}\n`]));
+        break;
+    }
+  };
+
+  let fitAddon = new XtermFitAddon();
+  terminalInstance.loadAddon(fitAddon);
+  terminalInstance.loadAddon(new XtermTerminadoAddon(ws));
+
+  terminalInstance.open(terminalElement.current);
+  fitAddon.fit();
+  terminalInstance.writeln("connecting... ");
+
+  return terminalInstance;
+}

--- a/src/components/Terminal/xterm-addon-terminado.js
+++ b/src/components/Terminal/xterm-addon-terminado.js
@@ -1,0 +1,72 @@
+class TerminadoAddon {
+  constructor(socket, options) {
+    this._disposables = [];
+    this._socket = socket;
+    this._socket.binaryType = "arraybuffer";
+    this._bidirectional =
+      options && options.bidirectional === false ? false : true;
+    this._utf8 = !!(options && options.inputUtf8);
+  }
+
+  activate(terminal) {
+    if (this._utf8) {
+      // TODO for terminado.
+      this._disposables.push(
+        addSocketListener(this._socket, "message", ev =>
+          terminal.writeUtf8(new Uint8Array(ev.data))
+        )
+      );
+    } else {
+      this._disposables.push(
+        addSocketListener(this._socket, "message", ev => {
+          const data = JSON.parse(ev.data);
+          // TODO add buffering support.
+          if (data[0] === "stdout") {
+            terminal.write(data[1]);
+          }
+        })
+      );
+    }
+
+    if (this._bidirectional) {
+      this._disposables.push(
+        terminal.onData(data => {
+          this._sendData(data);
+        })
+      );
+    }
+    this._disposables.push(
+      addSocketListener(this._socket, "close", () => {
+        this.dispose();
+      })
+    );
+    this._disposables.push(
+      addSocketListener(this._socket, "error", () => {
+        this.dispose();
+      })
+    );
+  }
+  dispose() {
+    this._disposables.forEach(d => d.dispose());
+  }
+  _sendData(data) {
+    if (this._socket.readyState !== 1) {
+      return;
+    }
+    this._socket.send(JSON.stringify(["stdin", data]));
+  }
+}
+
+function addSocketListener(socket, type, handler) {
+  socket.addEventListener(type, handler);
+  return {
+    dispose: () => {
+      if (!handler) {
+        return;
+      }
+      socket.removeEventListener(type, handler);
+    }
+  };
+}
+
+export default TerminadoAddon;

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -1,13 +1,18 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { Terminal } from "@canonical/juju-react-components";
+import { createSelector } from "reselect";
 
-import Layout from "components/Layout/Layout";
 import Filter from "components/Filter/Filter";
 import InfoPanel from "components/InfoPanel/InfoPanel";
+import Layout from "components/Layout/Layout";
 import MainTable from "components/MainTable/MainTable";
+import Terminal from "components/Terminal/Terminal";
 
-import { isLoggedIn, getUserCredentials } from "app/selectors";
+import {
+  isLoggedIn,
+  getDecodedMacaroons,
+  getUserCredentials
+} from "app/selectors";
 
 import "./_model-details.scss";
 
@@ -84,7 +89,11 @@ const MainTableRows = [
 ];
 
 const ModelDetails = () => {
-  const credentials = useSelector(getUserCredentials);
+  const getMacaroons = createSelector(
+    getUserCredentials,
+    getDecodedMacaroons
+  );
+  const macaroons = useSelector(getMacaroons);
   const isUserLoggedIn = useSelector(isLoggedIn);
 
   if (!isUserLoggedIn) {
@@ -110,7 +119,7 @@ const ModelDetails = () => {
         address="wss://shell.jujugui.org:443/ws/"
         addNotification={() => {}}
         close={() => {}}
-        creds={credentials}
+        creds={{ macaroons }}
         WebSocket={WebSocket}
       />
     </Layout>

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -25,15 +25,17 @@ describe("ModelDetail Container", () => {
     expect(wrapper.find("div")).toMatchSnapshot();
   });
 
-  it("renders the details pane when the user is logged in", () => {
-    const store = mockStore(dataDump);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <ModelDetail />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(".model-details")).toMatchSnapshot();
+  describe("When the user is logged in...", () => {
+    it("renders the details pane", () => {
+      const store = mockStore(dataDump);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter>
+            <ModelDetail />
+          </MemoryRouter>
+        </Provider>
+      );
+      expect(wrapper.find(".model-details")).toMatchSnapshot();
+    });
   });
 });

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -7,6 +7,8 @@ import dataDump from "testing/complete-redux-store-dump";
 
 import ModelDetail from "./ModelDetails";
 
+jest.mock("components/Terminal/Terminal", () => () => "Terminal");
+
 const mockStore = configureStore([]);
 
 describe("ModelDetail Container", () => {

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModelDetail Container renders the details pane when the user is logged in 1`] = `
+exports[`ModelDetail Container When the user is logged in... renders the details pane 1`] = `
 <div
   className="model-details"
 >

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -1,7 +1,7 @@
 .model-details {
   display: grid;
   grid-template-columns: 350px 1fr;
-  min-height: 100vh;
+  min-height: calc(100vh - 48px); // hack to fix initial set of 100vh
 
   &__filters {
     display: grid;

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -1,7 +1,7 @@
 .model-details {
   display: grid;
   grid-template-columns: 350px 1fr;
-  min-height: calc(100vh - 48px); // hack to fix initial set of 100vh
+  min-height: calc(100vh - 48px); // header is 48px high.
 
   &__filters {
     display: grid;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9920,6 +9920,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -12102,7 +12107,7 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xterm-addon-fit@^0.2.1:
+xterm-addon-fit@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.2.1.tgz#353f43921eb78e3f9ad3f3afbb14e7ac183ca738"
   integrity sha512-BlR57O3t1/bmVcnS81bn9ZnNf+GiGNbeXdNUKSBa9tKEwNUMcU3S+KFLIRv7rm1Ty0D5pMOu0vbz/RDorKRwKQ==
@@ -12114,15 +12119,15 @@ xterm-webfont@^1.1.1:
   dependencies:
     fontfaceobserver "2.*"
 
+xterm@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.0.2.tgz#c6a1b9586c0786627625e2ee9e78ad519dbc8c99"
+  integrity sha512-NIr11b6C782TZznU8e6K/IMfmwlWMWRI6ba9GEDG9uX25SadkpjoMnzvxOS0Z/15sfrbn0rghPiarGDmmP0uhQ==
+
 xterm@^3.14.5:
   version "3.14.5"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.14.5.tgz#c9d14e48be6873aa46fb429f22f2165557fd2dea"
   integrity sha512-DVmQ8jlEtL+WbBKUZuMxHMBgK/yeIZwkXB81bH+MGaKKnJGYwA+770hzhXPfwEIokK9On9YIFPRleVp/5G7z9g==
-
-xterm@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.0.2.tgz#c6a1b9586c0786627625e2ee9e78ad519dbc8c99"
-  integrity sha512-NIr11b6C782TZznU8e6K/IMfmwlWMWRI6ba9GEDG9uX25SadkpjoMnzvxOS0Z/15sfrbn0rghPiarGDmmP0uhQ==
 
 y18n@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12102,6 +12102,11 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-fit@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.2.1.tgz#353f43921eb78e3f9ad3f3afbb14e7ac183ca738"
+  integrity sha512-BlR57O3t1/bmVcnS81bn9ZnNf+GiGNbeXdNUKSBa9tKEwNUMcU3S+KFLIRv7rm1Ty0D5pMOu0vbz/RDorKRwKQ==
+
 xterm-webfont@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/xterm-webfont/-/xterm-webfont-1.1.1.tgz#8cf008b01ab5281af17b5b703f53f4ae53acb299"
@@ -12113,6 +12118,11 @@ xterm@^3.14.5:
   version "3.14.5"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-3.14.5.tgz#c9d14e48be6873aa46fb429f22f2165557fd2dea"
   integrity sha512-DVmQ8jlEtL+WbBKUZuMxHMBgK/yeIZwkXB81bH+MGaKKnJGYwA+770hzhXPfwEIokK9On9YIFPRleVp/5G7z9g==
+
+xterm@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.0.2.tgz#c6a1b9586c0786627625e2ee9e78ad519dbc8c99"
+  integrity sha512-NIr11b6C782TZznU8e6K/IMfmwlWMWRI6ba9GEDG9uX25SadkpjoMnzvxOS0Z/15sfrbn0rghPiarGDmmP0uhQ==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Done

Create a Terminal component on the ModelDetails page that will connect to the limited shell on JAAS using the currently active users credentials.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models/foo
- The Terminal should be open and will try and switch to a model called `test3`. You should now be able to execute limited terminal commands here like `ls -al` and `juju` commands.

## Details

Fixes #889
