### PR TITLE
Add title attribute to truncated error message on models details page

### DIFF
--- a/src/components/TableList/TableList.js
+++ b/src/components/TableList/TableList.js
@@ -50,8 +50,11 @@ const generateModelDetailsLink = (modelName, ownerTag, activeUser) => {
 */
 const generateWarningMessage = model => {
   const { messages } = getModelStatusGroupData(model);
+  const title = messages.join("; ");
   return (
-    <span className="table-list_error-message">{messages.join("; ")}</span>
+    <span className="table-list_error-message" title={title}>
+      {title}
+    </span>
   );
 };
 

--- a/src/components/TableList/__snapshots__/TableList.test.js.snap
+++ b/src/components/TableList/__snapshots__/TableList.test.js.snap
@@ -193,6 +193,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 </div>
                 <span
                   className="table-list_error-message"
+                  title="missing required namenode and/or resourcemanager relation; waiting for machine"
                 >
                   missing required namenode and/or resourcemanager relation; waiting for machine
                 </span>
@@ -312,6 +313,7 @@ exports[`TableList displays all data from redux store 1`] = `
                 </div>
                 <span
                   className="table-list_error-message"
+                  title="elasticsearch service not running"
                 >
                   elasticsearch service not running
                 </span>
@@ -539,6 +541,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   </div>
                   <span
                     className="table-list_error-message"
+                    title="missing required namenode and/or resourcemanager relation; waiting for machine"
                   >
                     missing required namenode and/or resourcemanager relation; waiting for machine
                   </span>
@@ -717,6 +720,7 @@ exports[`TableList displays all data from redux store 1`] = `
                   </div>
                   <span
                     className="table-list_error-message"
+                    title="elasticsearch service not running"
                   >
                     elasticsearch service not running
                   </span>


### PR DESCRIPTION
## Done

Add title attribute to truncated error message on models details page

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to models details and hover over truncated red error message and verify browser tooltip appears

## Details

Fixes #212 
