### PR TITLE
Remove bottom-border on last table rows

### DIFF
--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -74,10 +74,6 @@
     tbody tr {
       @include vf-animation(background, brisk, ease-in-out);
 
-      &:last-child {
-        border-bottom: 1px solid $color-mid-light;
-      }
-
       &:hover {
         background-color: #cef3ff;
       }


### PR DESCRIPTION
## Done

Remove bottom-border on last table rows

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify no tables have a bottom border

## Details

See: https://github.com/canonical-web-and-design/vanilla-framework/issues/2628#issuecomment-551113219
