### PR TITLE
Add auth wrapper components & Fetch model UUID on details page

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -1,5 +1,6 @@
 /**
   Checks state to see if the user is logged in.
+  @param {Object} state The application state.
   @returns {Boolean} If the user is logged in.
 */
 export const isLoggedIn = state =>
@@ -7,6 +8,7 @@ export const isLoggedIn = state =>
 
 /**
   Pull the users macaroon credentials from state.
+  @param {Object} state The application state.
   @returns {Object} The macaroons extracted from the bakery in state.
 */
 export const getUserCredentials = state => {
@@ -35,4 +37,33 @@ export const getDecodedMacaroons = macaroons => {
     }
   });
   return decodedMacaroons;
+};
+
+/**
+  Fetches the model list from state.
+  @param {Object} state The application state.
+  @returns {Object|Null} The list of models or null if none found.
+*/
+export const getModelList = state => {
+  if (state.juju && state.juju.models) {
+    return state.juju.models;
+  }
+  return null;
+};
+
+/**
+  Gets the model UUID from the supplied name.
+  @param {String} name The name of the model.
+  @param {Object} modelInfo The list of models.
+  @returns {Object|Null} The model UUID or null if none found.
+*/
+export const getModelUUIDByName = (name, modelInfo) => {
+  if (modelInfo) {
+    for (let uuid in modelInfo) {
+      if (modelInfo[uuid].name === name) {
+        return uuid;
+      }
+    }
+  }
+  return null;
 };

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 
 // Components
 import ErrorBoundary from "components/ErrorBoundary/ErrorBoundary";
+import IsLoggedIn from "components/IsLoggedIn/IsLoggedIn";
 
 // Pages
 import Controllers from "pages/Controllers/Controllers";
@@ -18,7 +19,11 @@ function App() {
       <ErrorBoundary>
         <Switch>
           <Route path="/" exact component={Models} />
-          <Route path="/models/:id" exact component={ModelDetails} />
+          <Route path="/models/:name" exact>
+            <IsLoggedIn>
+              <ModelDetails />
+            </IsLoggedIn>
+          </Route>
           <Route path="/controllers" exact component={Controllers} />
           <Route path="/usage" exact component={Usage} />
           <Route path="/logs" exact component={Logs} />

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -18,7 +18,11 @@ function App() {
     <Router>
       <ErrorBoundary>
         <Switch>
-          <Route path="/" exact component={Models} />
+          <Route path="/" exact>
+            <IsLoggedIn>
+              <Models />
+            </IsLoggedIn>
+          </Route>
           <Route path="/models/:name" exact>
             <IsLoggedIn>
               <ModelDetails />

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -5,15 +5,21 @@ exports[`App renders without crashing and matches snapshot 1`] = `
   <ErrorBoundary>
     <Switch>
       <Route
-        component={[Function]}
         exact={true}
         path="/"
-      />
+      >
+        <IsLoggedIn>
+          <Models />
+        </IsLoggedIn>
+      </Route>
       <Route
-        component={[Function]}
         exact={true}
-        path="/models/:id"
-      />
+        path="/models/:name"
+      >
+        <IsLoggedIn>
+          <ModelDetails />
+        </IsLoggedIn>
+      </Route>
       <Route
         component={[Function]}
         exact={true}

--- a/src/components/IsLoggedIn/IsLoggedIn.js
+++ b/src/components/IsLoggedIn/IsLoggedIn.js
@@ -3,9 +3,25 @@ import { useSelector } from "react-redux";
 import { isLoggedIn } from "app/selectors";
 
 const IsLoggedIn = ({ children }) => {
-  const isUserLoggedIn = useSelector(isLoggedIn);
-  if (!isUserLoggedIn) {
-    return <div>Please log in</div>;
+  const userIsLoggedIn = useSelector(isLoggedIn);
+  const visitURL = useSelector(state => {
+    if (!userIsLoggedIn) {
+      const root = state.root;
+      if (root && root.visitURL) {
+        return root.visitURL;
+      }
+    }
+  });
+
+  if (!userIsLoggedIn) {
+    return (
+      <div>
+        Please{" "}
+        <a href={visitURL} rel="noopener noreferrer" target="_blank">
+          log in
+        </a>
+      </div>
+    );
   }
   return children;
 };

--- a/src/components/IsLoggedIn/IsLoggedIn.js
+++ b/src/components/IsLoggedIn/IsLoggedIn.js
@@ -1,0 +1,13 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { isLoggedIn } from "app/selectors";
+
+const IsLoggedIn = ({ children }) => {
+  const isUserLoggedIn = useSelector(isLoggedIn);
+  if (!isUserLoggedIn) {
+    return <div>Please log in</div>;
+  }
+  return children;
+};
+
+export default IsLoggedIn;

--- a/src/components/IsLoggedIn/__snapshots__/isLoggedIn.test.js.snap
+++ b/src/components/IsLoggedIn/__snapshots__/isLoggedIn.test.js.snap
@@ -15,7 +15,14 @@ exports[`IsLoggedIn renders a login UI if the user is not logged in 1`] = `
 >
   <IsLoggedIn>
     <div>
-      Please log in
+      Please
+       
+      <a
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        log in
+      </a>
     </div>
   </IsLoggedIn>
 </Provider>

--- a/src/components/IsLoggedIn/__snapshots__/isLoggedIn.test.js.snap
+++ b/src/components/IsLoggedIn/__snapshots__/isLoggedIn.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IsLoggedIn renders a login UI if the user is not logged in 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <IsLoggedIn>
+    <div>
+      Please log in
+    </div>
+  </IsLoggedIn>
+</Provider>
+`;
+
+exports[`IsLoggedIn renders it's children if the user is logged in 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <IsLoggedIn>
+    Hello world!
+  </IsLoggedIn>
+</Provider>
+`;

--- a/src/components/IsLoggedIn/isLoggedIn.test.js
+++ b/src/components/IsLoggedIn/isLoggedIn.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { mount } from "enzyme";
+
+import IsLoggedIn from "./IsLoggedIn";
+
+const mockStore = configureStore([]);
+
+describe("IsLoggedIn", () => {
+  it("renders a login UI if the user is not logged in", () => {
+    const store = mockStore({
+      root: {}
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <IsLoggedIn>I should not be rendered</IsLoggedIn>
+      </Provider>
+    );
+    expect(wrapper.find("IsLoggedIn").text()).toBe("Please log in");
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders it's children if the user is logged in", () => {
+    const store = mockStore({
+      root: {
+        controllerConnection: {},
+        bakery: {}
+      }
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <IsLoggedIn>Hello world!</IsLoggedIn>
+      </Provider>
+    );
+    expect(wrapper.find("IsLoggedIn").text()).toBe("Hello world!");
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef } from "react";
-
 import cleanUpTerminal from "./cleanup-terminal";
 import setupTerminal from "./setup-terminal";
 
 import "./_terminal.scss";
 
-const Terminal = ({ address, creds }) => {
+const Terminal = ({ address, creds, modelUUID }) => {
   const terminalElement = useRef(null);
 
   useEffect(() => {

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -9,11 +9,39 @@ export const actionsList = {
 // Action creators
 /**
   @param {Array} models The list of models to store.
+  @returns {Object} An action for Redux.
 */
 export function updateModelList(models) {
   return {
     type: actionsList.updateModelList,
     payload: models
+  };
+}
+
+/**
+  @param {String} modelUUID The modelUUID of the model to store the
+    status under.
+  @param {Object} status The status data as returned from the API.
+  @returns {Object} An action for Redux.
+ */
+export function updateModelStatus(modelUUID, status) {
+  return {
+    type: actionsList.updateModelStatus,
+    payload: {
+      modelUUID,
+      status
+    }
+  };
+}
+
+/**
+  @param {Object} modelInfo The model info data as returned from the API.
+  @returns {Object} An action for Redux.
+ */
+export function updateModelInfo(modelInfo) {
+  return {
+    type: actionsList.updateModelInfo,
+    payload: modelInfo
   };
 }
 

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -3,39 +3,42 @@ import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { mount } from "enzyme";
 import { MemoryRouter } from "react-router";
+import { Route } from "react-router-dom";
 import dataDump from "testing/complete-redux-store-dump";
 
-import ModelDetail from "./ModelDetails";
+import ModelDetails from "./ModelDetails";
 
-jest.mock("components/Terminal/Terminal", () => () => "Terminal");
+jest.mock("components/Terminal/Terminal", () => {
+  const Terminal = () => <div className="terminal"></div>;
+  return Terminal;
+});
 
 const mockStore = configureStore([]);
 
 describe("ModelDetail Container", () => {
-  it("renders with a login message when not logged in", () => {
-    const store = mockStore({
-      root: {},
-      juju: dataDump.juju
-    });
+  it("renders the details pane", () => {
+    const store = mockStore(dataDump);
     const wrapper = mount(
       <Provider store={store}>
-        <ModelDetail />
+        <MemoryRouter>
+          <ModelDetails />
+        </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("div")).toMatchSnapshot();
+    expect(wrapper.find(".model-details")).toMatchSnapshot();
   });
 
-  describe("When the user is logged in...", () => {
-    it("renders the details pane", () => {
-      const store = mockStore(dataDump);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter>
-            <ModelDetail />
-          </MemoryRouter>
-        </Provider>
-      );
-      expect(wrapper.find(".model-details")).toMatchSnapshot();
-    });
+  it("renders the terminal", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/test1"]}>
+          <Route path="/models/:name">
+            <ModelDetails />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Terminal")).toMatchSnapshot();
   });
 });

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModelDetail Container When the user is logged in... renders the details pane 1`] = `
+exports[`ModelDetail Container renders the details pane 1`] = `
 <div
   className="model-details"
 >
@@ -797,8 +797,26 @@ exports[`ModelDetail Container When the user is logged in... renders the details
 </div>
 `;
 
-exports[`ModelDetail Container renders with a login message when not logged in 1`] = `
-<div>
-  Please log in
-</div>
+exports[`ModelDetail Container renders the terminal 1`] = `
+<Terminal
+  WebSocket={[Function]}
+  address="wss://shell.jujugui.org:443/ws/"
+  creds={
+    Object {
+      "macaroons": Object {
+        "https://api.jujucharms.com/identity": Object {
+          "not": "a valid macaroon",
+        },
+        "identity": Object {
+          "not": "a valid macaroon",
+        },
+      },
+    }
+  }
+  modelUUID="2446g278-7928-4c50-811b-563f79acd991"
+>
+  <div
+    className="terminal"
+  />
+</Terminal>
 `;


### PR DESCRIPTION
## Done

- When trying to view an authenticated page, if you've not already authenticated it'll now render a very basic text link for you to authenticate with usso.
- Get the model UUID and pass it to the Terminal component for use later.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Open / it should request that you log in.
- After logging in, click one of the models in your model list to show the details page.
- The page with dummy data should load as expected.
