### PR TITLE
Controller connection reliability improvements

### DIFF
--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -100,7 +100,7 @@ async function loginWithBakery(visitPage, macaroonStore) {
 }
 
 /**
-  Commects and logs in to the supplied modelURL. If the connection takes longer
+  Connects and logs in to the supplied modelURL. If the connection takes longer
   than the allowed timeout it gives up.
   @param {String} modelURL The fully qualified url of the model api.
   @param {Object} options The options for the connection.

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -154,6 +154,9 @@ async function fetchModelStatus(modelUUID) {
  */
 async function fetchAndStoreModelStatus(modelUUID, dispatch) {
   const status = await fetchModelStatus(modelUUID);
+  if (status === null) {
+    return;
+  }
   dispatch(updateModelStatus(modelUUID, status));
 }
 

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -93,7 +93,7 @@ async function loginWithBakery(visitPage, macaroonStore) {
   // Ping to keep the connection alive.
   conn.facades.pinger.pingForever(20000, err => {
     if (err) {
-      console.log("unable to ping:", err);
+      console.error("unable to ping:", err);
     }
   });
   return { bakery, conn };

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -132,13 +132,17 @@ async function connectAndLoginWithTimeout(modelURL, options, duration = 5000) {
 */
 async function fetchModelStatus(modelUUID) {
   const modelURL = controllerURL.replace("/api", `/model/${modelUUID}/api`);
-  const { conn, logout } = await jujulib.connectAndLogin(
-    modelURL,
-    {},
-    generateConnectionOptions()
-  );
-  const status = await conn.facades.client.fullStatus();
-  logout();
+  let status = null;
+  try {
+    const { conn, logout } = await connectAndLoginWithTimeout(
+      modelURL,
+      generateConnectionOptions()
+    );
+    status = await conn.facades.client.fullStatus();
+    logout();
+  } catch (e) {
+    console.error("timeout, unable to log into model:", modelUUID);
+  }
   return status;
 }
 

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -100,6 +100,30 @@ async function loginWithBakery(visitPage, macaroonStore) {
 }
 
 /**
+  Commects and logs in to the supplied modelURL. If the connection takes longer
+  than the allowed timeout it gives up.
+  @param {String} modelURL The fully qualified url of the model api.
+  @param {Object} options The options for the connection.
+  @param {Number} duration The timeout in ms for the connection. Defaults to 5s
+  @returns {Object} The full model status.
+*/
+async function connectAndLoginWithTimeout(modelURL, options, duration = 5000) {
+  const timeout = new Promise((resolve, reject) => {
+    setTimeout(resolve, duration, "timeout");
+  });
+  const juju = jujulib.connectAndLogin(modelURL, {}, options);
+  return new Promise((resolve, reject) => {
+    Promise.race([timeout, juju]).then(resp => {
+      if (resp === "timeout") {
+        reject("timeout");
+        return;
+      }
+      resolve(resp);
+    });
+  });
+}
+
+/**
   Connects to the model url by doing a replacement on the controller url and
   fetches it's full status then logs out of the model and closes the connection.
   @param {String} modelUUID The UUID of the model to connect to. Must be on the

--- a/src/juju/reducers.js
+++ b/src/juju/reducers.js
@@ -53,7 +53,13 @@ export default produce(
         // There don't appear to be any irrelevent data in the modelInfo so
         // we overwrite the whole object every time it changes even though
         // mostly that'll just be status timestamps.
-        draftState.modelData[modelInfo.uuid].info = modelInfo;
+        const modelData = draftState.modelData[modelInfo.uuid];
+        // If any of the status requests timeout then it's possible the data
+        // won't be available. Just abandon saving any data in that case.
+        // This will go away with the new API.
+        if (modelData) {
+          draftState.modelData[modelInfo.uuid].info = modelInfo;
+        }
         // XXX Remove the following line  when all selectors have switched to
         // use the modelData key.
         draftState.modelInfo[modelInfo.uuid] = modelInfo;


### PR DESCRIPTION
## Done

- When connecting to a controller, start the pinger on 20s increments to keep the controller connection alive. This is required because the controller interactions can be spaced out longer than the 1m timeout in the event the user has a large number of models we're polling against.
- If a model connection takes longer than 5s then abandon the connection. This was necessary because sometimes model connections hang, which prevents the poller from starting over again as something is always stuck in the queue.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- The model list should work as expected
- To test the failure case, change the timeout to 50ms from 5000ms and reload. The console should have a number of console errors that an item has timed out.

## Details

Fixes #105 