### PR TITLE
Collapse external nav if user hovers off and sidebar collapses

### DIFF
--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -124,3 +124,8 @@
     width: 1.5rem;
   }
 }
+
+// Collapse external nav if user hovers off and sidebar collapses
+.is-collapsed .p-primary-nav ul.p-list.is-external {
+  max-height: 0;
+}


### PR DESCRIPTION
## Done

Collapse external nav if the user hovers off and sidebar collapses

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Open model details
- Hover over sidebar
- Open external nav
- Hover off sidebar
- Verify external nav collapses

## Details

Fixes #231 
