### PR TITLE
Pass fully qualified model name from model list

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -23,7 +23,7 @@ function App() {
               <Models />
             </IsLoggedIn>
           </Route>
-          <Route path="/models/:name" exact>
+          <Route path="/models/*" exact>
             <IsLoggedIn>
               <ModelDetails />
             </IsLoggedIn>

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -14,7 +14,7 @@ exports[`App renders without crashing and matches snapshot 1`] = `
       </Route>
       <Route
         exact={true}
-        path="/models/:name"
+        path="/models/*"
       >
         <IsLoggedIn>
           <ModelDetails />

--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -17,12 +17,22 @@ function generateModelTableData(state) {
     const modelInfoData = modelInfo[modelUUID];
     const modelStatus = state.juju.modelStatuses[modelUUID];
     const modelDetailsPath = `/models/${modelListData.name}`;
-    const modelDetailsLink = (
-      <Link to={modelDetailsPath}>{modelListData.name}</Link>
-    );
+    const generateModelDetailsLink = () => {
+      const owner = modelListData.ownerTag;
+      const user = state.root.controllerConnection.info.user.identity;
+      if (owner === user) {
+        return <Link to={modelDetailsPath}>{modelListData.name}</Link>;
+      }
+      // If the owner isn't the logged in user then we need to use the
+      // fully qualified path name.
+      const sharedModelDetailsPath = `/models/${owner.replace("user-", "")}/${
+        modelListData.name
+      }`;
+      return <Link to={sharedModelDetailsPath}>{modelListData.name}</Link>;
+    };
     return {
       columns: [
-        { content: modelDetailsLink },
+        { content: generateModelDetailsLink() },
         { content: modelListData.ownerTag.split("@")[0].replace("user-", "") },
         { content: getStatusValue(modelStatus, "summary") },
         { content: getStatusValue(modelStatus, "cloudTag") },

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -221,7 +221,7 @@ exports[`TableList displays all data from redux store 1`] = `
           "columns": Array [
             Object {
               "content": <ForwardRef
-                to="/models/juju-all-the-things"
+                to="/models/otheruser@external/juju-all-the-things"
               >
                 juju-all-the-things
               </ForwardRef>,
@@ -253,7 +253,7 @@ exports[`TableList displays all data from redux store 1`] = `
           "columns": Array [
             Object {
               "content": <ForwardRef
-                to="/models/frontend-ci"
+                to="/models/space-man@external/frontend-ci"
               >
                 frontend-ci
               </ForwardRef>,
@@ -285,7 +285,7 @@ exports[`TableList displays all data from redux store 1`] = `
           "columns": Array [
             Object {
               "content": <ForwardRef
-                to="/models/backend-ci"
+                to="/models/space-man@external/backend-ci"
               >
                 backend-ci
               </ForwardRef>,
@@ -317,7 +317,7 @@ exports[`TableList displays all data from redux store 1`] = `
           "columns": Array [
             Object {
               "content": <ForwardRef
-                to="/models/data-aggregator"
+                to="/models/space-man@external/data-aggregator"
               >
                 data-aggregator
               </ForwardRef>,
@@ -858,14 +858,14 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <Link
-                    to="/models/juju-all-the-things"
+                    to="/models/otheruser@external/juju-all-the-things"
                   >
                     <LinkAnchor
-                      href="/models/juju-all-the-things"
+                      href="/models/otheruser@external/juju-all-the-things"
                       navigate={[Function]}
                     >
                       <a
-                        href="/models/juju-all-the-things"
+                        href="/models/otheruser@external/juju-all-the-things"
                         onClick={[Function]}
                       >
                         juju-all-the-things
@@ -960,14 +960,14 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <Link
-                    to="/models/frontend-ci"
+                    to="/models/space-man@external/frontend-ci"
                   >
                     <LinkAnchor
-                      href="/models/frontend-ci"
+                      href="/models/space-man@external/frontend-ci"
                       navigate={[Function]}
                     >
                       <a
-                        href="/models/frontend-ci"
+                        href="/models/space-man@external/frontend-ci"
                         onClick={[Function]}
                       >
                         frontend-ci
@@ -1062,14 +1062,14 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <Link
-                    to="/models/backend-ci"
+                    to="/models/space-man@external/backend-ci"
                   >
                     <LinkAnchor
-                      href="/models/backend-ci"
+                      href="/models/space-man@external/backend-ci"
                       navigate={[Function]}
                     >
                       <a
-                        href="/models/backend-ci"
+                        href="/models/space-man@external/backend-ci"
                         onClick={[Function]}
                       >
                         backend-ci
@@ -1164,14 +1164,14 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <Link
-                    to="/models/data-aggregator"
+                    to="/models/space-man@external/data-aggregator"
                   >
                     <LinkAnchor
-                      href="/models/data-aggregator"
+                      href="/models/space-man@external/data-aggregator"
                       navigate={[Function]}
                     >
                       <a
-                        href="/models/data-aggregator"
+                        href="/models/space-man@external/data-aggregator"
                         onClick={[Function]}
                       >
                         data-aggregator

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -107,7 +107,7 @@ const getModelUUIDSelector = modelName => {
 const ModelDetails = () => {
   const macaroons = useSelector(getMacaroons);
 
-  const { name: modelName } = useParams();
+  const { 0: modelName } = useParams();
   const dispatch = useDispatch();
 
   const getModelUUID = useMemo(getModelUUIDSelector.bind(null, modelName), [

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -33,7 +33,7 @@ describe("ModelDetail Container", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/test1"]}>
-          <Route path="/models/:name">
+          <Route path="/models/*">
             <ModelDetails />
           </Route>
         </MemoryRouter>


### PR DESCRIPTION
## Done

When clicking a model name in the model list to view its details we need to pass the fully qualified name to the details page so that we can correctly fetch the status and switch the Terminal to the model.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- You'll need at least one model you own and one someone else owns in your model list.
- Click both of them and they should take you to the details page and the terminal should successfully switch to that model.

## Details

Fixes #69 
