### PR TITLE
Position unplaced applications on the topology

### DIFF
--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -43,7 +43,7 @@ const computePositionDelta = annotations => {
 /**
   Retrieve the X and Y annotation with the highest value.
   @param {Object} annotations The annotations object from the model status.
-  @returns {Number} The value of the annotation with the highest X and Y value.
+  @returns {Object} The value of the annotation with the highest X and Y value.
 */
 const computeMaxXY = annotations => {
   let maxY = 0;


### PR DESCRIPTION
## Done

Position unplaced applications in a grid below any placed applications on the topology.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Contact me to get access to my models that contain models with partial and all unplaced applications.
- Do they position the applications in a grid below any placed applications?

## Details

Fixes #242 

## Screenshots

<img width="352" alt="Screen Shot 2020-01-24 at 1 36 27 PM" src="https://user-images.githubusercontent.com/532033/73098862-df9c9000-3eaf-11ea-9b18-5dd391372948.png">
<img width="338" alt="Screen Shot 2020-01-24 at 1 36 14 PM" src="https://user-images.githubusercontent.com/532033/73098863-df9c9000-3eaf-11ea-869a-047159930c92.png">
