### PR TITLE
Models details collapsible sidebar

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -3,8 +3,7 @@ export const actionsList = {
   storeBakery: "STORE_BAKERY",
   storeVisitURL: "STORE_VISIT_URL",
   updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
-  logOut: "LOG_OUT"
-  LogOut: "LOG_OUT",
+  logOut: "LOG_OUT",
   collapsibleSidebar: "TOGGLE_COLLAPSIBLE_SIDEBAR"
 };
 

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -4,6 +4,8 @@ export const actionsList = {
   storeVisitURL: "STORE_VISIT_URL",
   updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
   logOut: "LOG_OUT"
+  LogOut: "LOG_OUT",
+  collapsibleSidebar: "TOGGLE_COLLAPSIBLE_SIDEBAR"
 };
 
 // Action creators
@@ -55,5 +57,15 @@ export function logOut() {
     localStorage.removeItem("identity");
     localStorage.removeItem("https://api.jujucharms.com/identity");
     dispatch(clearUserData());
+  };
+}
+
+/**
+  Toggle collapsible sidebar
+*/
+export function collapsibleSidebar(toggle) {
+  return {
+    type: actionsList.collapsibleSidebar,
+    payload: toggle
   };
 }

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -17,6 +17,9 @@ function rootReducer(state = {}, action) {
       case actionsList.logOut:
         draftState.bakery = null;
         break;
+      case actionsList.collapsibleSidebar:
+        draftState.collapsibleSidebar = action.payload;
+        break;
       default:
         // no default value, fall through.
         break;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -206,6 +206,20 @@ const countModelStatusGroups = groupedModelStatuses => {
 // ----- Exported functions
 
 /**
+  Checks state to see if the sidebar is collapsible.
+  Usage:
+    const isSidebarCollapsible = useSelector(isSidebarCollapsible);
+
+  @param {Object} state The application state.
+  @returns {Boolean} If the sidebar is collapsible.
+*/
+export const isSidebarCollapsible = state => {
+  if (state && state.root) {
+    return state.root.collapsibleSidebar;
+  }
+};
+
+/**
   Gets the model UUID from the supplied name using a memoized selector
   Usage:
     const getModelUUIDMemo = useMemo(getModelUUID.bind(null, modelName), [

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,12 +1,21 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
+import classNames from "classnames";
+
+import { isSidebarCollapsible } from "app/selectors";
 
 import "./_layout.scss";
 
 const Layout = ({ children }) => {
+  const sidebarCollapsible = useSelector(isSidebarCollapsible);
   return (
     <div className="l-container">
-      <div className="l-side">
+      <div
+        className={classNames("l-side", {
+          "is-collapsible": sidebarCollapsible
+        })}
+      >
         <PrimaryNav />
       </div>
       <div className="l-main">

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -14,7 +14,7 @@ const Layout = ({ children }) => {
   return (
     <div
       className={classNames("l-container", {
-        "is-collapsible": sidebarCollapsible && !isSidebarHovered
+        "has-collapsible-sidebar": sidebarCollapsible && !isSidebarHovered
       })}
     >
       <div className="l-side" ref={sidebarRef}>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -2,20 +2,22 @@ import React from "react";
 import { useSelector } from "react-redux";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 import classNames from "classnames";
+import useHover from "hooks/useHover";
 
 import { isSidebarCollapsible } from "app/selectors";
 
 import "./_layout.scss";
 
 const Layout = ({ children }) => {
+  const [sidebarRef, isSidebarHovered] = useHover();
   const sidebarCollapsible = useSelector(isSidebarCollapsible);
   return (
-    <div className="l-container">
-      <div
-        className={classNames("l-side", {
-          "is-collapsible": sidebarCollapsible
-        })}
-      >
+    <div
+      className={classNames("l-container", {
+        "is-collapsible": sidebarCollapsible && !isSidebarHovered
+      })}
+    >
+      <div className="l-side" ref={sidebarRef}>
         <PrimaryNav />
       </div>
       <div className="l-main">

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -1,21 +1,46 @@
 import React from "react";
-import { shallow } from "enzyme";
-
+import { BrowserRouter as Router } from "react-router-dom";
+import { mount } from "enzyme";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import dataDump from "testing/complete-redux-store-dump";
 import Layout from "./Layout";
 
+const mockStore = configureStore([]);
 describe("Layout", () => {
   it("renders without crashing and matches snapshot", () => {
-    const wrapper = shallow(<Layout />);
-    expect(wrapper).toMatchSnapshot();
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router>
+          <Layout />
+        </Router>
+      </Provider>
+    );
+    expect(wrapper.find(".l-container")).toMatchSnapshot();
   });
 
   it("renders with a sidebar", () => {
-    const wrapper = shallow(<Layout />);
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router>
+          <Layout />
+        </Router>
+      </Provider>
+    );
     expect(wrapper.find(".l-side")).toHaveLength(1);
   });
 
   it("should display the children", () => {
-    const wrapper = shallow(<Layout>content</Layout>);
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router>
+          <Layout>content</Layout>
+        </Router>
+      </Provider>
+    );
     expect(wrapper.find("#main-content").html()).toStrictEqual(
       `<main id="main-content">content</main>`
     );

--- a/src/components/Layout/__snapshots__/Layout.test.js.snap
+++ b/src/components/Layout/__snapshots__/Layout.test.js.snap
@@ -7,7 +7,225 @@ exports[`Layout renders without crashing and matches snapshot 1`] = `
   <div
     className="l-side"
   >
-    <PrimaryNav />
+    <PrimaryNav>
+      <nav
+        className="p-primary-nav"
+      >
+        <div
+          className="p-primary-nav__header"
+        >
+          <Link
+            to="/"
+          >
+            <LinkAnchor
+              href="/"
+              navigate={[Function]}
+            >
+              <a
+                href="/"
+                onClick={[Function]}
+              >
+                <img
+                  alt="JAAS logo"
+                  className="p-primary-nav__logo"
+                  src="https://assets.ubuntu.com/v1/a9e0ed4a-jaas-logo1.svg"
+                />
+              </a>
+            </LinkAnchor>
+          </Link>
+          <button
+            className="p-primary-nav__toggle"
+            onClick={[Function]}
+          >
+            <i
+              className="p-icon--contextual-menu"
+            >
+              Toggle external navigation
+            </i>
+          </button>
+        </div>
+        <ul
+          className="p-list is-external"
+        >
+          <li
+            className="p-list__item"
+          >
+            <a
+              className="p-list__link"
+              href="https://jaas.ai/store"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Store
+            </a>
+          </li>
+          <li
+            className="p-list__item"
+          >
+            <a
+              className="p-list__link"
+              href="https://jaas.ai/about"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              About
+            </a>
+          </li>
+          <li
+            className="p-list__item"
+          >
+            <a
+              className="p-list__link"
+              href="https://jaas.ai/how-it-works"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              How it works
+            </a>
+          </li>
+          <li
+            className="p-list__item"
+          >
+            <a
+              className="p-link--external p-list__link"
+              href="https://discourse.jujucharms.com/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Discourse
+            </a>
+          </li>
+          <li
+            className="p-list__item"
+          >
+            <a
+              className="p-link--external p-list__link"
+              href="https://jaas.ai/docs/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Docs
+            </a>
+          </li>
+        </ul>
+        <ul
+          className="p-list is-internal"
+        >
+          <li
+            className="p-list__item is-selected"
+            key="/"
+          >
+            <Link
+              className="p-list__link"
+              to="/"
+            >
+              <LinkAnchor
+                className="p-list__link"
+                href="/"
+                navigate={[Function]}
+              >
+                <a
+                  className="p-list__link"
+                  href="/"
+                  onClick={[Function]}
+                >
+                  <img
+                    alt="Models icon"
+                    className="p-list__icon"
+                    src="https://assets.ubuntu.com/v1/51642f58-models.svg"
+                  />
+                  Models
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+          <li
+            className="p-list__item"
+            key="/controllers"
+          >
+            <Link
+              className="p-list__link"
+              to="/controllers"
+            >
+              <LinkAnchor
+                className="p-list__link"
+                href="/controllers"
+                navigate={[Function]}
+              >
+                <a
+                  className="p-list__link"
+                  href="/controllers"
+                  onClick={[Function]}
+                >
+                  <img
+                    alt="Controllers icon"
+                    className="p-list__icon"
+                    src="https://assets.ubuntu.com/v1/8414b187-controllers.svg"
+                  />
+                  Controllers
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+          <li
+            className="p-list__item"
+            key="/usage"
+          >
+            <Link
+              className="p-list__link"
+              to="/usage"
+            >
+              <LinkAnchor
+                className="p-list__link"
+                href="/usage"
+                navigate={[Function]}
+              >
+                <a
+                  className="p-list__link"
+                  href="/usage"
+                  onClick={[Function]}
+                >
+                  <img
+                    alt="Usage icon"
+                    className="p-list__icon"
+                    src="https://assets.ubuntu.com/v1/1b1d07ae-usage.svg"
+                  />
+                  Usage
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+          <li
+            className="p-list__item"
+            key="/logs"
+          >
+            <Link
+              className="p-list__link"
+              to="/logs"
+            >
+              <LinkAnchor
+                className="p-list__link"
+                href="/logs"
+                navigate={[Function]}
+              >
+                <a
+                  className="p-list__link"
+                  href="/logs"
+                  onClick={[Function]}
+                >
+                  <img
+                    alt="Logs icon"
+                    className="p-list__icon"
+                    src="https://assets.ubuntu.com/v1/741097ff-logs.svg"
+                  />
+                  Logs
+                </a>
+              </LinkAnchor>
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </PrimaryNav>
   </div>
   <div
     className="l-main"

--- a/src/components/Layout/__snapshots__/Layout.test.js.snap
+++ b/src/components/Layout/__snapshots__/Layout.test.js.snap
@@ -114,116 +114,187 @@ exports[`Layout renders without crashing and matches snapshot 1`] = `
           className="p-list is-internal"
         >
           <li
-            className="p-list__item is-selected"
+            className="p-list__item"
             key="/"
           >
-            <Link
+            <NavLink
+              activeClassName="is-selected"
               className="p-list__link"
+              exact={true}
               to="/"
             >
-              <LinkAnchor
-                className="p-list__link"
-                href="/"
-                navigate={[Function]}
+              <Link
+                aria-current="page"
+                className="p-list__link is-selected"
+                style={Object {}}
+                to={
+                  Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": null,
+                  }
+                }
               >
-                <a
-                  className="p-list__link"
+                <LinkAnchor
+                  aria-current="page"
+                  className="p-list__link is-selected"
                   href="/"
-                  onClick={[Function]}
+                  navigate={[Function]}
+                  style={Object {}}
                 >
-                  <img
-                    alt="Models icon"
-                    className="p-list__icon"
-                    src="https://assets.ubuntu.com/v1/51642f58-models.svg"
-                  />
-                  Models
-                </a>
-              </LinkAnchor>
-            </Link>
+                  <a
+                    aria-current="page"
+                    className="p-list__link is-selected"
+                    href="/"
+                    onClick={[Function]}
+                    style={Object {}}
+                  >
+                    <img
+                      alt="Models icon"
+                      className="p-list__icon"
+                      src="https://assets.ubuntu.com/v1/51642f58-models.svg"
+                    />
+                    Models
+                  </a>
+                </LinkAnchor>
+              </Link>
+            </NavLink>
           </li>
           <li
             className="p-list__item"
             key="/controllers"
           >
-            <Link
+            <NavLink
+              activeClassName="is-selected"
               className="p-list__link"
+              exact={true}
               to="/controllers"
             >
-              <LinkAnchor
+              <Link
+                aria-current={null}
                 className="p-list__link"
-                href="/controllers"
-                navigate={[Function]}
+                to={
+                  Object {
+                    "hash": "",
+                    "pathname": "/controllers",
+                    "search": "",
+                    "state": null,
+                  }
+                }
               >
-                <a
+                <LinkAnchor
+                  aria-current={null}
                   className="p-list__link"
                   href="/controllers"
-                  onClick={[Function]}
+                  navigate={[Function]}
                 >
-                  <img
-                    alt="Controllers icon"
-                    className="p-list__icon"
-                    src="https://assets.ubuntu.com/v1/8414b187-controllers.svg"
-                  />
-                  Controllers
-                </a>
-              </LinkAnchor>
-            </Link>
+                  <a
+                    aria-current={null}
+                    className="p-list__link"
+                    href="/controllers"
+                    onClick={[Function]}
+                  >
+                    <img
+                      alt="Controllers icon"
+                      className="p-list__icon"
+                      src="https://assets.ubuntu.com/v1/8414b187-controllers.svg"
+                    />
+                    Controllers
+                  </a>
+                </LinkAnchor>
+              </Link>
+            </NavLink>
           </li>
           <li
             className="p-list__item"
             key="/usage"
           >
-            <Link
+            <NavLink
+              activeClassName="is-selected"
               className="p-list__link"
+              exact={true}
               to="/usage"
             >
-              <LinkAnchor
+              <Link
+                aria-current={null}
                 className="p-list__link"
-                href="/usage"
-                navigate={[Function]}
+                to={
+                  Object {
+                    "hash": "",
+                    "pathname": "/usage",
+                    "search": "",
+                    "state": null,
+                  }
+                }
               >
-                <a
+                <LinkAnchor
+                  aria-current={null}
                   className="p-list__link"
                   href="/usage"
-                  onClick={[Function]}
+                  navigate={[Function]}
                 >
-                  <img
-                    alt="Usage icon"
-                    className="p-list__icon"
-                    src="https://assets.ubuntu.com/v1/1b1d07ae-usage.svg"
-                  />
-                  Usage
-                </a>
-              </LinkAnchor>
-            </Link>
+                  <a
+                    aria-current={null}
+                    className="p-list__link"
+                    href="/usage"
+                    onClick={[Function]}
+                  >
+                    <img
+                      alt="Usage icon"
+                      className="p-list__icon"
+                      src="https://assets.ubuntu.com/v1/1b1d07ae-usage.svg"
+                    />
+                    Usage
+                  </a>
+                </LinkAnchor>
+              </Link>
+            </NavLink>
           </li>
           <li
             className="p-list__item"
             key="/logs"
           >
-            <Link
+            <NavLink
+              activeClassName="is-selected"
               className="p-list__link"
+              exact={true}
               to="/logs"
             >
-              <LinkAnchor
+              <Link
+                aria-current={null}
                 className="p-list__link"
-                href="/logs"
-                navigate={[Function]}
+                to={
+                  Object {
+                    "hash": "",
+                    "pathname": "/logs",
+                    "search": "",
+                    "state": null,
+                  }
+                }
               >
-                <a
+                <LinkAnchor
+                  aria-current={null}
                   className="p-list__link"
                   href="/logs"
-                  onClick={[Function]}
+                  navigate={[Function]}
                 >
-                  <img
-                    alt="Logs icon"
-                    className="p-list__icon"
-                    src="https://assets.ubuntu.com/v1/741097ff-logs.svg"
-                  />
-                  Logs
-                </a>
-              </LinkAnchor>
-            </Link>
+                  <a
+                    aria-current={null}
+                    className="p-list__link"
+                    href="/logs"
+                    onClick={[Function]}
+                  >
+                    <img
+                      alt="Logs icon"
+                      className="p-list__icon"
+                      src="https://assets.ubuntu.com/v1/741097ff-logs.svg"
+                    />
+                    Logs
+                  </a>
+                </LinkAnchor>
+              </Link>
+            </NavLink>
           </li>
         </ul>
       </nav>

--- a/src/components/Layout/__snapshots__/Layout.test.js.snap
+++ b/src/components/Layout/__snapshots__/Layout.test.js.snap
@@ -28,7 +28,9 @@ exports[`Layout renders without crashing and matches snapshot 1`] = `
                 <img
                   alt="JAAS logo"
                   className="p-primary-nav__logo"
+                  height="35"
                   src="https://assets.ubuntu.com/v1/a9e0ed4a-jaas-logo1.svg"
+                  width="110"
                 />
               </a>
             </LinkAnchor>

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -1,17 +1,31 @@
+@import "vanilla-framework/scss/settings_colors";
+
 $color-sidebar: #003b4e;
+$sidebar-collapsed: 48px;
 
 .l-container {
-  display: grid;
-  grid-template-columns: 250px 1fr;
+  display: flex;
   min-height: 100vh;
 }
 
 .l-main {
+  background-color: $color-x-light;
   overflow: hidden;
   position: relative;
+  width: calc(100vw - 250px);
+
+  .is-collapsible & {
+    width: calc(100vw - #{$sidebar-collapsed});
+  }
 }
 
 .l-side {
   background: $color-sidebar;
   padding: 0;
+  transition: 0.5s;
+  width: 250px;
+
+  .is-collapsible & {
+    width: $sidebar-collapsed;
+  }
 }

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -1,7 +1,5 @@
 @import "vanilla-framework/scss/settings_colors";
-
-$color-sidebar: #003b4e;
-$sidebar-collapsed: 48px;
+@import "../../scss/settings";
 
 .l-container {
   display: flex;
@@ -12,9 +10,9 @@ $sidebar-collapsed: 48px;
   background-color: $color-x-light;
   overflow: hidden;
   position: relative;
-  width: calc(100vw - 250px);
+  width: calc(100vw - #{$sidebar-full-width});
 
-  .is-collapsible & {
+  .has-collapsible-sidebar & {
     width: calc(100vw - #{$sidebar-collapsed});
   }
 }
@@ -22,10 +20,10 @@ $sidebar-collapsed: 48px;
 .l-side {
   background: $color-sidebar;
   padding: 0;
-  transition: 0.5s;
-  width: 250px;
+  transition: width 0.25s ease-in-out;
+  width: $sidebar-full-width;
 
-  .is-collapsible & {
+  .has-collapsible-sidebar & {
     width: $sidebar-collapsed;
   }
 }

--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -27,6 +27,8 @@ const PrimaryNav = () => {
             className="p-primary-nav__logo"
             src="https://assets.ubuntu.com/v1/a9e0ed4a-jaas-logo1.svg"
             alt="JAAS logo"
+            height="35"
+            width="110"
           />
         </Link>
         <button

--- a/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.js.snap
+++ b/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.js.snap
@@ -45,7 +45,9 @@ exports[`Primary Nav renders without crashing and matches snapshot 1`] = `
                 <img
                   alt="JAAS logo"
                   className="p-primary-nav__logo"
+                  height="35"
                   src="https://assets.ubuntu.com/v1/a9e0ed4a-jaas-logo1.svg"
+                  width="110"
                 />
               </a>
             </LinkAnchor>

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -1,13 +1,10 @@
 @import "vanilla-framework/scss/settings_colors";
-
-$color-navigation-dark: #002835;
-$color-navigation-highlight: #004e68;
-$color-navigation-accent: #3fc8f2;
+@import "../../scss/settings";
 
 .p-primary-nav {
   position: sticky;
   top: 0;
-  width: 250px;
+  width: $sidebar-full-width;
 
   a,
   a:hover {

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -7,6 +7,7 @@ $color-navigation-accent: #3fc8f2;
 .p-primary-nav {
   position: sticky;
   top: 0;
+  width: 250px;
 
   a,
   a:hover {

--- a/src/hooks/useHover.js
+++ b/src/hooks/useHover.js
@@ -1,0 +1,31 @@
+// https://usehooks.com/useHover/
+import { useRef, useState, useEffect } from "react";
+
+function useHover() {
+  const [value, setValue] = useState(false);
+
+  const ref = useRef(null);
+
+  const handleMouseOver = () => setValue(true);
+  const handleMouseOut = () => setValue(false);
+
+  useEffect(
+    () => {
+      const node = ref.current;
+      if (node) {
+        node.addEventListener("mouseover", handleMouseOver);
+        node.addEventListener("mouseout", handleMouseOut);
+
+        return () => {
+          node.removeEventListener("mouseover", handleMouseOver);
+          node.removeEventListener("mouseout", handleMouseOut);
+        };
+      }
+    },
+    [] // Recall only if ref changes
+  );
+
+  return [ref, value];
+}
+
+export default useHover;

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -169,15 +169,12 @@ const ModelDetails = () => {
   ]);
   const modelStatusData = useSelector(getModelStatusMemo);
 
-  // Toggle collapsible sidebar when component mounts/unmounts
   useEffect(() => {
-    // This gets called after every render
     dispatch(collapsibleSidebar(true));
-    // Cleanup when unmounting
     return () => {
       dispatch(collapsibleSidebar(false));
     };
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     if (modelUUID !== null && modelStatusData === null) {

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -177,7 +177,7 @@ const ModelDetails = () => {
     return () => {
       dispatch(collapsibleSidebar(false));
     };
-  });
+  }, []);
 
   useEffect(() => {
     if (modelUUID !== null && modelStatusData === null) {

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -12,6 +12,7 @@ import UserIcon from "components/UserIcon/UserIcon";
 
 import { getModelUUID, getModelStatus } from "app/selectors";
 import { fetchModelStatus } from "juju/actions";
+import { collapsibleSidebar } from "app/actions";
 import { generateStatusIcon } from "app/utils";
 
 import "./_model-details.scss";
@@ -167,6 +168,16 @@ const ModelDetails = () => {
     modelUUID
   ]);
   const modelStatusData = useSelector(getModelStatusMemo);
+
+  // Toggle collapsible sidebar when component mounts/unmounts
+  useEffect(() => {
+    // This gets called after every render
+    dispatch(collapsibleSidebar(true));
+    // Cleanup when unmounting
+    return () => {
+      dispatch(collapsibleSidebar(false));
+    };
+  });
 
   useEffect(() => {
     if (modelUUID !== null && modelStatusData === null) {

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,0 +1,9 @@
+// Custom colors
+$color-sidebar: #003b4e;
+$color-navigation-dark: #002835;
+$color-navigation-highlight: #004e68;
+$color-navigation-accent: #3fc8f2;
+
+// Sidebar
+$sidebar-full-width: 250px;
+$sidebar-collapsed: 48px;


### PR DESCRIPTION
## Done

Make the models details sidebar collapsible

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to models details page and see the sidebar is collapsed. 
- Hover over to expand and interact with it.
- Hover off to see it collapse again.
- No other page should have this behavior.

## Details

#129 

## Known issues

- I tried to test for the existence of the `has-collapsible-sidebar` on the `<ModelDetails>` component but it's not there when Jest loads it - is this before useEffect onDomReady?

- When you expand the sidenav, open the external nav and hover off - the external nav does not close. Will follow up later.

- The icons in the collapsed sidebar will need proper aligning and pixel pushing. I will follow up with @spencerbygraves on this.