### PR TITLE
Show cloud provider name in model details

### DIFF
--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -38,7 +38,7 @@ const InfoPanel = () => {
         <div className="info-panel__grid-item">
           <h4 className="p-muted-heading">Cloud/Region</h4>
           <p data-name="cloud-region">
-            {cloudProvider ? cloudProvider[1] : ""}
+            {cloudProvider}
             {modelStatusData ? "/" : ""}
             {modelStatusData ? modelStatusData.model.region : ""}
           </p>

--- a/src/components/InfoPanel/__snapshots__/InfoPanel.test.js.snap
+++ b/src/components/InfoPanel/__snapshots__/InfoPanel.test.js.snap
@@ -40,7 +40,7 @@ exports[`Info Panel renders without crashing and matches snapshot 1`] = `
       <p
         data-name="cloud-region"
       >
-        o
+        google
         /
         us-central1
       </p>

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -44,7 +44,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
           <p
             data-name="cloud-region"
           >
-            o
+            google
             /
             us-central1
           </p>


### PR DESCRIPTION
## Done

The cloud provider name was being incorrectly displayed. This shows the cloud provider name correctly on the model details page.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a model details page and the cloud provider name should be shown correctly.

## Details

Fixes #178 
