### PR TITLE
Use soft links on Models listing page

### DIFF
--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -94,7 +94,7 @@ function generateModelTableData(groupedModels, activeUser) {
           { content: generateModelNameCell(model, groupLabel, activeUser) },
           {
             content: (
-              <a href="#_">
+              <a href="#_" className="p-link--soft">
                 {model.info &&
                   model.info.ownerTag.split("@")[0].replace("user-", "")}
               </a>
@@ -103,7 +103,7 @@ function generateModelTableData(groupedModels, activeUser) {
           { content: getStatusValue(model, "summary") },
           {
             content: (
-              <a href="#_">
+              <a href="#_" className="p-link--soft">
                 {getStatusValue(model, "region")}/
                 {getStatusValue(model, "cloudTag")}
               </a>
@@ -111,7 +111,7 @@ function generateModelTableData(groupedModels, activeUser) {
           },
           {
             content: (
-              <a href="#_">
+              <a href="#_" className="p-link--soft">
                 {getStatusValue(model.info, "cloudCredentialTag")}
               </a>
             )
@@ -120,7 +120,11 @@ function generateModelTableData(groupedModels, activeUser) {
           // so display the controller UUID instead.
           {
             content: (
-              <a href="#_" title={getStatusValue(model.info, "controllerUuid")}>
+              <a
+                href="#_"
+                className="p-link--soft"
+                title={getStatusValue(model.info, "controllerUuid")}
+              >
                 {getStatusValue(model.info, "controllerUuid").split("-")[0] +
                   "..."}
               </a>

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -198,6 +198,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 spaceman
@@ -264,6 +265,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -273,6 +275,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 Algebra-json
@@ -280,6 +283,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -310,6 +314,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 that-guy
@@ -376,6 +381,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 eu-central-1
@@ -385,6 +391,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 personal
@@ -392,6 +399,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -536,6 +544,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     spaceman
@@ -614,6 +623,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -630,6 +640,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     Algebra-json
@@ -644,6 +655,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -707,6 +719,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     that-guy
@@ -785,6 +798,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     eu-central-1
@@ -801,6 +815,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     personal
@@ -815,6 +830,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -894,6 +910,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 spaceman
@@ -960,6 +977,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 europe-west1
@@ -969,6 +987,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 clean-algebra-206308
@@ -976,6 +995,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -1001,6 +1021,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 alto
@@ -1067,6 +1088,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -1076,6 +1098,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 google-rickbot
@@ -1083,6 +1106,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -1108,6 +1132,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 uncle-phil
@@ -1174,6 +1199,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -1183,6 +1209,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 gce
@@ -1190,6 +1217,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -1215,6 +1243,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 uncle-phil
@@ -1281,6 +1310,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -1290,6 +1320,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 gce
@@ -1297,6 +1328,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -1436,6 +1468,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     spaceman
@@ -1514,6 +1547,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     europe-west1
@@ -1530,6 +1564,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     clean-algebra-206308
@@ -1544,6 +1579,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -1602,6 +1638,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     alto
@@ -1680,6 +1717,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -1696,6 +1734,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     google-rickbot
@@ -1710,6 +1749,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -1768,6 +1808,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     uncle-phil
@@ -1846,6 +1887,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -1862,6 +1904,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     gce
@@ -1876,6 +1919,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -1934,6 +1978,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     uncle-phil
@@ -2012,6 +2057,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -2028,6 +2074,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     gce
@@ -2042,6 +2089,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -2121,6 +2169,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 spaceman
@@ -2187,6 +2236,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-central1
@@ -2196,6 +2246,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 clean-algebra-206308
@@ -2203,6 +2254,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2228,6 +2280,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 spaceman
@@ -2294,6 +2347,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -2303,6 +2357,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 clean-algebra-206308
@@ -2310,6 +2365,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2335,6 +2391,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 spaceman
@@ -2401,6 +2458,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-central1
@@ -2410,6 +2468,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 clean-algebra-206308
@@ -2417,6 +2476,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2442,6 +2502,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 activedev
@@ -2508,6 +2569,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-central1
@@ -2517,6 +2579,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 admin
@@ -2524,6 +2587,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2549,6 +2613,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 activedev
@@ -2615,6 +2680,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-central1
@@ -2624,6 +2690,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 jujuongce
@@ -2631,6 +2698,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2656,6 +2724,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 activedev
@@ -2722,6 +2791,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -2731,6 +2801,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 juju
@@ -2738,6 +2809,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2763,6 +2835,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 activedev
@@ -2829,6 +2902,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -2838,6 +2912,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 juju
@@ -2845,6 +2920,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2870,6 +2946,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 activedev
@@ -2936,6 +3013,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -2945,6 +3023,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 juju
@@ -2952,6 +3031,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -2977,6 +3057,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 uncle-phil
@@ -3043,6 +3124,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 us-east1
@@ -3052,6 +3134,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 gce
@@ -3059,6 +3142,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -3084,6 +3168,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 that-guy
@@ -3150,6 +3235,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 eu-central-1
@@ -3159,6 +3245,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
               >
                 personal
@@ -3166,6 +3253,7 @@ exports[`TableList displays all data from redux store 1`] = `
             },
             Object {
               "content": <a
+                className="p-link--soft"
                 href="#_"
                 title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
@@ -3305,6 +3393,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     spaceman
@@ -3383,6 +3472,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-central1
@@ -3399,6 +3489,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     clean-algebra-206308
@@ -3413,6 +3504,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -3471,6 +3563,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     spaceman
@@ -3549,6 +3642,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -3565,6 +3659,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     clean-algebra-206308
@@ -3579,6 +3674,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -3637,6 +3733,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     spaceman
@@ -3715,6 +3812,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-central1
@@ -3731,6 +3829,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     clean-algebra-206308
@@ -3745,6 +3844,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -3803,6 +3903,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     activedev
@@ -3881,6 +3982,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-central1
@@ -3897,6 +3999,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     admin
@@ -3911,6 +4014,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -3969,6 +4073,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     activedev
@@ -4047,6 +4152,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-central1
@@ -4063,6 +4169,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     jujuongce
@@ -4077,6 +4184,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -4135,6 +4243,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     activedev
@@ -4213,6 +4322,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -4229,6 +4339,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     juju
@@ -4243,6 +4354,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -4301,6 +4413,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     activedev
@@ -4379,6 +4492,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -4395,6 +4509,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     juju
@@ -4409,6 +4524,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -4467,6 +4583,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     activedev
@@ -4545,6 +4662,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -4561,6 +4679,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     juju
@@ -4575,6 +4694,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -4633,6 +4753,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     uncle-phil
@@ -4711,6 +4832,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     us-east1
@@ -4727,6 +4849,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     gce
@@ -4741,6 +4864,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
@@ -4799,6 +4923,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     that-guy
@@ -4877,6 +5002,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     eu-central-1
@@ -4893,6 +5019,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                   >
                     personal
@@ -4907,6 +5034,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   role="gridcell"
                 >
                   <a
+                    className="p-link--soft"
                     href="#_"
                     title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >


### PR DESCRIPTION
## Done

Use soft links on Models listing page

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Check that only model name is a blue link, the rest are black but blue on hover
## Details

Fixes #193