### PR TITLE
Patch the optimization key of Webpack in CRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ To run tests locally:
 ```
 ./run test
 ```
+
+### Updating CRA
+
+When updating Create React App it's important to take a look at the `optimization.minimizer` values in the webpack config and then update the config in `craco.config.js`. After copying over any updates be sure to re-introduce the `terserOptions.mangle.reserved` key and values in the newly updated config.

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,116 @@
+const TerserPlugin = require("terser-webpack-plugin");
+const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const safePostCssParser = require("postcss-safe-parser");
+const isWsl = require("is-wsl");
+
+module.exports = function({ env }) {
+  // The values below are copied wholesale from the webpack.config.js that
+  // CRA uses to generate it's builds.
+  // The following values have been modified to tweak the minification steps
+  // to support jujulib and the check-auth redux middleware for thunks.
+  // Both jujulib and the check-auth middleware require that the function names
+  // remain intact so we need to tell Terser to not mangle those names.
+  // - mangle.reserved
+  return {
+    webpack: {
+      configure: (webpackConfig, { env, paths }) => {
+        const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== "false";
+        const isEnvProduction = env === "production";
+        const isEnvProductionProfile =
+          isEnvProduction && process.argv.includes("--profile");
+        return Object.assign(webpackConfig, {
+          optimization: {
+            minimize: isEnvProduction,
+            minimizer: [
+              // This is only used in production mode
+              new TerserPlugin({
+                terserOptions: {
+                  parse: {
+                    // We want terser to parse ecma 8 code. However, we don't want it
+                    // to apply any minification steps that turns valid ecma 5 code
+                    // into invalid ecma 5 code. This is why the 'compress' and 'output'
+                    // sections only apply transformations that are ecma 5 safe
+                    // https://github.com/facebook/create-react-app/pull/4234
+                    ecma: 8
+                  },
+                  compress: {
+                    ecma: 5,
+                    warnings: false,
+                    // Disabled because of an issue with Uglify breaking seemingly valid code:
+                    // https://github.com/facebook/create-react-app/issues/2376
+                    // Pending further investigation:
+                    // https://github.com/mishoo/UglifyJS2/issues/2011
+                    comparisons: false,
+                    // Disabled because of an issue with Terser breaking valid code:
+                    // https://github.com/facebook/create-react-app/issues/5250
+                    // Pending further investigation:
+                    // https://github.com/terser-js/terser/issues/120
+                    inline: 2
+                  },
+                  mangle: {
+                    safari10: true,
+                    reserved: [
+                      // Juju facades
+                      "ClientV2",
+                      "ModelManagerV5",
+                      "PingerV1",
+                      // Thunks
+                      "logOut"
+                    ]
+                  },
+                  // Added for profiling in devtools
+                  keep_classnames: isEnvProductionProfile,
+                  keep_fnames: isEnvProductionProfile,
+                  output: {
+                    ecma: 5,
+                    comments: false,
+                    // Turned on because emoji and regex is not minified properly using default
+                    // https://github.com/facebook/create-react-app/issues/2488
+                    ascii_only: true
+                  }
+                },
+                // Use multi-process parallel running to improve the build speed
+                // Default number of concurrent runs: os.cpus().length - 1
+                // Disabled on WSL (Windows Subsystem for Linux) due to an issue with Terser
+                // https://github.com/webpack-contrib/terser-webpack-plugin/issues/21
+                parallel: !isWsl,
+                // Enable file caching
+                cache: true,
+                sourceMap: shouldUseSourceMap
+              }),
+              // This is only used in production mode
+              new OptimizeCSSAssetsPlugin({
+                cssProcessorOptions: {
+                  parser: safePostCssParser,
+                  map: shouldUseSourceMap
+                    ? {
+                        // `inline: false` forces the sourcemap to be output into a
+                        // separate file
+                        inline: false,
+                        // `annotation: true` appends the sourceMappingURL to the end of
+                        // the css file, helping the browser find the sourcemap
+                        annotation: true
+                      }
+                    : false
+                }
+              })
+            ],
+            // Automatically split vendor and commons
+            // https://twitter.com/wSokra/status/969633336732905474
+            // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+            splitChunks: {
+              chunks: "all",
+              name: false
+            },
+            // Keep the runtime chunk separated to enable long term caching
+            // https://twitter.com/wSokra/status/969679223278505985
+            // https://github.com/facebook/create-react-app/issues/5358
+            runtimeChunk: {
+              name: entrypoint => `runtime-${entrypoint.name}`
+            }
+          }
+        });
+      }
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "react-scripts build",
+    "build": "craco build",
     "clean": "./scripts/clean-files",
     "eslint-check": "eslint src/",
     "lint": "yarn run eslint-check && yarn run prettier-check && yarn run stylelint-check",
     "prettier-check": "prettier --check 'src/**/*'",
     "serve": "yarn run start",
-    "start": "react-scripts start",
+    "start": "craco start",
     "stylelint-check": "stylelint 'src/**/*.scss'",
     "stylelint-fix": "stylelint --fix 'src/**/*.scss'",
-    "test": "react-scripts test"
+    "test": "craco test"
   },
   "browserslist": {
     "production": [
@@ -51,6 +51,7 @@
     "@canonical/jujulib": "1.3.0",
     "@canonical/macaroon-bakery": "0.3.0",
     "@canonical/react-components": "0.2.1",
+    "@craco/craco": "^5.6.2",
     "async-limiter": "^2.0.0",
     "classnames": "^2.2.6",
     "enzyme": "3.10.0",

--- a/src/app/check-auth.js
+++ b/src/app/check-auth.js
@@ -15,6 +15,8 @@ const actionWhitelist = [
   "TOGGLE_COLLAPSIBLE_SIDEBAR"
 ];
 
+// When updating this list be sure to update the mangle.reserved list in
+// craco.config.js so that the name doesn't get mangled by CRA.
 const thunkWhitelist = ["logOut"];
 
 function error(name) {

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -1,5 +1,7 @@
 import Limiter from "async-limiter";
 import jujulib from "@canonical/jujulib";
+// When updating this list of juju facades be sure to update the
+// mangle.reserved list in craco.config.js.
 import client from "@canonical/jujulib/api/facades/client-v2";
 import modelManager from "@canonical/jujulib/api/facades/model-manager-v5";
 import pinger from "@canonical/jujulib/api/facades/pinger-v1";

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@craco/craco@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-5.6.2.tgz#d98d660962e810bb1c9bb3e5318b99df6c620472"
+  integrity sha512-64nPBTTf4EpIAbdVZbgCR77cCTgLI2xgLSesj886HsfatQi6WfcYder4u60CnBsjvQE4/lz8Wa4DvD1ebTXjGQ==
+  dependencies:
+    cross-spawn "^7.0.0"
+    lodash.mergewith "^4.6.2"
+    webpack-merge "^4.2.2"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -3119,6 +3128,15 @@ cross-spawn@^3.0.0:
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -6750,6 +6768,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -8022,6 +8045,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -10195,10 +10223,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.7.2:
   version "1.7.2"
@@ -11663,6 +11703,13 @@ webpack-manifest-plugin@2.1.1:
     object.entries "^1.1.0"
     tapable "^1.0.0"
 
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
+
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -11763,6 +11810,13 @@ which@1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
## Done

The mangling being done by Terser in the default CRA Webpack config was causing issues in a few files. To resolve this we use `craco` to patch the webpack config to include the `reserved` configuration value to skip mangling on a few property names. 

Disabling mangling here increases the finished bundle by only 62B.

## QA

### Development

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/

It should work as before

### Production

- Pull code
- Run `./run exec yarn run build`
- use your webserver of choice to serve the build files. I use `http-server`
  - `yarn global add http-server`
  - `cd build && http-server`

It should work as expected. Try logging out, refreshing, logging back in, etc.

## Details

Fixes #225 