### PR TITLE
Update logout mechanism to allow re-log-in

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -41,7 +41,7 @@ export function storeVisitURL(visitURL) {
   };
 }
 
-export function clearUserData() {
+export function clearBakeryIdentity() {
   return {
     type: actionsList.logOut
   };
@@ -51,11 +51,11 @@ export function clearUserData() {
 /**
   Flush localStorage login keys
 */
-export function logOut() {
+export function logOut(bakery) {
   return async function thunk(dispatch) {
-    localStorage.removeItem("identity");
-    localStorage.removeItem("https://api.jujucharms.com/identity");
-    dispatch(clearUserData());
+    bakery.storage._store.removeItem("identity");
+    bakery.storage._store.removeItem("https://api.jujucharms.com/identity");
+    dispatch(clearBakeryIdentity());
   };
 }
 

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -49,7 +49,7 @@ export function clearBakeryIdentity() {
 
 // Thunks
 /**
-  Flush localStorage login keys
+  Flush bakery from redux store
 */
 export function logOut(bakery) {
   return async function thunk(dispatch) {

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -15,7 +15,7 @@ function rootReducer(state = {}, action) {
         draftState.visitURL = action.payload;
         break;
       case actionsList.logOut:
-        draftState.bakery = null;
+        delete draftState.bakery.storage._store.localStorage.identity;
         break;
       case actionsList.collapsibleSidebar:
         draftState.collapsibleSidebar = action.payload;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -16,6 +16,18 @@ const getModelData = state => {
   return null;
 };
 
+/**
+  Fetches the bakery from state.
+  @param {Object} state The application state.
+  @returns {Object|Null} The bakery instance or null if none found.
+*/
+export const getBakery = state => {
+  if (state.root && state.root.bakery) {
+    return state.root.bakery;
+  }
+  return null;
+};
+
 // ---- Utility selectors
 
 /**
@@ -186,7 +198,9 @@ export const getMacaroons = createSelector(
   @returns {Boolean} If the user is logged in.
 */
 export const isLoggedIn = state =>
-  state.root.controllerConnection && state.root.bakery;
+  state.root.controllerConnection &&
+  state.root.bakery &&
+  state.root.bakery.storage._store.localStorage.identity;
 
 /**
   Returns the users current controller logged in identity

--- a/src/components/LogIn/LogIn.test.js
+++ b/src/components/LogIn/LogIn.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { mount } from "enzyme";
+import dataDump from "testing/complete-redux-store-dump";
 
 import LogIn from "./LogIn";
 
@@ -25,10 +26,7 @@ describe("LogIn", () => {
 
   it("renders it's children if the user is logged in", () => {
     const store = mockStore({
-      root: {
-        controllerConnection: {},
-        bakery: {}
-      }
+      root: dataDump.root
     });
     const wrapper = mount(
       <Provider store={store}>

--- a/src/components/UserIcon/UserIcon.js
+++ b/src/components/UserIcon/UserIcon.js
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect } from "react";
 import classNames from "classnames";
 import { Link } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { logOut } from "app/actions";
+import { getBakery } from "app/selectors";
 
 import "./_user-icon.scss";
 
@@ -43,6 +44,8 @@ export default function User() {
     };
   }, []);
 
+  const bakery = useSelector(getBakery);
+
   return (
     <div
       className="user-icon"
@@ -64,7 +67,7 @@ export default function User() {
             <a href="#_">Help</a>
           </li>
           <li className="p-list__item">
-            <Link to="/" onClick={() => dispatch(logOut())}>
+            <Link to="/" onClick={() => dispatch(logOut(bakery))}>
               Log out
             </Link>
           </li>

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -29,8 +29,11 @@ class LocalMacaroonStore {
   setItem(service, macaroon) {
     return this.localStorage.setItem(service, macaroon);
   }
-  clear(service) {
+  removeItem(service) {
     return this.localStorage.removeItem(service);
+  }
+  clear() {
+    return this.localStorage.clear();
   }
 }
 


### PR DESCRIPTION
## Done

When logging out clear the identity item out of the bakery instead of removing the bakery. This allows the user to re-log in after logging out.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Log in, log out, navigate around, log in, log out, etc. Try and break it.

## Details

Fixes #121