### PR TITLE
Upgrade Vanilla to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "redux-mock-store": "^1.5.3",
     "redux-thunk": "2.3.0",
     "reselect": "^4.0.0",
-    "vanilla-framework": "2.4.1",
+    "vanilla-framework": "2.5.0",
     "xterm": "4.2.0",
     "xterm-addon-fit": "0.3.0"
   },

--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -5,7 +5,9 @@
   padding: 0.5rem;
   position: relative;
 
-  &__input {
+  // Increased specificity needed here due to:
+  // https://github.com/canonical-web-and-design/jaas-dashboard/issues/254
+  .p-filter-tags__input {
     font-size: 0.875rem;
     margin: 0;
     padding: 0.25rem 0.5rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11495,6 +11495,11 @@ vanilla-framework@2.4.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.4.1.tgz#36ef374e90b8457a07e55cf33be1bcfd07092c84"
   integrity sha512-St8LdmoMpWSFWvFRDBNjFcdfWo/nOMwrkRPJN+dR0vOHP/Jb1UqOSxw+wDxkiGrpeRb0VPFwCuz/2u0RWb0xuQ==
 
+vanilla-framework@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.5.0.tgz#b7f689d7583f4a215cde39b726091ffc2ec4f62a"
+  integrity sha512-8dY70fTDo2v/Lw96nMRyhi5e74KUk1krcEHEd1qt/hzMzAfy2NYddENS1bZahEg7hoAY1TZc8mQJr+bVu4qW7w==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
## Done

- Upgrade Vanilla to 2.5.0
- Fixes bug where external link icon in the external menu was cut off
- Removes bottom margin from the input element in the header

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify the above

## Details

Fixes #230 
