### PR TITLE
Switch UI to a different model on juju switch

### DIFF
--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -32,7 +32,12 @@ const Terminal = ({ address, modelName }) => {
     );
 
     return cleanUpTerminal(terminalInstance);
-  }, [address, macaroons, modelName, history]);
+    // Because the user can switch the model details UI from within the
+    // component the `modelName` passed above will change as the UI
+    // updates. This causes the terminal to log in again which is
+    // undesirable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [terminalVisible, setTerminalVisible] = useState(false);
 

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { getMacaroons } from "app/selectors";
 import classNames from "classnames";
@@ -11,18 +12,27 @@ import "./_terminal.scss";
 const Terminal = ({ address, modelName }) => {
   const terminalElement = useRef(null);
   const macaroons = useSelector(getMacaroons);
+  const history = useHistory();
 
   useEffect(() => {
+    // If the model name is found after a juju switch then
+    // switch to that route.
+    const switchFound = model => {
+      if (modelName !== model) {
+        history.push(`/models/${model}`);
+      }
+    };
     const creds = { macaroons };
     const terminalInstance = setupTerminal(
       address,
       creds,
       modelName,
-      terminalElement
+      terminalElement,
+      switchFound
     );
 
     return cleanUpTerminal(terminalInstance);
-  }, [address, macaroons, modelName]);
+  }, [address, macaroons, modelName, history]);
 
   const [terminalVisible, setTerminalVisible] = useState(false);
 


### PR DESCRIPTION
## Done

When running `juju switch` from within the terminal it now changes the UI to the model you've switched to.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a model
- After the terminal has loaded then juju switch to a different model. The UI should update to that model and the terminal should not re-render or output any 'logging-in' messages.
- Do this a few times between your own models and your shared models.
- Try and break it!

## Details

It's probably best if #156 lands first else you'll have to do this QA before it times out, then refresh, etc.

Fixes #123 

## Known Issues

- When switching to a model you own the URL will contain the full path to your model ie) `foo@external/mymodel` instead of just `mymodel` this has no negative side effects but a longer url.