### PR TITLE
Add tooltips to config icons in Models list

### DIFF
--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -120,7 +120,10 @@ function generateModelTableData(groupedModels, activeUser) {
           // so display the controller UUID instead.
           {
             content: (
-              <a href="#_">{getStatusValue(model.info, "controllerUuid")}</a>
+              <a href="#_" title={getStatusValue(model.info, "controllerUuid")}>
+                {getStatusValue(model.info, "controllerUuid").split("-")[0] +
+                  "..."}
+              </a>
             )
           },
           // We're not currently able to get a last-accessed or updated from JAAS.
@@ -188,7 +191,7 @@ function getStatusValue(status, key) {
           .split("_")[1];
         break;
       case "controllerUuid":
-        returnValue = status.controllerUuid.split("-")[0] + "...";
+        returnValue = status.controllerUuid;
         break;
       case "status.since":
         returnValue = status.status.since.split("T")[0];

--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -171,9 +171,36 @@ function getStatusValue(status, key) {
         returnValue = (
           <Fragment>
             <div className="model-details__config">
-              {applicationCount}
-              {unitCount}
-              {machineCount}
+              <div className="p-tooltip--top-center" aria-describedby="tp-cntr">
+                {applicationCount}
+                <span
+                  className="p-tooltip__message"
+                  role="tooltip"
+                  id="tp-cntr"
+                >
+                  Applications
+                </span>
+              </div>
+              <div className="p-tooltip--top-center" aria-describedby="tp-cntr">
+                {unitCount}
+                <span
+                  className="p-tooltip__message"
+                  role="tooltip"
+                  id="tp-cntr"
+                >
+                  Units
+                </span>
+              </div>
+              <div className="p-tooltip--top-center" aria-describedby="tp-cntr">
+                {machineCount}
+                <span
+                  className="p-tooltip__message"
+                  role="tooltip"
+                  id="tp-cntr"
+                >
+                  Machines
+                </span>
+              </div>
             </div>
           </Fragment>
         );

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -169,21 +169,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    11
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      11
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    10
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      10
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    6
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      6
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -206,6 +242,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -244,21 +281,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -281,6 +354,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -422,21 +496,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      11
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        11
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      10
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        10
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      6
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        6
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -479,6 +589,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -554,21 +665,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -611,6 +758,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -698,21 +846,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    4
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      4
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -735,6 +919,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -768,21 +953,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -805,6 +1026,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -838,21 +1060,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -875,6 +1133,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -908,21 +1167,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    3
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      3
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -945,6 +1240,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1081,21 +1377,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      4
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        4
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -1138,6 +1470,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -1208,21 +1541,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -1265,6 +1634,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -1335,21 +1705,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -1392,6 +1798,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -1462,21 +1869,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      3
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        3
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -1519,6 +1962,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -1606,21 +2050,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    6
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      6
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    10
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      10
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    10
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      10
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1643,6 +2123,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1676,21 +2157,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    6
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      6
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    10
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      10
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    10
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      10
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1713,6 +2230,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1746,21 +2264,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    7
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      7
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    11
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      11
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    11
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      11
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1783,6 +2337,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1816,21 +2371,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    9
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      9
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1853,6 +2444,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1886,21 +2478,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    1
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      1
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1923,6 +2551,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -1956,21 +2585,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -1993,6 +2658,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -2026,21 +2692,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -2063,6 +2765,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -2096,21 +2799,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    0
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      0
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -2133,6 +2872,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -2166,21 +2906,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -2203,6 +2979,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -2236,21 +3013,57 @@ exports[`TableList displays all data from redux store 1`] = `
                 <div
                   className="model-details__config"
                 >
-                  <span
-                    className="model-details__app-icon"
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__unit-icon"
+                    <span
+                      className="model-details__app-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Applications
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
-                  <span
-                    className="model-details__machine-icon"
+                    <span
+                      className="model-details__unit-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Units
+                    </span>
+                  </div>
+                  <div
+                    aria-describedby="tp-cntr"
+                    className="p-tooltip--top-center"
                   >
-                    2
-                  </span>
+                    <span
+                      className="model-details__machine-icon"
+                    >
+                      2
+                    </span>
+                    <span
+                      className="p-tooltip__message"
+                      id="tp-cntr"
+                      role="tooltip"
+                    >
+                      Machines
+                    </span>
+                  </div>
                 </div>
               </React.Fragment>,
             },
@@ -2273,6 +3086,7 @@ exports[`TableList displays all data from redux store 1`] = `
             Object {
               "content": <a
                 href="#_"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 a030379a...
               </a>,
@@ -2409,21 +3223,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      6
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        6
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      10
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        10
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      10
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        10
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -2466,6 +3316,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -2536,21 +3387,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      6
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        6
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      10
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        10
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      10
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        10
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -2593,6 +3480,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -2663,21 +3551,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      7
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        7
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      11
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        11
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      11
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        11
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -2720,6 +3644,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -2790,21 +3715,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      9
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        9
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -2847,6 +3808,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -2917,21 +3879,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      1
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        1
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -2974,6 +3972,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -3044,21 +4043,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -3101,6 +4136,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -3171,21 +4207,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -3228,6 +4300,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -3298,21 +4371,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      0
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        0
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -3355,6 +4464,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -3425,21 +4535,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -3482,6 +4628,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>
@@ -3552,21 +4699,57 @@ exports[`TableList displays all data from redux store 1`] = `
                   <div
                     className="model-details__config"
                   >
-                    <span
-                      className="model-details__app-icon"
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__unit-icon"
+                      <span
+                        className="model-details__app-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Applications
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
-                    <span
-                      className="model-details__machine-icon"
+                      <span
+                        className="model-details__unit-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Units
+                      </span>
+                    </div>
+                    <div
+                      aria-describedby="tp-cntr"
+                      className="p-tooltip--top-center"
                     >
-                      2
-                    </span>
+                      <span
+                        className="model-details__machine-icon"
+                      >
+                        2
+                      </span>
+                      <span
+                        className="p-tooltip__message"
+                        id="tp-cntr"
+                        role="tooltip"
+                      >
+                        Machines
+                      </span>
+                    </div>
                   </div>
                 </td>
               </TableCell>
@@ -3609,6 +4792,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 >
                   <a
                     href="#_"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     a030379a...
                   </a>

--- a/src/pages/Models/_models.scss
+++ b/src/pages/Models/_models.scss
@@ -14,4 +14,10 @@
     display: grid;
     grid-template-columns: 1fr 0.6fr 0.75fr 1.15fr 1fr 0.5fr 0.65fr;
   }
+
+  // Tooltips override
+  .p-tooltip--top-center .p-tooltip__message {
+    left: calc(50% - 0.875rem);
+    margin-bottom: -0.5rem;
+  }
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -34,6 +34,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-table-of-contents;
 @include vf-p-table-mobile-card;
 @include vf-p-table-sortable;
+@include vf-p-tooltips;
 @include vf-u-align;
 @include vf-u-layout;
 


### PR DESCRIPTION
## Done

Add tooltips to config icons in Models list

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Roll over config icons on Models listing table

## Details

Fixes #145 
