### PR TITLE
WIP: Clear the model data on log out and stop polling

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -2,11 +2,12 @@ import { clearModelData, clearModellist } from "juju/actions";
 
 // Action labels
 export const actionsList = {
+  collapsibleSidebar: "TOGGLE_COLLAPSIBLE_SIDEBAR",
+  logOut: "LOG_OUT",
+  modelStatusPolling: "MODEL_STATUS_POLLING",
   storeBakery: "STORE_BAKERY",
   storeVisitURL: "STORE_VISIT_URL",
-  updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
-  logOut: "LOG_OUT",
-  collapsibleSidebar: "TOGGLE_COLLAPSIBLE_SIDEBAR"
+  updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION"
 };
 
 // Action creators
@@ -62,12 +63,24 @@ export function collapsibleSidebar(toggle) {
   };
 }
 
+/**
+  Toggles whether we should continue to poll the models or not.
+  @param {Boolean} enabled If it should continue to poll.
+*/
+export function toggleModelStatusPolling(enabled) {
+  return {
+    type: actionsList.modelStatusPolling,
+    payload: enabled
+  };
+}
+
 // Thunks
 /**
   Flush bakery from redux store
 */
 export function logOut(bakery) {
   return async function thunk(dispatch) {
+    dispatch(toggleModelStatusPolling(false));
     bakery.storage._store.removeItem("identity");
     bakery.storage._store.removeItem("https://api.jujucharms.com/identity");
     dispatch(clearBakeryIdentity());

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -43,9 +43,22 @@ export function storeVisitURL(visitURL) {
   };
 }
 
+/**
+  Returns action for logging out.
+*/
 export function clearBakeryIdentity() {
   return {
     type: actionsList.logOut
+  };
+}
+
+/**
+  Toggle collapsible sidebar
+*/
+export function collapsibleSidebar(toggle) {
+  return {
+    type: actionsList.collapsibleSidebar,
+    payload: toggle
   };
 }
 
@@ -61,15 +74,5 @@ export function logOut(bakery) {
     // Clear the model data from the Juju store.
     dispatch(clearModelData());
     dispatch(clearModellist());
-  };
-}
-
-/**
-  Toggle collapsible sidebar
-*/
-export function collapsibleSidebar(toggle) {
-  return {
-    type: actionsList.collapsibleSidebar,
-    payload: toggle
   };
 }

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -1,3 +1,5 @@
+import { clearModelData, clearModellist } from "juju/actions";
+
 // Action labels
 export const actionsList = {
   storeBakery: "STORE_BAKERY",
@@ -56,6 +58,9 @@ export function logOut(bakery) {
     bakery.storage._store.removeItem("identity");
     bakery.storage._store.removeItem("https://api.jujucharms.com/identity");
     dispatch(clearBakeryIdentity());
+    // Clear the model data from the Juju store.
+    dispatch(clearModelData());
+    dispatch(clearModellist());
   };
 }
 

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -17,6 +17,9 @@ function rootReducer(state = {}, action) {
       case actionsList.logOut:
         delete draftState.bakery.storage._store.localStorage.identity;
         break;
+      case actionsList.modelStatusPolling:
+        draftState.modelStatusPolling = action.payload;
+        break;
       case actionsList.collapsibleSidebar:
         draftState.collapsibleSidebar = action.payload;
         break;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -160,6 +160,13 @@ export const isSidebarCollapsible = state => {
   }
 };
 
+export const continueModelStatusPolling = state => {
+  if (state && state.root) {
+    return state.root.modelStatusPolling;
+  }
+  return null;
+};
+
 /**
   Gets the model UUID from the supplied name using a memoized selector
   Usage:

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -5,7 +5,9 @@ export const actionsList = {
   fetchModelList: "FETCH_MODEL_LIST",
   updateModelInfo: "UPDATE_MODEL_INFO",
   updateModelStatus: "UPDATE_MODEL_STATUS",
-  updateModelList: "UPDATE_MODEL_LIST"
+  updateModelList: "UPDATE_MODEL_LIST",
+  clearModelData: "CLEAR_MODEL_DATA",
+  clearModelList: "CLEAR_MODEL_LIST"
 };
 
 // Action creators
@@ -44,6 +46,24 @@ export function updateModelInfo(modelInfo) {
   return {
     type: actionsList.updateModelInfo,
     payload: modelInfo
+  };
+}
+
+/**
+  @returns {Object} An action for Redux.
+ */
+export function clearModelData() {
+  return {
+    type: actionsList.clearModelData
+  };
+}
+
+/**
+  @returns {Object} An action for Redux.
+ */
+export function clearModellist() {
+  return {
+    type: actionsList.clearModelList
   };
 }
 

--- a/src/juju/reducers.js
+++ b/src/juju/reducers.js
@@ -57,6 +57,13 @@ export default produce(
           draftState.modelData[modelInfo.uuid].info = modelInfo;
         }
         break;
+      case actionsList.clearModelData:
+        draftState.modelData = {};
+        break;
+      case actionsList.clearModelList:
+        draftState.models = {};
+        break;
+
       default:
         // No default value, fall through.
         break;


### PR DESCRIPTION
## Done

When logging out:
- Stop polling the model statuses and model lists.
- Clear the stored model data.


## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Perform the following steps with the redux store open
- After logging in check that it loads your models as expected.
- After 30s from completing it should restart the polling.
- If you log out the polling should stop and it should not restart or fetch the model list.
- Try logging out during active polling, and after all polling has stopped (during the 30s delay).

## Details

Fixes #218
