### PR TITLE
Align table columns

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -1,3 +1,4 @@
+@import "../../scss/settings";
 @import "vanilla-framework/scss/vanilla";
 
 .info-panel {
@@ -14,7 +15,7 @@
     display: grid;
     grid-template-columns: 1fr;
 
-    @media (min-width: $breakpoint-x-large) {
+    @media (min-width: $breakpoint-m-large) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -156,8 +156,8 @@ function getStatusValue(status, key) {
           <Fragment>
             <div className="model-details__config">
               {applicationCount}
-              {machineCount}
               {unitCount}
+              {machineCount}
             </div>
           </Fragment>
         );

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -171,14 +171,14 @@ exports[`TableList displays all data from redux store 1`] = `
                     11
                   </span>
                   <span
-                    className="model-details__machine-icon"
-                  >
-                    6
-                  </span>
-                  <span
                     className="model-details__unit-icon"
                   >
                     10
+                  </span>
+                  <span
+                    className="model-details__machine-icon"
+                  >
+                    6
                   </span>
                 </div>
               </React.Fragment>,
@@ -232,12 +232,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     1
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     1
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     1
                   </span>
@@ -396,14 +396,14 @@ exports[`TableList displays all data from redux store 1`] = `
                       11
                     </span>
                     <span
-                      className="model-details__machine-icon"
-                    >
-                      6
-                    </span>
-                    <span
                       className="model-details__unit-icon"
                     >
                       10
+                    </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      6
                     </span>
                   </div>
                 </td>
@@ -512,12 +512,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       1
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       1
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       1
                     </span>
@@ -640,14 +640,14 @@ exports[`TableList displays all data from redux store 1`] = `
                     2
                   </span>
                   <span
-                    className="model-details__machine-icon"
-                  >
-                    4
-                  </span>
-                  <span
                     className="model-details__unit-icon"
                   >
                     2
+                  </span>
+                  <span
+                    className="model-details__machine-icon"
+                  >
+                    4
                   </span>
                 </div>
               </React.Fragment>,
@@ -696,12 +696,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     3
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     3
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     3
                   </span>
@@ -752,12 +752,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     1
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     1
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     1
                   </span>
@@ -808,12 +808,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     3
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     3
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     3
                   </span>
@@ -967,14 +967,14 @@ exports[`TableList displays all data from redux store 1`] = `
                       2
                     </span>
                     <span
-                      className="model-details__machine-icon"
-                    >
-                      4
-                    </span>
-                    <span
                       className="model-details__unit-icon"
                     >
                       2
+                    </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      4
                     </span>
                   </div>
                 </td>
@@ -1078,12 +1078,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       3
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       3
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       3
                     </span>
@@ -1189,12 +1189,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       1
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       1
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       1
                     </span>
@@ -1300,12 +1300,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       3
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       3
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       3
                     </span>
@@ -1428,12 +1428,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     6
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     10
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     10
                   </span>
@@ -1484,12 +1484,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     6
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     10
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     10
                   </span>
@@ -1540,12 +1540,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     7
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     11
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     11
                   </span>
@@ -1596,12 +1596,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     9
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     0
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     0
                   </span>
@@ -1652,12 +1652,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     2
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     1
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     1
                   </span>
@@ -1708,12 +1708,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     0
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     0
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     0
                   </span>
@@ -1764,12 +1764,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     0
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     0
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     0
                   </span>
@@ -1820,12 +1820,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     0
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     0
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     0
                   </span>
@@ -1876,12 +1876,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     2
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     2
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     2
                   </span>
@@ -1932,12 +1932,12 @@ exports[`TableList displays all data from redux store 1`] = `
                     2
                   </span>
                   <span
-                    className="model-details__machine-icon"
+                    className="model-details__unit-icon"
                   >
                     2
                   </span>
                   <span
-                    className="model-details__unit-icon"
+                    className="model-details__machine-icon"
                   >
                     2
                   </span>
@@ -2091,12 +2091,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       6
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       10
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       10
                     </span>
@@ -2202,12 +2202,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       6
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       10
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       10
                     </span>
@@ -2313,12 +2313,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       7
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       11
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       11
                     </span>
@@ -2424,12 +2424,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       9
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       0
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       0
                     </span>
@@ -2535,12 +2535,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       2
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       1
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       1
                     </span>
@@ -2646,12 +2646,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       0
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       0
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       0
                     </span>
@@ -2757,12 +2757,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       0
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       0
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       0
                     </span>
@@ -2868,12 +2868,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       0
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       0
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       0
                     </span>
@@ -2979,12 +2979,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       2
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       2
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       2
                     </span>
@@ -3090,12 +3090,12 @@ exports[`TableList displays all data from redux store 1`] = `
                       2
                     </span>
                     <span
-                      className="model-details__machine-icon"
+                      className="model-details__unit-icon"
                     >
                       2
                     </span>
                     <span
-                      className="model-details__unit-icon"
+                      className="model-details__machine-icon"
                     >
                       2
                     </span>

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -13,7 +13,7 @@ import UserIcon from "components/UserIcon/UserIcon";
 import { getModelUUID, getModelStatus } from "app/selectors";
 import { fetchModelStatus } from "juju/actions";
 import { collapsibleSidebar } from "app/actions";
-import { generateStatusIcon } from "app/utils";
+import { generateStatusIcon, generateSpanClass } from "app/utils";
 
 import "./_model-details.scss";
 
@@ -163,7 +163,7 @@ const generateRelationRows = modelStatusData => {
         { content: requirer || "-" },
         { content: relation.interface },
         { content: relation.endpoints[0].role },
-        { content: relation.status.status }
+        { content: generateSpanClass("u-capitalise", relation.status.status) }
       ]
     };
   });
@@ -198,7 +198,12 @@ const generateMachineRows = modelStatusData => {
         { content: generateStatusIcon(machine.instanceStatus.status) },
         { content: splitParts(machine.hardware)["availability-zone"] },
         { content: machine.instanceId },
-        { content: machine.instanceStatus.info }
+        {
+          content: generateSpanClass(
+            "u-capitalise",
+            machine.instanceStatus.info.toLowerCase()
+          )
+        }
       ]
     };
   });

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -20,7 +20,7 @@ import "./_model-details.scss";
 const applicationTableHeaders = [
   { content: "app" },
   { content: "status" },
-  { content: "version" },
+  { content: "version", className: "u-align--right" },
   { content: "scale", className: "u-align--right" },
   { content: "store" },
   { content: "rev", className: "u-align--right" },
@@ -32,9 +32,17 @@ const unitTableHeaders = [
   { content: "unit" },
   { content: "workload" },
   { content: "agent" },
-  { content: "machine" },
+  { content: "machine", className: "u-align--right" },
   { content: "public address" },
-  { content: "port" },
+  { content: "port", className: "u-align--right" },
+  { content: "message" }
+];
+
+const machineTableHeaders = [
+  { content: "machine" },
+  { content: "state" },
+  { content: "az" },
+  { content: "instance id" },
   { content: "message" }
 ];
 
@@ -46,21 +54,12 @@ const relationTableHeaders = [
   { content: "message" }
 ];
 
-const machineTableHeaders = [
-  { content: "machine" },
-  { content: "ip" },
-  { content: "state" },
-  { content: "az" },
-  { content: "instance id" },
-  { content: "message" }
-];
-
 const generateEntityLink = (namespace, href, name) => {
   return (
     <>
       {namespace && (
         <img
-          alt=""
+          alt={name + " icon"}
           width="24"
           height="24"
           className="entity-icon"
@@ -92,11 +91,11 @@ const generateApplicationRows = modelStatusData => {
           )
         },
         { content: app.status ? generateStatusIcon(app.status.status) : "-" },
-        { content: "-" },
+        { content: "-", className: "u-align--right" },
+        { content: "-", className: "u-align--right" },
         { content: "CharmHub" },
-        { content: key.split("-")[-1] },
-        { content: "-" },
-        { content: "-" },
+        { content: key.split("-")[-1] || "-", className: "u-align--right" },
+        { content: "Ubuntu" },
         { content: "-" }
       ]
     };
@@ -127,9 +126,12 @@ const generateUnitRows = modelStatusData => {
           },
           { content: generateStatusIcon(unit.workloadStatus.status) },
           { content: unit.agentStatus.status },
-          { content: unit.machine },
+          { content: unit.machine, className: "u-align--right" },
           { content: unit.publicAddress },
-          { content: unit.publicAddress.split(":")[-1] },
+          {
+            content: unit.publicAddress.split(":")[-1] || "-",
+            className: "u-align--right"
+          },
           { content: unit.workloadStatus.info }
         ]
       });
@@ -185,9 +187,15 @@ const generateMachineRows = modelStatusData => {
     const machine = machines[machineId];
     return {
       columns: [
-        { content: machineId },
-        { content: machine.dnsName },
-        { content: machine.instanceStatus.status },
+        {
+          content: (
+            <>
+              <div>{machineId}</div>
+              <a href="#_">{machine.dnsName}</a>
+            </>
+          )
+        },
+        { content: generateStatusIcon(machine.instanceStatus.status) },
         { content: splitParts(machine.hardware)["availability-zone"] },
         { content: machine.instanceId },
         { content: machine.instanceStatus.info }
@@ -260,21 +268,25 @@ const ModelDetails = () => {
             <MainTable
               headers={applicationTableHeaders}
               rows={applicationTableRows}
+              className="model-details__apps"
               sortable
             />
             <MainTable
               headers={unitTableHeaders}
               rows={unitTableRows}
+              className="model-details__units"
               sortable
             />
             <MainTable
               headers={machineTableHeaders}
               rows={machinesTableRows}
+              className="model-details__machines"
               sortable
             />
             <MainTable
               headers={relationTableHeaders}
               rows={relationTableRows}
+              className="model-details__relations"
               sortable
             />
           </div>

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -84,6 +84,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
     className="model-details__main"
   >
     <MainTable
+      className="model-details__apps"
       headers={
         Array [
           Object {
@@ -93,6 +94,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
             "content": "status",
           },
           Object {
+            "className": "u-align--right",
             "content": "version",
           },
           Object {
@@ -121,7 +123,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="easyrsa icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-68/icon.svg"
@@ -143,19 +145,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -167,7 +172,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="elasticsearch icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/trusty/elasticsearch-15/icon.svg"
@@ -189,19 +194,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -213,7 +221,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="etcd icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/etcd-126/icon.svg"
@@ -235,19 +243,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -259,7 +270,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="flannel icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/flannel-81/icon.svg"
@@ -281,19 +292,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -305,7 +319,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="kibana icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/trusty/kibana-14/icon.svg"
@@ -327,19 +341,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -351,7 +368,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="kubeapi-load-balancer icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/kubeapi-load-balancer-88/icon.svg"
@@ -373,19 +390,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -397,7 +417,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="kubernetes-master icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-144/icon.svg"
@@ -419,19 +439,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -443,7 +466,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="kubernetes-worker icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-worker-163/icon.svg"
@@ -465,19 +488,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -489,7 +515,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               Object {
                 "content": <React.Fragment>
                   <img
-                    alt=""
+                    alt="rsyslog icon"
                     className="entity-icon"
                     height="24"
                     src="https://api.jujucharms.com/charmstore/v5/trusty/rsyslog-10/icon.svg"
@@ -511,19 +537,22 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </span>,
               },
               Object {
+                "className": "u-align--right",
+                "content": "-",
+              },
+              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
                 "content": "CharmHub",
               },
               Object {
-                "content": undefined,
-              },
-              Object {
+                "className": "u-align--right",
                 "content": "-",
               },
               Object {
-                "content": "-",
+                "content": "Ubuntu",
               },
               Object {
                 "content": "-",
@@ -535,10 +564,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       sortable={true}
     >
       <Table
+        className="model-details__apps"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__apps p-table--sortable"
           role="grid"
         >
           <thead>
@@ -565,10 +595,12 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="2"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     version
@@ -644,7 +676,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="easyrsa icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/easyrsa-68/icon.svg"
@@ -672,17 +704,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -692,18 +736,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -716,7 +753,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -743,7 +780,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="elasticsearch icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/trusty/elasticsearch-15/icon.svg"
@@ -771,17 +808,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -791,18 +840,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -815,7 +857,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -842,7 +884,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="etcd icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/etcd-126/icon.svg"
@@ -870,17 +912,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -890,18 +944,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -914,7 +961,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -941,7 +988,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="flannel icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/flannel-81/icon.svg"
@@ -969,17 +1016,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -989,18 +1048,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1013,7 +1065,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1040,7 +1092,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="kibana icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/trusty/kibana-14/icon.svg"
@@ -1068,17 +1120,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -1088,18 +1152,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1112,7 +1169,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1139,7 +1196,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="kubeapi-load-balancer icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/kubeapi-load-balancer-88/icon.svg"
@@ -1167,17 +1224,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -1187,18 +1256,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1211,7 +1273,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1238,7 +1300,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="kubernetes-master icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-master-144/icon.svg"
@@ -1266,17 +1328,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -1286,18 +1360,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1310,7 +1377,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1337,7 +1404,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="kubernetes-worker icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/~containers/kubernetes-worker-163/icon.svg"
@@ -1365,17 +1432,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -1385,18 +1464,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1409,7 +1481,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1436,7 +1508,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <img
-                      alt=""
+                      alt="rsyslog icon"
                       className="entity-icon"
                       height="24"
                       src="https://api.jujucharms.com/charmstore/v5/trusty/rsyslog-10/icon.svg"
@@ -1464,17 +1536,29 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="2"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-align--right"
                   key="3"
+                >
+                  <td
+                    className="u-align--right"
+                    role="gridcell"
+                  >
+                    -
+                  </td>
+                </TableCell>
+                <TableCell
+                  key="4"
                 >
                   <td
                     className=""
@@ -1484,18 +1568,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
-                  key="4"
-                >
-                  <td
-                    className=""
-                    role="gridcell"
-                  />
-                </TableCell>
-                <TableCell
+                  className="u-align--right"
                   key="5"
                 >
                   <td
-                    className=""
+                    className="u-align--right"
                     role="gridcell"
                   >
                     -
@@ -1508,7 +1585,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    -
+                    Ubuntu
                   </td>
                 </TableCell>
                 <TableCell
@@ -1528,6 +1605,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__units"
       headers={
         Array [
           Object {
@@ -1540,12 +1618,14 @@ exports[`ModelDetail Container renders the details pane 1`] = `
             "content": "agent",
           },
           Object {
+            "className": "u-align--right",
             "content": "machine",
           },
           Object {
             "content": "public address",
           },
           Object {
+            "className": "u-align--right",
             "content": "port",
           },
           Object {
@@ -1557,10 +1637,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       sortable={true}
     >
       <Table
+        className="model-details__units"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__units p-table--sortable"
           role="grid"
         >
           <thead>
@@ -1597,10 +1678,12 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="3"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     machine
@@ -1617,10 +1700,12 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="5"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     port
@@ -1644,13 +1729,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__machines"
       headers={
         Array [
           Object {
             "content": "machine",
-          },
-          Object {
-            "content": "ip",
           },
           Object {
             "content": "state",
@@ -1670,10 +1753,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       sortable={true}
     >
       <Table
+        className="model-details__machines"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__machines p-table--sortable"
           role="grid"
         >
           <thead>
@@ -1696,7 +1780,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   <th
                     onClick={[Function]}
                   >
-                    ip
+                    state
                   </th>
                 </TableHeader>
                 <TableHeader
@@ -1706,7 +1790,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   <th
                     onClick={[Function]}
                   >
-                    state
+                    az
                   </th>
                 </TableHeader>
                 <TableHeader
@@ -1716,21 +1800,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   <th
                     onClick={[Function]}
                   >
-                    az
-                  </th>
-                </TableHeader>
-                <TableHeader
-                  key="4"
-                  onClick={[Function]}
-                >
-                  <th
-                    onClick={[Function]}
-                  >
                     instance id
                   </th>
                 </TableHeader>
                 <TableHeader
-                  key="5"
+                  key="4"
                   onClick={[Function]}
                 >
                   <th
@@ -1747,6 +1821,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__relations"
       headers={
         Array [
           Object {
@@ -1783,7 +1858,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "provider",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1802,7 +1881,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1821,7 +1904,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1840,7 +1927,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1859,7 +1950,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "peer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1878,7 +1973,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1897,7 +1996,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "peer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1916,7 +2019,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1935,7 +2042,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1954,7 +2065,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1973,7 +2088,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -1992,7 +2111,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -2011,7 +2134,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "provider",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -2030,7 +2157,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -2049,7 +2180,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 "content": "requirer",
               },
               Object {
-                "content": "joining",
+                "content": <span
+                  className="u-capitalise"
+                >
+                  joining
+                </span>,
               },
             ],
           },
@@ -2058,10 +2193,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
       sortable={true}
     >
       <Table
+        className="model-details__relations"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__relations p-table--sortable"
           role="grid"
         >
           <thead>
@@ -2172,7 +2308,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2228,7 +2368,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2284,7 +2428,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2340,7 +2488,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2396,7 +2548,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2452,7 +2608,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2508,7 +2668,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2564,7 +2728,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2620,7 +2788,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2676,7 +2848,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2732,7 +2908,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2788,7 +2968,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2844,7 +3028,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2900,7 +3088,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -2956,7 +3148,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     className=""
                     role="gridcell"
                   >
-                    joining
+                    <span
+                      className="u-capitalise"
+                    >
+                      joining
+                    </span>
                   </td>
                 </TableCell>
               </tr>
@@ -3043,6 +3239,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
     className="model-details__main"
   >
     <MainTable
+      className="model-details__apps"
       headers={
         Array [
           Object {
@@ -3052,6 +3249,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
             "content": "status",
           },
           Object {
+            "className": "u-align--right",
             "content": "version",
           },
           Object {
@@ -3077,10 +3275,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       sortable={true}
     >
       <Table
+        className="model-details__apps"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__apps p-table--sortable"
           role="grid"
         >
           <thead>
@@ -3107,10 +3306,12 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="2"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     version
@@ -3178,6 +3379,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__units"
       headers={
         Array [
           Object {
@@ -3190,12 +3392,14 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
             "content": "agent",
           },
           Object {
+            "className": "u-align--right",
             "content": "machine",
           },
           Object {
             "content": "public address",
           },
           Object {
+            "className": "u-align--right",
             "content": "port",
           },
           Object {
@@ -3207,10 +3411,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       sortable={true}
     >
       <Table
+        className="model-details__units"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__units p-table--sortable"
           role="grid"
         >
           <thead>
@@ -3247,10 +3452,12 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="3"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     machine
@@ -3267,10 +3474,12 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   </th>
                 </TableHeader>
                 <TableHeader
+                  className="u-align--right"
                   key="5"
                   onClick={[Function]}
                 >
                   <th
+                    className="u-align--right"
                     onClick={[Function]}
                   >
                     port
@@ -3294,13 +3503,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__machines"
       headers={
         Array [
           Object {
             "content": "machine",
-          },
-          Object {
-            "content": "ip",
           },
           Object {
             "content": "state",
@@ -3320,10 +3527,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       sortable={true}
     >
       <Table
+        className="model-details__machines"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__machines p-table--sortable"
           role="grid"
         >
           <thead>
@@ -3346,7 +3554,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   <th
                     onClick={[Function]}
                   >
-                    ip
+                    state
                   </th>
                 </TableHeader>
                 <TableHeader
@@ -3356,7 +3564,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   <th
                     onClick={[Function]}
                   >
-                    state
+                    az
                   </th>
                 </TableHeader>
                 <TableHeader
@@ -3366,21 +3574,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
                   <th
                     onClick={[Function]}
                   >
-                    az
-                  </th>
-                </TableHeader>
-                <TableHeader
-                  key="4"
-                  onClick={[Function]}
-                >
-                  <th
-                    onClick={[Function]}
-                  >
                     instance id
                   </th>
                 </TableHeader>
                 <TableHeader
-                  key="5"
+                  key="4"
                   onClick={[Function]}
                 >
                   <th
@@ -3397,6 +3595,7 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       </Table>
     </MainTable>
     <MainTable
+      className="model-details__relations"
       headers={
         Array [
           Object {
@@ -3420,10 +3619,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
       sortable={true}
     >
       <Table
+        className="model-details__relations"
         sortable={true}
       >
         <table
-          className="p-table--sortable"
+          className="model-details__relations p-table--sortable"
           role="grid"
         >
           <thead>

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -29,6 +29,29 @@
     text-align: center;
   }
 
+  tr {
+    display: grid;
+  }
+
+  td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: wrap;
+  }
+
+  .model-details__apps tr {
+    grid-template-columns: 15% 15% 9% 11% 17.5% 5% 10% 20%;
+  }
+
+  .model-details__units tr {
+    grid-template-columns: 15% 15% 9% 11% 17.5% 5% 30%;
+  }
+
+  .model-details__machines tr,
+  .model-details__relations tr {
+    grid-template-columns: 30% 9% 11% 22.5% 27.5%;
+  }
+
   .p-table--sortable {
     margin-bottom: 2rem;
 
@@ -58,6 +81,7 @@
     display: grid;
     gap: 0.25rem;
     grid-template-columns: repeat(3, 1fr);
+    padding-right: 0.75rem;
     text-align: left;
   }
 

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -1,3 +1,4 @@
+@import "../../scss/settings";
 @import "vanilla-framework/scss/vanilla";
 
 .model-details {

--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -41,7 +41,9 @@ export default function Models() {
         </div>
       </Header>
       <div className="l-content">
-        <TableList />
+        <div className="models">
+          <TableList />
+        </div>
       </div>
     </Layout>
   );

--- a/src/pages/Models/_models.scss
+++ b/src/pages/Models/_models.scss
@@ -9,4 +9,9 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr) 3rem;
   }
+
+  tr {
+    display: grid;
+    grid-template-columns: 1fr 0.6fr 0.75fr 1.15fr 1fr 0.5fr 0.65fr;
+  }
 }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,3 +1,6 @@
+// Vanilla overrides
+$increase-font-size-on-larger-screens: false;
+
 // Custom colors
 $color-sidebar: #003b4e;
 $color-navigation-dark: #002835;

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,6 +1,9 @@
 // Vanilla overrides
 $increase-font-size-on-larger-screens: false;
 
+// Custom breakpoints
+$breakpoint-m-large: 1580px;
+
 // Custom colors
 $color-sidebar: #003b4e;
 $color-navigation-dark: #002835;

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -1,0 +1,4 @@
+// Capitalise text
+.u-capitalise {
+  text-transform: capitalize;
+}

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -2,6 +2,7 @@
   display: inline-block;
   padding-left: 1.5rem;
   position: relative;
+  text-transform: capitalize;
 
   &::before {
     content: "\00B7";

--- a/src/scss/custom/_tables.scss
+++ b/src/scss/custom/_tables.scss
@@ -1,0 +1,7 @@
+// Site-wide Vanilla table overrides
+
+table tr th {
+  font-size: 0.75rem;
+  margin-bottom: 0;
+  padding-bottom: 0.5rem;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,6 +4,9 @@
 // Import settings
 @import "settings";
 
+// Import utils
+@import "utils";
+
 // Import functions
 @import "functions/z-index";
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -9,6 +9,7 @@
 
 // Import custom patterns
 @import "custom/status_icons";
+@import "custom/tables";
 
 // Settings
 $grid-max-width: 100%;


### PR DESCRIPTION
## Done

- Align table columns
- Switch machine and unit icons in config column
- Capitalise td strings to match designs
- Turn off Vanilla text increases at larger breakpoints
- Tweak breakpoint for topology panel to 1580px

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View models and model details tables and verify that columns align as per the design

If you add this snippet to `index.scss`, you can see the column alignment visually.

```css
td {border-right: 1px solid orangered}
```

Fixes #119, 
Fixes #140, 
Fixes #142, 
Fixes #180, 
Fixes #146,
Fixes #179 

