### PR TITLE
Use generic Vanilla import instead of specific color settings

### DIFF
--- a/src/components/ButtonToggle/_button-toggle.scss
+++ b/src/components/ButtonToggle/_button-toggle.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .p-button-toggle {
   align-items: center;

--- a/src/components/Filter/_filter.scss
+++ b/src/components/Filter/_filter.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .p-filter {
   font-size: 0.875rem;

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .p-filter-tags {
   padding: 0.5rem;

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .header {
   background-color: $color-x-light;

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .info-panel {
   margin-right: 1rem;

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 @import "../../scss/settings";
 
 .l-container {

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 @import "../../scss/settings";
 
 .p-primary-nav {

--- a/src/components/TableList/_table-list.scss
+++ b/src/components/TableList/_table-list.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .table-list_error-message {
   color: $color-negative;

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 @import "xterm/css/xterm";
 
 $terminal-shell-height: 10rem;

--- a/src/components/UserIcon/_user-icon.scss
+++ b/src/components/UserIcon/_user-icon.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .user-icon {
   cursor: pointer;

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -1,4 +1,4 @@
-@import "vanilla-framework/scss/settings_colors";
+@import "vanilla-framework/scss/vanilla";
 
 .model-details {
   display: grid;


### PR DESCRIPTION
## Done

Use generic Vanilla import instead of specific color settings. This should mean all of Vanilla can be accessed if needs be, not just colors. 

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Ensure no errors.
