### PR TITLE
Create API endpoint for fetching the controller list

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # API host to allow app to connect and retrieve models
-REACT_APP_CONTROLLER_URL=wss://jimm.jujucharms.com/api
+REACT_APP_BASE_CONTROLLER_URL=jimm.jujucharms.com
 # Sass path to allow Sass to reference NPM packages directly
 SASS_PATH=node_modules:src
 # Extend Eslint config

--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -1,4 +1,8 @@
-import { fetchAllModelStatuses, loginWithBakery } from "juju";
+import {
+  fetchAllModelStatuses,
+  fetchControllerList,
+  loginWithBakery
+} from "juju";
 import { fetchModelList } from "juju/actions";
 import {
   updateControllerConnection,
@@ -13,6 +17,7 @@ export default async function connectAndListModels(reduxStore, bakery) {
     reduxStore.dispatch(updateControllerConnection(conn));
     reduxStore.dispatch(updateJujuAPIInstance(juju));
     reduxStore.dispatch(updatePingerIntervalId(intervalId));
+    fetchControllerList(reduxStore);
     do {
       await reduxStore.dispatch(fetchModelList());
       await fetchAllModelStatuses(conn, reduxStore);

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -4,6 +4,7 @@ import { fetchAndStoreModelStatus } from "juju";
 export const actionsList = {
   clearModelData: "CLEAR_MODEL_DATA",
   fetchModelList: "FETCH_MODEL_LIST",
+  updateControllerList: "UPDATE_CONTROLLER_LIST",
   updateModelInfo: "UPDATE_MODEL_INFO",
   updateModelStatus: "UPDATE_MODEL_STATUS",
   updateModelList: "UPDATE_MODEL_LIST"
@@ -14,6 +15,13 @@ export const actionsList = {
 export function clearModelData() {
   return {
     type: actionsList.clearModelData
+  };
+}
+
+export function updateControllerList(controllers) {
+  return {
+    type: actionsList.updateControllerList,
+    payload: controllers
   };
 }
 

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -180,6 +180,11 @@ export async function fetchAllModelStatuses(conn, reduxStore) {
   });
 }
 
+/**
+  Performs an HTTP request to the controller to fetch the controller list.
+  Will fail with a console error message if the user doesn't have access.
+  @param {Object} reduxStore The applications reduxStore.
+*/
 export async function fetchControllerList(reduxStore) {
   const bakery = getBakery(reduxStore.getState());
   function errorHandler(err, data) {

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -7,11 +7,16 @@ import modelManager from "@canonical/jujulib/api/facades/model-manager-v5";
 import pinger from "@canonical/jujulib/api/facades/pinger-v1";
 
 import { getBakery, isLoggedIn } from "app/selectors";
-import { updateModelInfo, updateModelStatus } from "./actions";
+import {
+  updateControllerList,
+  updateModelInfo,
+  updateModelStatus
+} from "./actions";
 
 // Full URL path to the controller.
-const controllerURL = process.env.REACT_APP_CONTROLLER_URL;
-
+const controllerBaseURL = process.env.REACT_APP_BASE_CONTROLLER_URL;
+const wsControllerURL = `wss://${controllerBaseURL}/api`;
+const httpControllerURL = `https://${controllerBaseURL}/v2`;
 /**
   Return a common connection option config.
   @param {Boolean} usePinger If the connection will be long lived then use the
@@ -43,7 +48,7 @@ function generateConnectionOptions(usePinger = false, bakery, onClose) {
 */
 export async function loginWithBakery(bakery) {
   const juju = await jujulib.connect(
-    controllerURL,
+    wsControllerURL,
     generateConnectionOptions(true, bakery, e =>
       console.log("controller closed", e)
     )
@@ -85,13 +90,13 @@ async function connectAndLoginWithTimeout(modelURL, options, duration = 5000) {
   Connects to the model url by doing a replacement on the controller url and
   fetches it's full status then logs out of the model and closes the connection.
   @param {String} modelUUID The UUID of the model to connect to. Must be on the
-    same controller as provided by the controllerURL`.
+    same controller as provided by the wsControllerURL`.
   @param {Object} getState A function that'll return the app redux state.
   @returns {Object} The full model status.
 */
 async function fetchModelStatus(modelUUID, getState) {
   const bakery = getBakery(getState());
-  const modelURL = controllerURL.replace("/api", `/model/${modelUUID}/api`);
+  const modelURL = wsControllerURL.replace("/api", `/model/${modelUUID}/api`);
   let status = null;
   // Logged in state is checked multiple times as the user may have logged out
   // between requests.
@@ -132,7 +137,7 @@ export async function fetchAndStoreModelStatus(modelUUID, dispatch, getState) {
   controller connection.
   @param {Object} conn The active controller connection.
   @param {String} modelUUID The UUID of the model to connect to. Must be on the
-    same controller as provided by the controllerURL`.
+    same controller as provided by the wsControllerURL`.
   @returns {Object} The full modelInfo.
 */
 async function fetchModelInfo(conn, modelUUID) {
@@ -172,5 +177,26 @@ export async function fetchAllModelStatuses(conn, reduxStore) {
     queue.onDone(() => {
       resolve();
     });
+  });
+}
+
+export async function fetchControllerList(reduxStore) {
+  const bakery = getBakery(reduxStore.getState());
+  function errorHandler(err, data) {
+    // XXX Surface to UI.
+    console.error("unable to fetch controller list", err);
+    return;
+  }
+  bakery.get(`${httpControllerURL}/controller`, null, (err, resp) => {
+    if (err !== null) {
+      errorHandler(err, resp);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(resp.currentTarget.response);
+      reduxStore.dispatch(updateControllerList(parsed.controllers));
+    } catch (error) {
+      errorHandler(error, resp.currentTarget.response);
+    }
   });
 }

--- a/src/juju/reducers.js
+++ b/src/juju/reducers.js
@@ -66,6 +66,9 @@ export default function jujuReducer(state = defaultState, action) {
         draftState.modelData = {};
         draftState.models = {};
         break;
+      case actionsList.updateControllerList:
+        draftState.controllers = action.payload;
+        break;
       default:
         // No default value, fall through.
         break;


### PR DESCRIPTION
## Done

Create API endpoint for fetching the controller list.

## Note

This does not work in Firefox, you'll have to use Chrome/Safari to QA. It appears to be around the `OPTIONS` request not having the correct `CORS` headers for redirects. I'll still need to investigate this further.

In Firefox it'll just fail silently with a `CORS` warning message in the console.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- After logging in, watch the redux store. `juju/controllers` should contain the controller list (if you have permissions to do so).

## Details

Fixes #237
