### PR TITLE
Change port to 80 for prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /srv
 ADD build .
 ADD nginx.conf /etc/nginx/sites-enabled/default
 RUN sed -i "s/~REVISION_ID~/${REVISION_ID}/" /etc/nginx/sites-enabled/default
+RUN sed -i "s/8036/80/" /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM
 


### PR DESCRIPTION
## Done

Change nginx port for prod

## QA

- Pull code
- Run `./run build`
- ` docker build --build-arg REVISION_ID=test --tag prod-comms.docker-registry.canonical.com/dashboard.jaas.ai:latest .`
- `docker run -d -p 8080:80  prod-comms.docker-registry.canonical.com/dashboard.jaas.ai:latest`
- http://localhost:8080
- should work
