### PR TITLE
Add some padding around the ghost bundle image.

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -9,6 +9,7 @@
     background: $color-light;
     border: solid 1px $color-mid-x-light;
     margin-bottom: 1rem;
+    padding: 1rem;
   }
 
   &__grid {


### PR DESCRIPTION
## Done

Add some padding around the ghost bundle image.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View the model details page, there should be some padding around the bundle ghost image.

## Details

Requested from https://github.com/canonical-web-and-design/jaas-dashboard/pull/196#issuecomment-551445301

## Screenshots

<img width="292" alt="Screen Shot 2019-11-08 at 9 25 42 AM" src="https://user-images.githubusercontent.com/532033/68488144-08df4580-020a-11ea-9b59-e21ef12c9c47.png">

