### PR TITLE
Correct status label capitalisation

### DIFF
--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -169,7 +169,12 @@ const generateRelationRows = modelStatusData => {
         { content: requirer || "-" },
         { content: relation.interface },
         { content: relation.endpoints[0].role },
-        { content: generateSpanClass("u-capitalise", relation.status.status) }
+        {
+          content: generateSpanClass(
+            "u-capitalise--first-letter",
+            relation.status.status
+          )
+        }
       ]
     };
   });

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -90,7 +90,10 @@ const generateApplicationRows = modelStatusData => {
             key
           )
         },
-        { content: app.status ? generateStatusIcon(app.status.status) : "-" },
+        {
+          content: app.status ? generateStatusIcon(app.status.status) : "-",
+          className: "u-capitalise"
+        },
         { content: "-", className: "u-align--right" },
         { content: "-", className: "u-align--right" },
         { content: "CharmHub" },
@@ -124,7 +127,10 @@ const generateUnitRows = modelStatusData => {
               unitId
             )
           },
-          { content: generateStatusIcon(unit.workloadStatus.status) },
+          {
+            content: generateStatusIcon(unit.workloadStatus.status),
+            className: "u-capitalise"
+          },
           { content: unit.agentStatus.status },
           { content: unit.machine, className: "u-align--right" },
           { content: unit.publicAddress },
@@ -195,7 +201,10 @@ const generateMachineRows = modelStatusData => {
             </>
           )
         },
-        { content: generateStatusIcon(machine.instanceStatus.status) },
+        {
+          content: generateStatusIcon(machine.instanceStatus.status),
+          className: "u-capitalise"
+        },
         { content: splitParts(machine.hardware)["availability-zone"] },
         { content: machine.instanceId },
         {

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -137,6 +137,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -186,6 +187,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -235,6 +237,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -284,6 +287,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -333,6 +337,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -382,6 +387,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -431,6 +437,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -480,6 +487,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -529,6 +537,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                 </React.Fragment>,
               },
               Object {
+                "className": "u-capitalise",
                 "content": <span
                   className="status-icon is-waiting"
                 >
@@ -690,10 +699,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -794,10 +804,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -898,10 +909,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1002,10 +1014,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1106,10 +1119,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1210,10 +1224,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1314,10 +1329,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1418,10 +1434,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span
@@ -1522,10 +1539,11 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                   </td>
                 </TableCell>
                 <TableCell
+                  className="u-capitalise"
                   key="1"
                 >
                   <td
-                    className=""
+                    className="u-capitalise"
                     role="gridcell"
                   >
                     <span

--- a/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
+++ b/src/pages/Models/Details/__snapshots__/ModelDetails.test.js.snap
@@ -1877,7 +1877,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -1900,7 +1900,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -1923,7 +1923,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -1946,7 +1946,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -1969,7 +1969,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -1992,7 +1992,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2015,7 +2015,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2038,7 +2038,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2061,7 +2061,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2084,7 +2084,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2107,7 +2107,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2130,7 +2130,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2153,7 +2153,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2176,7 +2176,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2199,7 +2199,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
               },
               Object {
                 "content": <span
-                  className="u-capitalise"
+                  className="u-capitalise--first-letter"
                 >
                   joining
                 </span>,
@@ -2327,7 +2327,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2387,7 +2387,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2447,7 +2447,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2507,7 +2507,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2567,7 +2567,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2627,7 +2627,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2687,7 +2687,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2747,7 +2747,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2807,7 +2807,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2867,7 +2867,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2927,7 +2927,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -2987,7 +2987,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -3047,7 +3047,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -3107,7 +3107,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -3167,7 +3167,7 @@ exports[`ModelDetail Container renders the details pane 1`] = `
                     role="gridcell"
                   >
                     <span
-                      className="u-capitalise"
+                      className="u-capitalise--first-letter"
                     >
                       joining
                     </span>
@@ -3747,6 +3747,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3785,6 +3786,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3823,6 +3825,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3861,6 +3864,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3899,6 +3903,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3937,6 +3942,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -3975,6 +3981,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -4013,6 +4020,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -4051,6 +4059,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -4089,6 +4098,7 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
             </React.Fragment>,
           },
           Object {
+            "className": "u-capitalise",
             "content": <span
               className="status-icon is-provisioning error"
             >
@@ -4201,10 +4211,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4269,10 +4280,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4337,10 +4349,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4405,10 +4418,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4473,10 +4487,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4541,10 +4556,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4609,10 +4625,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4677,10 +4694,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4745,10 +4763,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span
@@ -4813,10 +4832,11 @@ exports[`ModelDetail Container renders the machine details section 1`] = `
               </td>
             </TableCell>
             <TableCell
+              className="u-capitalise"
               key="1"
             >
               <td
-                className=""
+                className="u-capitalise"
                 role="gridcell"
               >
                 <span

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -1,4 +1,8 @@
 // Capitalise text
 .u-capitalise {
   text-transform: capitalize;
+
+  &--first-letter::first-letter {
+    text-transform: uppercase;
+  }
 }

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -2,7 +2,6 @@
   display: inline-block;
   padding-left: 1.5rem;
   position: relative;
-  text-transform: capitalize;
 
   &::before {
     content: "\00B7";


### PR DESCRIPTION
Fixes #187

## Done

Correct status label capitalisation

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Status in table headers should be uppercase, all others should be capitalised. 


