### PR TITLE
Remove double border on table rows

### DIFF
--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -74,7 +74,9 @@
     tbody tr {
       @include vf-animation(background, brisk, ease-in-out);
 
-      border-bottom: 1px solid $color-mid-x-light;
+      &:last-child {
+        border-bottom: 1px solid $color-mid-light;
+      }
 
       &:hover {
         background-color: #cef3ff;


### PR DESCRIPTION
Fixes #185

## Done

Remove double border on table rows

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify that double borders on table rows ahve been removed.


