### PR TITLE
Sort models by status and display them in separate tables

### DIFF
--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -81,12 +81,13 @@ function determineModelStatus(modelStatus) {
   // Short circuit the loop. If something is in error then the model is in error.
   // Grab the first error message and display that.
   Object.values(modelStatus.applications).some(app => {
-    Object.values(app.units).some(unit => {
+    return Object.values(app.units).some(unit => {
       if (badStatuses.includes(unit.agentStatus.status)) {
         status = "blockedModelData";
         why = unit.agentStatus.info;
         return true;
       }
+      return false;
     });
   });
   return { status, why };

--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 
 import MainTable from "../MainTable/MainTable";
 
+import "./_table-list.scss";
 /**
   Returns the model info and statuses in the proper format for the table data.
   @param {Object} state The application state.
@@ -35,10 +36,19 @@ function generateModelTableData(state) {
       }`;
       return <Link to={sharedModelDetailsPath}>{modelListData.name}</Link>;
     };
+    const generateModelNameCell = why => {
+      const link = generateModelDetailsLink();
+      return (
+        <>
+          {link}
+          <div className="table-list_error-message">{why}</div>
+        </>
+      );
+    };
     const { status, why } = determineModelStatus(modelStatus);
     modelData[status].push({
       columns: [
-        { content: generateModelDetailsLink() },
+        { content: generateModelNameCell(why) },
         { content: modelListData.ownerTag.split("@")[0].replace("user-", "") },
         { content: getStatusValue(modelStatus, "summary") },
         { content: getStatusValue(modelStatus, "cloudTag") },

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -5,7 +5,87 @@ Array [
   <th
     role="columnheader"
   >
-    Name
+    Blocked
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Owner
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Apps/Machines/Units
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Cloud
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Region
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Credential
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Controller
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Last Updated
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Attention
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Owner
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Apps/Machines/Units
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Cloud
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Region
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Credential
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Controller
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Last Updated
+  </th>,
+  <th
+    role="columnheader"
+  >
+    Running
   </th>,
   <th
     role="columnheader"
@@ -45,7 +125,13 @@ Array [
 ]
 `;
 
-exports[`TableList by default, renders with all table headers and no data 2`] = `<tbody />`;
+exports[`TableList by default, renders with all table headers and no data 2`] = `
+Array [
+  <tbody />,
+  <tbody />,
+  <tbody />,
+]
+`;
 
 exports[`TableList displays all data from redux store 1`] = `
 <TableList>
@@ -54,8 +140,8 @@ exports[`TableList displays all data from redux store 1`] = `
     headers={
       Array [
         Object {
-          "content": "Name",
-          "sortKey": "name",
+          "content": "Blocked",
+          "sortKey": "blocked",
         },
         Object {
           "content": "Owner",
@@ -92,171 +178,18 @@ exports[`TableList displays all data from redux store 1`] = `
         Object {
           "columns": Array [
             Object {
-              "content": <ForwardRef
-                to="/models/group-test"
-              >
-                group-test
-              </ForwardRef>,
-            },
-            Object {
-              "content": "mrdata",
-            },
-            Object {
-              "content": "9/0/0",
-            },
-            Object {
-              "content": "google",
-            },
-            Object {
-              "content": "us-central1",
-            },
-            Object {
-              "content": "admin",
-            },
-            Object {
-              "content": "a030329a...",
-            },
-            Object {
-              "content": "2019-08-22",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "content": <ForwardRef
-                to="/models/test1"
-              >
-                test1
-              </ForwardRef>,
-            },
-            Object {
-              "content": "mrdata",
-            },
-            Object {
-              "content": "0/0/0",
-            },
-            Object {
-              "content": "google",
-            },
-            Object {
-              "content": "us-east1",
-            },
-            Object {
-              "content": "juju",
-            },
-            Object {
-              "content": "a030329a...",
-            },
-            Object {
-              "content": "2019-08-26",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "content": <ForwardRef
-                to="/models/test2"
-              >
-                test2
-              </ForwardRef>,
-            },
-            Object {
-              "content": "mrdata",
-            },
-            Object {
-              "content": "0/0/0",
-            },
-            Object {
-              "content": "google",
-            },
-            Object {
-              "content": "us-east1",
-            },
-            Object {
-              "content": "juju",
-            },
-            Object {
-              "content": "a030329a...",
-            },
-            Object {
-              "content": "2019-08-26",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "content": <ForwardRef
-                to="/models/test3"
-              >
-                test3
-              </ForwardRef>,
-            },
-            Object {
-              "content": "mrdata",
-            },
-            Object {
-              "content": "0/0/0",
-            },
-            Object {
-              "content": "google",
-            },
-            Object {
-              "content": "us-east1",
-            },
-            Object {
-              "content": "juju",
-            },
-            Object {
-              "content": "a030329a...",
-            },
-            Object {
-              "content": "2019-08-26",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "content": <ForwardRef
-                to="/models/otheruser@external/juju-all-the-things"
-              >
-                juju-all-the-things
-              </ForwardRef>,
-            },
-            Object {
-              "content": "otheruser",
-            },
-            Object {
-              "content": "3/3/3",
-            },
-            Object {
-              "content": "google",
-            },
-            Object {
-              "content": "us-east1",
-            },
-            Object {
-              "content": "google-bigbot",
-            },
-            Object {
-              "content": "a030329a...",
-            },
-            Object {
-              "content": "2019-08-20",
-            },
-          ],
-        },
-        Object {
-          "columns": Array [
-            Object {
-              "content": <ForwardRef
-                to="/models/space-man@external/frontend-ci"
-              >
-                frontend-ci
-              </ForwardRef>,
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/space-man@external/frontend-ci"
+                >
+                  frontend-ci
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  agent is not communicating with the server
+                </div>
+              </React.Fragment>,
             },
             Object {
               "content": "space-man",
@@ -284,11 +217,18 @@ exports[`TableList displays all data from redux store 1`] = `
         Object {
           "columns": Array [
             Object {
-              "content": <ForwardRef
-                to="/models/space-man@external/backend-ci"
-              >
-                backend-ci
-              </ForwardRef>,
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/space-man@external/backend-ci"
+                >
+                  backend-ci
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  agent is not communicating with the server
+                </div>
+              </React.Fragment>,
             },
             Object {
               "content": "space-man",
@@ -313,14 +253,696 @@ exports[`TableList displays all data from redux store 1`] = `
             },
           ],
         },
+      ]
+    }
+  >
+    <Table
+      className="u-table-layout--auto"
+    >
+      <table
+        className="u-table-layout--auto"
+        role="grid"
+      >
+        <thead>
+          <TableRow>
+            <tr
+              role="row"
+            >
+              <TableHeader
+                key="0"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Blocked
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="1"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Owner
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="2"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Apps/Machines/Units
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="3"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Cloud
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="4"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Region
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="5"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Credential
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="6"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Controller
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="7"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Last Updated
+                </th>
+              </TableHeader>
+            </tr>
+          </TableRow>
+        </thead>
+        <tbody>
+          <TableRow
+            key="0"
+          >
+            <tr
+              role="row"
+            >
+              <TableCell
+                key="0"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  <Link
+                    to="/models/space-man@external/frontend-ci"
+                  >
+                    <LinkAnchor
+                      href="/models/space-man@external/frontend-ci"
+                      navigate={[Function]}
+                    >
+                      <a
+                        href="/models/space-man@external/frontend-ci"
+                        onClick={[Function]}
+                      >
+                        frontend-ci
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                  <div
+                    className="table-list_error-message"
+                  >
+                    agent is not communicating with the server
+                  </div>
+                </td>
+              </TableCell>
+              <TableCell
+                key="1"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  space-man
+                </td>
+              </TableCell>
+              <TableCell
+                key="2"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  1/1/1
+                </td>
+              </TableCell>
+              <TableCell
+                key="3"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  google
+                </td>
+              </TableCell>
+              <TableCell
+                key="4"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  us-east1
+                </td>
+              </TableCell>
+              <TableCell
+                key="5"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  gce
+                </td>
+              </TableCell>
+              <TableCell
+                key="6"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  a030329a...
+                </td>
+              </TableCell>
+              <TableCell
+                key="7"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  2019-04-13
+                </td>
+              </TableCell>
+            </tr>
+          </TableRow>
+          <TableRow
+            key="1"
+          >
+            <tr
+              role="row"
+            >
+              <TableCell
+                key="0"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  <Link
+                    to="/models/space-man@external/backend-ci"
+                  >
+                    <LinkAnchor
+                      href="/models/space-man@external/backend-ci"
+                      navigate={[Function]}
+                    >
+                      <a
+                        href="/models/space-man@external/backend-ci"
+                        onClick={[Function]}
+                      >
+                        backend-ci
+                      </a>
+                    </LinkAnchor>
+                  </Link>
+                  <div
+                    className="table-list_error-message"
+                  >
+                    agent is not communicating with the server
+                  </div>
+                </td>
+              </TableCell>
+              <TableCell
+                key="1"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  space-man
+                </td>
+              </TableCell>
+              <TableCell
+                key="2"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  3/3/3
+                </td>
+              </TableCell>
+              <TableCell
+                key="3"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  google
+                </td>
+              </TableCell>
+              <TableCell
+                key="4"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  us-east1
+                </td>
+              </TableCell>
+              <TableCell
+                key="5"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  gce
+                </td>
+              </TableCell>
+              <TableCell
+                key="6"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  a030329a...
+                </td>
+              </TableCell>
+              <TableCell
+                key="7"
+              >
+                <td
+                  className=""
+                  role="gridcell"
+                >
+                  2019-04-13
+                </td>
+              </TableCell>
+            </tr>
+          </TableRow>
+        </tbody>
+      </table>
+    </Table>
+  </MainTable>
+  <MainTable
+    className="u-table-layout--auto"
+    headers={
+      Array [
+        Object {
+          "content": "Attention",
+          "sortKey": "attention",
+        },
+        Object {
+          "content": "Owner",
+          "sortKey": "owner",
+        },
+        Object {
+          "content": "Apps/Machines/Units",
+          "sortKey": "summary",
+        },
+        Object {
+          "content": "Cloud",
+          "sortKey": "cloud",
+        },
+        Object {
+          "content": "Region",
+          "sortKey": "region",
+        },
+        Object {
+          "content": "Credential",
+          "sortKey": "credential",
+        },
+        Object {
+          "content": "Controller",
+          "sortKey": "controller",
+        },
+        Object {
+          "content": "Last Updated",
+          "sortKey": "last-updated",
+        },
+      ]
+    }
+    rows={Array []}
+  >
+    <Table
+      className="u-table-layout--auto"
+    >
+      <table
+        className="u-table-layout--auto"
+        role="grid"
+      >
+        <thead>
+          <TableRow>
+            <tr
+              role="row"
+            >
+              <TableHeader
+                key="0"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Attention
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="1"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Owner
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="2"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Apps/Machines/Units
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="3"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Cloud
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="4"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Region
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="5"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Credential
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="6"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Controller
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="7"
+              >
+                <th
+                  role="columnheader"
+                >
+                  Last Updated
+                </th>
+              </TableHeader>
+            </tr>
+          </TableRow>
+        </thead>
+        <tbody />
+      </table>
+    </Table>
+  </MainTable>
+  <MainTable
+    className="u-table-layout--auto"
+    headers={
+      Array [
+        Object {
+          "content": "Running",
+          "sortKey": "running",
+        },
+        Object {
+          "content": "Owner",
+          "sortKey": "owner",
+        },
+        Object {
+          "content": "Apps/Machines/Units",
+          "sortKey": "summary",
+        },
+        Object {
+          "content": "Cloud",
+          "sortKey": "cloud",
+        },
+        Object {
+          "content": "Region",
+          "sortKey": "region",
+        },
+        Object {
+          "content": "Credential",
+          "sortKey": "credential",
+        },
+        Object {
+          "content": "Controller",
+          "sortKey": "controller",
+        },
+        Object {
+          "content": "Last Updated",
+          "sortKey": "last-updated",
+        },
+      ]
+    }
+    rows={
+      Array [
         Object {
           "columns": Array [
             Object {
-              "content": <ForwardRef
-                to="/models/space-man@external/data-aggregator"
-              >
-                data-aggregator
-              </ForwardRef>,
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/group-test"
+                >
+                  group-test
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
+            },
+            Object {
+              "content": "mrdata",
+            },
+            Object {
+              "content": "9/0/0",
+            },
+            Object {
+              "content": "google",
+            },
+            Object {
+              "content": "us-central1",
+            },
+            Object {
+              "content": "admin",
+            },
+            Object {
+              "content": "a030329a...",
+            },
+            Object {
+              "content": "2019-08-22",
+            },
+          ],
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/test1"
+                >
+                  test1
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
+            },
+            Object {
+              "content": "mrdata",
+            },
+            Object {
+              "content": "0/0/0",
+            },
+            Object {
+              "content": "google",
+            },
+            Object {
+              "content": "us-east1",
+            },
+            Object {
+              "content": "juju",
+            },
+            Object {
+              "content": "a030329a...",
+            },
+            Object {
+              "content": "2019-08-26",
+            },
+          ],
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/test2"
+                >
+                  test2
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
+            },
+            Object {
+              "content": "mrdata",
+            },
+            Object {
+              "content": "0/0/0",
+            },
+            Object {
+              "content": "google",
+            },
+            Object {
+              "content": "us-east1",
+            },
+            Object {
+              "content": "juju",
+            },
+            Object {
+              "content": "a030329a...",
+            },
+            Object {
+              "content": "2019-08-26",
+            },
+          ],
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/test3"
+                >
+                  test3
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
+            },
+            Object {
+              "content": "mrdata",
+            },
+            Object {
+              "content": "0/0/0",
+            },
+            Object {
+              "content": "google",
+            },
+            Object {
+              "content": "us-east1",
+            },
+            Object {
+              "content": "juju",
+            },
+            Object {
+              "content": "a030329a...",
+            },
+            Object {
+              "content": "2019-08-26",
+            },
+          ],
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/otheruser@external/juju-all-the-things"
+                >
+                  juju-all-the-things
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
+            },
+            Object {
+              "content": "otheruser",
+            },
+            Object {
+              "content": "3/3/3",
+            },
+            Object {
+              "content": "google",
+            },
+            Object {
+              "content": "us-east1",
+            },
+            Object {
+              "content": "google-bigbot",
+            },
+            Object {
+              "content": "a030329a...",
+            },
+            Object {
+              "content": "2019-08-20",
+            },
+          ],
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment>
+                <ForwardRef
+                  to="/models/space-man@external/data-aggregator"
+                >
+                  data-aggregator
+                </ForwardRef>
+                <div
+                  className="table-list_error-message"
+                >
+                  
+                </div>
+              </React.Fragment>,
             },
             Object {
               "content": "space-man",
@@ -366,7 +988,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 <th
                   role="columnheader"
                 >
-                  Name
+                  Running
                 </th>
               </TableHeader>
               <TableHeader
@@ -464,6 +1086,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell
@@ -566,6 +1191,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell
@@ -668,6 +1296,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell
@@ -770,6 +1401,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell
@@ -872,6 +1506,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell
@@ -960,210 +1597,6 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <Link
-                    to="/models/space-man@external/frontend-ci"
-                  >
-                    <LinkAnchor
-                      href="/models/space-man@external/frontend-ci"
-                      navigate={[Function]}
-                    >
-                      <a
-                        href="/models/space-man@external/frontend-ci"
-                        onClick={[Function]}
-                      >
-                        frontend-ci
-                      </a>
-                    </LinkAnchor>
-                  </Link>
-                </td>
-              </TableCell>
-              <TableCell
-                key="1"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  space-man
-                </td>
-              </TableCell>
-              <TableCell
-                key="2"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  1/1/1
-                </td>
-              </TableCell>
-              <TableCell
-                key="3"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  google
-                </td>
-              </TableCell>
-              <TableCell
-                key="4"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  us-east1
-                </td>
-              </TableCell>
-              <TableCell
-                key="5"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  gce
-                </td>
-              </TableCell>
-              <TableCell
-                key="6"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  a030329a...
-                </td>
-              </TableCell>
-              <TableCell
-                key="7"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  2019-04-13
-                </td>
-              </TableCell>
-            </tr>
-          </TableRow>
-          <TableRow
-            key="6"
-          >
-            <tr
-              role="row"
-            >
-              <TableCell
-                key="0"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  <Link
-                    to="/models/space-man@external/backend-ci"
-                  >
-                    <LinkAnchor
-                      href="/models/space-man@external/backend-ci"
-                      navigate={[Function]}
-                    >
-                      <a
-                        href="/models/space-man@external/backend-ci"
-                        onClick={[Function]}
-                      >
-                        backend-ci
-                      </a>
-                    </LinkAnchor>
-                  </Link>
-                </td>
-              </TableCell>
-              <TableCell
-                key="1"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  space-man
-                </td>
-              </TableCell>
-              <TableCell
-                key="2"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  3/3/3
-                </td>
-              </TableCell>
-              <TableCell
-                key="3"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  google
-                </td>
-              </TableCell>
-              <TableCell
-                key="4"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  us-east1
-                </td>
-              </TableCell>
-              <TableCell
-                key="5"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  gce
-                </td>
-              </TableCell>
-              <TableCell
-                key="6"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  a030329a...
-                </td>
-              </TableCell>
-              <TableCell
-                key="7"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  2019-04-13
-                </td>
-              </TableCell>
-            </tr>
-          </TableRow>
-          <TableRow
-            key="7"
-          >
-            <tr
-              role="row"
-            >
-              <TableCell
-                key="0"
-              >
-                <td
-                  className=""
-                  role="gridcell"
-                >
-                  <Link
                     to="/models/space-man@external/data-aggregator"
                   >
                     <LinkAnchor
@@ -1178,6 +1611,9 @@ exports[`TableList displays all data from redux store 1`] = `
                       </a>
                     </LinkAnchor>
                   </Link>
+                  <div
+                    className="table-list_error-message"
+                  />
                 </td>
               </TableCell>
               <TableCell

--- a/src/components/TableList/_table-list.scss
+++ b/src/components/TableList/_table-list.scss
@@ -1,0 +1,4 @@
+.table-list_error-message {
+  font-size: 0.5rem;
+  color: red;
+}

--- a/src/components/TableList/_table-list.scss
+++ b/src/components/TableList/_table-list.scss
@@ -1,4 +1,4 @@
 .table-list_error-message {
-  font-size: 0.5rem;
   color: red;
+  font-size: 0.5rem;
 }


### PR DESCRIPTION
## Done

Naively sort the models by status and then display them in separate tables. 

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- If you have models with units who's agents are `lost` then you'll see them in the topmost table.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/929

We don't have a spec for this so at the moment it's only splitting the models by applications that have units who's agents are `lost`. This will need a follow-up to enhance this sorting functionality but it's good to get the component output landed so we can style things.

I'll leave https://github.com/canonical-web-and-design/juju-squad/issues/930 open to track for the follow-up

## Screenshots

For those who may not have models in this state:

<img width="1337" alt="Screen Shot 2019-10-16 at 2 49 09 PM" src="https://user-images.githubusercontent.com/532033/66958175-dedc9e00-f024-11e9-96c4-92b042da1509.png">
