### PR TITLE
Render JAAS instead of the controller UUID

### DIFF
--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -7,7 +7,11 @@ import {
   extractOwnerName
 } from "app/utils";
 import { getGroupedModelDataByCloud } from "app/selectors";
-import { generateModelDetailsLink, getStatusValue } from "./shared";
+import {
+  generateControllerUUID,
+  generateModelDetailsLink,
+  getStatusValue
+} from "./shared";
 
 /**
   Returns the model info and statuses in the proper format for the table data.
@@ -96,15 +100,8 @@ export default function CloudGroup({ activeUser }) {
             // We're not currently able to get the controller name from the API
             // so, display the controller UUID instead.
             {
-              content: (
-                <a
-                  href="#_"
-                  className="p-link--soft"
-                  title={getStatusValue(model.info, "controllerUuid")}
-                >
-                  {getStatusValue(model.info, "controllerUuid").split("-")[0] +
-                    "..."}
-                </a>
+              content: generateControllerUUID(
+                getStatusValue(model.info, "controllerUuid")
               )
             },
             // We're not currently able to get a last-accessed or updated from JAAS.

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -3,7 +3,11 @@ import { useSelector } from "react-redux";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import { generateStatusElement, getModelStatusGroupData } from "app/utils";
 import { getGroupedModelDataByOwner } from "app/selectors";
-import { generateModelDetailsLink, getStatusValue } from "./shared";
+import {
+  generateControllerUUID,
+  generateModelDetailsLink,
+  getStatusValue
+} from "./shared";
 
 /**
   Returns the model info and statuses in the proper format for the table data.
@@ -89,15 +93,8 @@ export default function OwnerGroup({ activeUser }) {
             // We're not currently able to get the controller name from the API
             // so, display the controller UUID instead.
             {
-              content: (
-                <a
-                  href="#_"
-                  className="p-link--soft"
-                  title={getStatusValue(model.info, "controllerUuid")}
-                >
-                  {getStatusValue(model.info, "controllerUuid").split("-")[0] +
-                    "..."}
-                </a>
+              content: generateControllerUUID(
+                getStatusValue(model.info, "controllerUuid")
               )
             },
             // We're not currently able to get a last-accessed or updated from JAAS.

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -10,7 +10,11 @@ import {
 
 import { getGroupedModelDataByStatus } from "app/selectors";
 
-import { generateModelDetailsLink, getStatusValue } from "./shared";
+import {
+  generateControllerUUID,
+  generateModelDetailsLink,
+  getStatusValue
+} from "./shared";
 
 /**
   Generates the table headers for the supplied table label.
@@ -128,15 +132,8 @@ function generateModelTableDataByStatus(groupedModels, activeUser) {
           // We're not currently able to get the controller name from the API
           // so display the controller UUID instead.
           {
-            content: (
-              <a
-                href="#_"
-                className="p-link--soft"
-                title={getStatusValue(model.info, "controllerUuid")}
-              >
-                {getStatusValue(model.info, "controllerUuid").split("-")[0] +
-                  "..."}
-              </a>
+            content: generateControllerUUID(
+              getStatusValue(model.info, "controllerUuid")
             )
           },
           // We're not currently able to get a last-accessed or updated from JAAS.

--- a/src/components/ModelTableList/__snapshots__/CloudGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/CloudGroup.test.js.snap
@@ -149,13 +149,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -261,13 +260,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -373,13 +371,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -485,13 +482,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -597,13 +593,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -709,13 +704,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -821,13 +815,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -933,13 +926,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1045,13 +1037,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1157,13 +1148,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1269,13 +1259,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1381,13 +1370,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1493,13 +1481,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1605,13 +1592,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1717,13 +1703,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1986,13 +1971,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2165,13 +2149,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2344,13 +2327,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2523,13 +2505,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2702,13 +2683,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2881,13 +2861,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3060,13 +3039,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3239,13 +3217,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3418,13 +3395,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3597,13 +3573,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3776,13 +3751,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3955,13 +3929,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4134,13 +4107,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4313,13 +4285,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4492,13 +4463,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4663,13 +4633,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4775,13 +4744,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -5044,13 +5012,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -5223,13 +5190,12 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell

--- a/src/components/ModelTableList/__snapshots__/CloudGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/CloudGroup.test.js.snap
@@ -152,9 +152,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -264,9 +264,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -376,9 +376,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -488,9 +488,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -600,9 +600,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -712,9 +712,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -824,9 +824,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -936,9 +936,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1048,9 +1048,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1160,9 +1160,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1272,9 +1272,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1384,9 +1384,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1496,9 +1496,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1608,9 +1608,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1720,9 +1720,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1989,9 +1989,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2168,9 +2168,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2347,9 +2347,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2526,9 +2526,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2705,9 +2705,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2884,9 +2884,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3063,9 +3063,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3242,9 +3242,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3421,9 +3421,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3600,9 +3600,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3779,9 +3779,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3958,9 +3958,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4137,9 +4137,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4316,9 +4316,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4495,9 +4495,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4666,9 +4666,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4778,9 +4778,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -5047,9 +5047,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -5226,9 +5226,9 @@ exports[`CloudGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>

--- a/src/components/ModelTableList/__snapshots__/OwnerGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/OwnerGroup.test.js.snap
@@ -147,9 +147,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -258,9 +258,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -369,9 +369,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -480,9 +480,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -591,9 +591,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -843,9 +843,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1014,9 +1014,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1185,9 +1185,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1356,9 +1356,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1527,9 +1527,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1693,9 +1693,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1804,9 +1804,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1915,9 +1915,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2026,9 +2026,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2137,9 +2137,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2248,9 +2248,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2500,9 +2500,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2671,9 +2671,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2842,9 +2842,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3013,9 +3013,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3184,9 +3184,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3355,9 +3355,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3521,9 +3521,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3773,9 +3773,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3939,9 +3939,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4050,9 +4050,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4161,9 +4161,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4413,9 +4413,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4584,9 +4584,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4755,9 +4755,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4921,9 +4921,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -5032,9 +5032,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -5284,9 +5284,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -5455,9 +5455,9 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>

--- a/src/components/ModelTableList/__snapshots__/OwnerGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/OwnerGroup.test.js.snap
@@ -144,13 +144,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -255,13 +254,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -366,13 +364,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -477,13 +474,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -588,13 +584,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -840,13 +835,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1011,13 +1005,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1182,13 +1175,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1353,13 +1345,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1524,13 +1515,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1690,13 +1680,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1801,13 +1790,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1912,13 +1900,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2023,13 +2010,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2134,13 +2120,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2245,13 +2230,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2497,13 +2481,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2668,13 +2651,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2839,13 +2821,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3010,13 +2991,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3181,13 +3161,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3352,13 +3331,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3518,13 +3496,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3770,13 +3747,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3936,13 +3912,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4047,13 +4022,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4158,13 +4132,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4410,13 +4383,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4581,13 +4553,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4752,13 +4723,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4918,13 +4888,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -5029,13 +4998,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -5281,13 +5249,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -5452,13 +5419,12 @@ exports[`OwnerGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell

--- a/src/components/ModelTableList/__snapshots__/StatusGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/StatusGroup.test.js.snap
@@ -152,13 +152,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -272,13 +271,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -392,13 +390,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -512,13 +509,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -632,13 +628,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -752,13 +747,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -1012,13 +1006,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1191,13 +1184,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1370,13 +1362,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1549,13 +1540,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1728,13 +1718,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -1907,13 +1896,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2075,13 +2063,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2189,13 +2176,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2303,13 +2289,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2417,13 +2402,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -2671,13 +2655,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -2844,13 +2827,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3017,13 +2999,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3190,13 +3171,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -3358,13 +3338,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3472,13 +3451,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3586,13 +3564,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3700,13 +3677,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3814,13 +3790,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -3928,13 +3903,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4042,13 +4016,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               </a>,
             },
             Object {
-              "content": <a
+              "content": <span
                 className="p-link--soft"
-                href="#_"
-                title="JAAS"
+                title="a030379a-940f-4760-8fcf-3062b41a04e7"
               >
                 JAAS
-              </a>,
+              </span>,
             },
             Object {
               "className": "u-align--right",
@@ -4296,13 +4269,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4469,13 +4441,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4642,13 +4613,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4815,13 +4785,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -4988,13 +4957,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -5161,13 +5129,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell
@@ -5334,13 +5301,12 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   className=""
                   role="gridcell"
                 >
-                  <a
+                  <span
                     className="p-link--soft"
-                    href="#_"
-                    title="JAAS"
+                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
                   >
                     JAAS
-                  </a>
+                  </span>
                 </td>
               </TableCell>
               <TableCell

--- a/src/components/ModelTableList/__snapshots__/StatusGroup.test.js.snap
+++ b/src/components/ModelTableList/__snapshots__/StatusGroup.test.js.snap
@@ -155,9 +155,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -275,9 +275,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -395,9 +395,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -515,9 +515,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -635,9 +635,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -755,9 +755,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -1015,9 +1015,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1194,9 +1194,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1373,9 +1373,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1552,9 +1552,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1731,9 +1731,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -1910,9 +1910,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2078,9 +2078,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2192,9 +2192,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2306,9 +2306,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2420,9 +2420,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -2674,9 +2674,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -2847,9 +2847,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3020,9 +3020,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3193,9 +3193,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -3361,9 +3361,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3475,9 +3475,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3589,9 +3589,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3703,9 +3703,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3817,9 +3817,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -3931,9 +3931,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4045,9 +4045,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
               "content": <a
                 className="p-link--soft"
                 href="#_"
-                title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                title="JAAS"
               >
-                a030379a...
+                JAAS
               </a>,
             },
             Object {
@@ -4299,9 +4299,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4472,9 +4472,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4645,9 +4645,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4818,9 +4818,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -4991,9 +4991,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -5164,9 +5164,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>
@@ -5337,9 +5337,9 @@ exports[`StatusGroup renders without crashing and matches snapshot 1`] = `
                   <a
                     className="p-link--soft"
                     href="#_"
-                    title="a030379a-940f-4760-8fcf-3062b41a04e7"
+                    title="JAAS"
                   >
-                    a030379a...
+                    JAAS
                   </a>
                 </td>
               </TableCell>

--- a/src/components/ModelTableList/shared.js
+++ b/src/components/ModelTableList/shared.js
@@ -138,8 +138,8 @@ export function generateControllerUUID(uuid) {
     controllerUUID = "JAAS";
   }
   return (
-    <a href="#_" className="p-link--soft" title={controllerUUID}>
+    <span className="p-link--soft" title={uuid}>
       {controllerUUID}
-    </a>
+    </span>
   );
 }

--- a/src/components/ModelTableList/shared.js
+++ b/src/components/ModelTableList/shared.js
@@ -125,3 +125,21 @@ export function getStatusValue(status, key) {
   }
   return returnValue;
 }
+
+/**
+  Renders the controller UUID element. If the UUID is the JAAS controller then
+  it replaces the UUID with "JAAS".
+  @param {string} uuid The controller UUID.
+  @returns {Object} The element to render the controller UUID entry
+*/
+export function generateControllerUUID(uuid) {
+  let controllerUUID = uuid.split("-")[0] + "...";
+  if (uuid === "a030379a-940f-4760-8fcf-3062b41a04e7") {
+    controllerUUID = "JAAS";
+  }
+  return (
+    <a href="#_" className="p-link--soft" title={controllerUUID}>
+      {controllerUUID}
+    </a>
+  );
+}


### PR DESCRIPTION
## Done
For the JAAS controller, render "JAAS" instead of its UUID.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View your models on all three groupings. The controller column should say "JAAS"

## Details

Fixes #313