### PR TITLE
Reduce info panel width on smaller screens

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -12,7 +12,11 @@
 
   &__grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
+
+    @media (min-width: $breakpoint-x-large) {
+      grid-template-columns: 1fr 1fr;
+    }
   }
 
   .p-muted-heading {

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -2,9 +2,13 @@
 
 .model-details {
   display: grid;
-  grid-template-columns: 350px 1fr;
+  grid-template-columns: 230px 1fr;
   min-height: calc(100vh - 48px); // header is 48px high.
   padding-bottom: 2rem;
+
+  @media (min-width: $breakpoint-x-large) {
+    grid-template-columns: 350px 1fr;
+  }
 
   &__header {
     align-items: center;


### PR DESCRIPTION
## Done

Reduce info panel width on smaller screens

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details
- Start with screen width less than 1681px then increase screen width and view changes with info panel and topology

## Details

Fixes #166 
