### PR TITLE
Truncate machine error messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 defaults: &defaults
   docker:
-    - image: canonicalwebteam/dev
+    - image: canonicalwebteam/dev:v1.6.5
   environment:
   working_directory: ~/project
 

--- a/run
+++ b/run
@@ -43,7 +43,7 @@ Commands
 ##
 
 # Define docker images versions
-dev_image="canonicalwebteam/dev:v1.6.4"
+dev_image="canonicalwebteam/dev:v1.6.5"
 if [ -n "${DOCKER_REGISTRY:-}" ]; then
     dev_image="${DOCKER_REGISTRY}/${dev_image}"
 fi

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -199,10 +199,12 @@ const generateMachineRows = modelStatusData => {
         { content: splitParts(machine.hardware)["availability-zone"] },
         { content: machine.instanceId },
         {
-          content: generateSpanClass(
-            "u-capitalise",
-            machine.instanceStatus.info.toLowerCase()
-          )
+          content: (
+            <span title={machine.instanceStatus.info}>
+              {machine.instanceStatus.info}
+            </span>
+          ),
+          className: "model-details__truncate-cell"
         }
       ]
     };

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -46,6 +46,20 @@ describe("ModelDetail Container", () => {
     expect(wrapper.find(".model-details")).toMatchSnapshot();
   });
 
+  it("renders the machine details section", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/spaceman@external/mymodel"]}>
+          <Route path="/models/*">
+            <ModelDetails />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").at(2)).toMatchSnapshot();
+  });
+
   it("renders the terminal", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -3690,6 +3690,1056 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
 </div>
 `;
 
+exports[`ModelDetail Container renders the machine details section 1`] = `
+<MainTable
+  headers={
+    Array [
+      Object {
+        "content": "machine",
+      },
+      Object {
+        "content": "ip",
+      },
+      Object {
+        "content": "state",
+      },
+      Object {
+        "content": "az",
+      },
+      Object {
+        "content": "instance id",
+      },
+      Object {
+        "content": "message",
+      },
+    ]
+  }
+  rows={
+    Array [
+      Object {
+        "columns": Array [
+          Object {
+            "content": "0",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "1",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "2",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "3",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "4",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "5",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "6",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "7",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "8",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+      Object {
+        "columns": Array [
+          Object {
+            "content": "9",
+          },
+          Object {
+            "content": "",
+          },
+          Object {
+            "content": "provisioning error",
+          },
+          Object {
+            "content": undefined,
+          },
+          Object {
+            "content": "pending",
+          },
+          Object {
+            "className": "model-details__truncate-cell",
+            "content": <span
+              title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+            >
+              googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+            </span>,
+          },
+        ],
+      },
+    ]
+  }
+  sortable={true}
+>
+  <Table
+    sortable={true}
+  >
+    <table
+      className="p-table--sortable"
+      role="grid"
+    >
+      <thead>
+        <TableRow>
+          <tr>
+            <TableHeader
+              key="0"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                machine
+              </th>
+            </TableHeader>
+            <TableHeader
+              key="1"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                ip
+              </th>
+            </TableHeader>
+            <TableHeader
+              key="2"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                state
+              </th>
+            </TableHeader>
+            <TableHeader
+              key="3"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                az
+              </th>
+            </TableHeader>
+            <TableHeader
+              key="4"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                instance id
+              </th>
+            </TableHeader>
+            <TableHeader
+              key="5"
+              onClick={[Function]}
+            >
+              <th
+                onClick={[Function]}
+              >
+                message
+              </th>
+            </TableHeader>
+          </tr>
+        </TableRow>
+      </thead>
+      <tbody>
+        <TableRow
+          key="0"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                0
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="1"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                1
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="2"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                2
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="3"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                3
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="4"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                4
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="5"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                5
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="6"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                6
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="7"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                7
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="8"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                8
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+        <TableRow
+          key="9"
+        >
+          <tr>
+            <TableCell
+              key="0"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                9
+              </td>
+            </TableCell>
+            <TableCell
+              key="1"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="2"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                provisioning error
+              </td>
+            </TableCell>
+            <TableCell
+              key="3"
+            >
+              <td
+                className=""
+                role="gridcell"
+              />
+            </TableCell>
+            <TableCell
+              key="4"
+            >
+              <td
+                className=""
+                role="gridcell"
+              >
+                pending
+              </td>
+            </TableCell>
+            <TableCell
+              className="model-details__truncate-cell"
+              key="5"
+            >
+              <td
+                className="model-details__truncate-cell"
+                role="gridcell"
+              >
+                <span
+                  title="googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState"
+                >
+                  googleapi: Error 403: Project clean-algebra-206308 cannot accept requests to insert while in an inactive billing state.  Billing state may take several minutes to update., inactiveBillingState
+                </span>
+              </td>
+            </TableCell>
+          </tr>
+        </TableRow>
+      </tbody>
+    </table>
+  </Table>
+</MainTable>
+`;
+
 exports[`ModelDetail Container renders the terminal 1`] = `
 <Terminal
   address="wss://shell.jujugui.org:443/ws/"

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -3692,13 +3692,11 @@ exports[`ModelDetail Container renders the details pane for models shared-with-m
 
 exports[`ModelDetail Container renders the machine details section 1`] = `
 <MainTable
+  className="model-details__machines"
   headers={
     Array [
       Object {
         "content": "machine",
-      },
-      Object {
-        "content": "ip",
       },
       Object {
         "content": "state",
@@ -3719,13 +3717,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "0",
+            "content": <React.Fragment>
+              <div>
+                0
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3746,13 +3755,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "1",
+            "content": <React.Fragment>
+              <div>
+                1
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3773,13 +3793,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "2",
+            "content": <React.Fragment>
+              <div>
+                2
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3800,13 +3831,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "3",
+            "content": <React.Fragment>
+              <div>
+                3
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3827,13 +3869,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "4",
+            "content": <React.Fragment>
+              <div>
+                4
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3854,13 +3907,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "5",
+            "content": <React.Fragment>
+              <div>
+                5
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3881,13 +3945,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "6",
+            "content": <React.Fragment>
+              <div>
+                6
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3908,13 +3983,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "7",
+            "content": <React.Fragment>
+              <div>
+                7
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3935,13 +4021,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "8",
+            "content": <React.Fragment>
+              <div>
+                8
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3962,13 +4059,24 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
       Object {
         "columns": Array [
           Object {
-            "content": "9",
+            "content": <React.Fragment>
+              <div>
+                9
+              </div>
+              <a
+                href="#_"
+              >
+                
+              </a>
+            </React.Fragment>,
           },
           Object {
-            "content": "",
-          },
-          Object {
-            "content": "provisioning error",
+            "content": <span
+              className="status-icon is-provisioning error"
+            >
+              provisioning error
+              
+            </span>,
           },
           Object {
             "content": undefined,
@@ -3991,10 +4099,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
   sortable={true}
 >
   <Table
+    className="model-details__machines"
     sortable={true}
   >
     <table
-      className="p-table--sortable"
+      className="model-details__machines p-table--sortable"
       role="grid"
     >
       <thead>
@@ -4017,7 +4126,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <th
                 onClick={[Function]}
               >
-                ip
+                state
               </th>
             </TableHeader>
             <TableHeader
@@ -4027,7 +4136,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <th
                 onClick={[Function]}
               >
-                state
+                az
               </th>
             </TableHeader>
             <TableHeader
@@ -4037,21 +4146,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <th
                 onClick={[Function]}
               >
-                az
-              </th>
-            </TableHeader>
-            <TableHeader
-              key="4"
-              onClick={[Function]}
-            >
-              <th
-                onClick={[Function]}
-              >
                 instance id
               </th>
             </TableHeader>
             <TableHeader
-              key="5"
+              key="4"
               onClick={[Function]}
             >
               <th
@@ -4075,7 +4174,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                0
+                <div>
+                  0
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4084,7 +4188,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4092,20 +4202,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4116,7 +4216,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4142,7 +4242,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                1
+                <div>
+                  1
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4151,7 +4256,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4159,20 +4270,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4183,7 +4284,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4209,7 +4310,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                2
+                <div>
+                  2
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4218,7 +4324,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4226,20 +4338,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4250,7 +4352,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4276,7 +4378,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                3
+                <div>
+                  3
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4285,7 +4392,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4293,20 +4406,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4317,7 +4420,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4343,7 +4446,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                4
+                <div>
+                  4
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4352,7 +4460,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4360,20 +4474,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4384,7 +4488,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4410,7 +4514,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                5
+                <div>
+                  5
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4419,7 +4528,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4427,20 +4542,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4451,7 +4556,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4477,7 +4582,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                6
+                <div>
+                  6
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4486,7 +4596,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4494,20 +4610,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4518,7 +4624,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4544,7 +4650,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                7
+                <div>
+                  7
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4553,7 +4664,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4561,20 +4678,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4585,7 +4692,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4611,7 +4718,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                8
+                <div>
+                  8
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4620,7 +4732,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4628,20 +4746,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4652,7 +4760,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"
@@ -4678,7 +4786,12 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
                 className=""
                 role="gridcell"
               >
-                9
+                <div>
+                  9
+                </div>
+                <a
+                  href="#_"
+                />
               </td>
             </TableCell>
             <TableCell
@@ -4687,7 +4800,13 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              />
+              >
+                <span
+                  className="status-icon is-provisioning error"
+                >
+                  provisioning error
+                </span>
+              </td>
             </TableCell>
             <TableCell
               key="2"
@@ -4695,20 +4814,10 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               <td
                 className=""
                 role="gridcell"
-              >
-                provisioning error
-              </td>
-            </TableCell>
-            <TableCell
-              key="3"
-            >
-              <td
-                className=""
-                role="gridcell"
               />
             </TableCell>
             <TableCell
-              key="4"
+              key="3"
             >
               <td
                 className=""
@@ -4719,7 +4828,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </TableCell>
             <TableCell
               className="model-details__truncate-cell"
-              key="5"
+              key="4"
             >
               <td
                 className="model-details__truncate-cell"

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -53,6 +53,10 @@
     grid-template-columns: 30% 9% 11% 22.5% 27.5%;
   }
 
+  &__truncate-cell {
+    white-space: nowrap;
+  }
+
   .p-table--sortable {
     margin-bottom: 2rem;
 


### PR DESCRIPTION
## Done

Truncate long machine error messages.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a model with long machine error messages. Contact me if you need one shared with you.

## Details

Fixes #173 