### PR TITLE
Stop munging of the Annotations facade.

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -51,6 +51,7 @@ module.exports = function({ env }) {
                     safari10: true,
                     reserved: [
                       // Juju facades
+                      "AnnotationsV2",
                       "ClientV2",
                       "ModelManagerV5",
                       "PingerV1",


### PR DESCRIPTION
## Done

The Annotations facade was being munged by the CRA config. This stops it so that the production builds can use the Annotations facade.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- The topology should be shown on the model details page

## Details

Fixes #321 
