### PR TITLE
Click to expand topology

### DIFF
--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -1,16 +1,29 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import Topology from "components/Topology/Topology";
+import Modal from "@canonical/react-components/dist/components/Modal";
 
 import { getModelUUID, getModelStatus } from "app/selectors";
 import { extractCloudName } from "app/utils";
 
 import "./_info-panel.scss";
 
+const expandedTopologyDimensions = () => {
+  const de = document.documentElement;
+  const vw = Math.max(de.clientWidth, window.innerWidth || 0);
+  const vh = Math.max(de.clientHeight, window.innerHeight || 0);
+  const delta = 300;
+  return {
+    width: vw - delta,
+    height: vh - delta
+  };
+};
+
 const InfoPanel = () => {
   const { 0: modelName } = useParams();
+  const [showExpandedTopology, setShowExpandedTopology] = useState(false);
 
   const getModelUUIDMemo = useMemo(() => getModelUUID(modelName), [modelName]);
   const modelUUID = useSelector(getModelUUIDMemo);
@@ -23,11 +36,25 @@ const InfoPanel = () => {
     ? extractCloudName(modelStatusData.model.cloudTag)
     : "";
 
+  const { width, height } = expandedTopologyDimensions();
+
   return (
     <div className="info-panel">
-      <div className="info-panel__pictogram">
-        <Topology width={300} height={300} modelData={modelStatusData} />
-      </div>
+      {showExpandedTopology ? (
+        <Modal close={() => setShowExpandedTopology(false)} title={false}>
+          <Topology width={width} height={height} modelData={modelStatusData} />
+        </Modal>
+      ) : (
+        <div className="info-panel__pictogram">
+          <Topology width={300} height={300} modelData={modelStatusData} />
+          <i
+            className="p-icon--expand"
+            onClick={() => setShowExpandedTopology(!showExpandedTopology)}
+          >
+            Expand topology
+          </i>
+        </div>
+      )}
       <div className="info-panel__grid">
         <div className="info-panel__grid-item">
           <h4 className="p-muted-heading">Controller</h4>

--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -41,7 +41,11 @@ const InfoPanel = () => {
   return (
     <div className="info-panel">
       {showExpandedTopology ? (
-        <Modal close={() => setShowExpandedTopology(false)} title={false}>
+        <Modal
+          close={() => setShowExpandedTopology(false)}
+          title={false}
+          data-test="topology-modal"
+        >
           <Topology width={width} height={height} modelData={modelStatusData} />
         </Modal>
       ) : (

--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -43,7 +43,7 @@ const InfoPanel = () => {
       {showExpandedTopology ? (
         <Modal
           close={() => setShowExpandedTopology(false)}
-          title={false}
+          title={modelName.split("/")[1]}
           data-test="topology-modal"
         >
           <Topology width={width} height={height} modelData={modelStatusData} />

--- a/src/components/InfoPanel/InfoPanel.test.js
+++ b/src/components/InfoPanel/InfoPanel.test.js
@@ -31,6 +31,22 @@ describe("Info Panel", () => {
     expect(wrapper.find("Topology").length).toBe(1);
   });
 
+  it("renders the expanded topology on click", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/group-test"]}>
+          <TestRoute path="/models/*">
+            <InfoPanel />
+          </TestRoute>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Modal").length).toBe(0);
+    wrapper.find("i.p-icon--expand").simulate("click");
+    expect(wrapper.find("Modal").length).toBe(1);
+  });
+
   it("displays correct model status info", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(

--- a/src/components/InfoPanel/InfoPanel.test.js
+++ b/src/components/InfoPanel/InfoPanel.test.js
@@ -43,7 +43,7 @@ describe("Info Panel", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='topology-modal']").length).toBe(0);
-    wrapper.find("i.p-icon--expand").simulate("click");
+    wrapper.find(".info-panel__pictogram .p-icon--expand").simulate("click");
     expect(wrapper.find("[data-test='topology-modal']").length).toBe(1);
   });
 

--- a/src/components/InfoPanel/InfoPanel.test.js
+++ b/src/components/InfoPanel/InfoPanel.test.js
@@ -42,9 +42,9 @@ describe("Info Panel", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Modal").length).toBe(0);
+    expect(wrapper.find("[data-test='topology-modal']").length).toBe(0);
     wrapper.find("i.p-icon--expand").simulate("click");
-    expect(wrapper.find("Modal").length).toBe(1);
+    expect(wrapper.find("[data-test='topology-modal']").length).toBe(1);
   });
 
   it("displays correct model status info", () => {

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -7,6 +7,7 @@
 
   .p-modal {
     z-index: 1;
+    position: fixed;
   }
 
   &__pictogram {

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -6,8 +6,8 @@
   padding: 1rem;
 
   .p-modal {
-    z-index: 1;
     position: fixed;
+    z-index: 1;
   }
 
   &__pictogram {
@@ -19,11 +19,12 @@
     margin-bottom: 1rem;
     position: relative;
     width: 300px;
+
     i {
-      position: absolute;
-      right: 10px;
       bottom: 10px;
       cursor: pointer;
+      position: absolute;
+      right: 10px;
     }
   }
 

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -5,6 +5,10 @@
   margin-right: 1rem;
   padding: 1rem;
 
+  .p-modal {
+    z-index: 1;
+  }
+
   &__pictogram {
     // Keep height and width in sync with the dimensions of
     // the Topology component.

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -12,7 +12,14 @@
     border: solid 1px $color-mid-x-light;
     height: 300px;
     margin-bottom: 1rem;
+    position: relative;
     width: 300px;
+    i {
+      position: absolute;
+      right: 10px;
+      bottom: 10px;
+      cursor: pointer;
+    }
   }
 
   &__grid {

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -7,7 +7,7 @@
 
   .p-modal {
     position: fixed;
-    z-index: 1;
+    z-index: z("beta");
   }
 
   &__pictogram {
@@ -20,7 +20,7 @@
     position: relative;
     width: 300px;
 
-    i {
+    .p-icon--expand {
       bottom: 10px;
       cursor: pointer;
       position: absolute;

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -1,5 +1,6 @@
 @import "../../scss/settings";
 @import "vanilla-framework/scss/vanilla";
+@import "../../scss/functions/z-index";
 
 .info-panel {
   margin-right: 1rem;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -31,6 +31,7 @@ $color-navigation-background: $color-brand;
 @include vf-b-typography;
 @include vf-p-navigation;
 @include vf-p-notification;
+@include vf-p-modal;
 @include vf-p-muted-heading;
 @include vf-u-off-screen;
 @include vf-p-strip;


### PR DESCRIPTION
## Done

When clicking the expand icon, render the topology in a Modal

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- [Add additional steps]

## Details

Fixes #243 

There is an error in the console now from no title being provided in the modal. This issue has been raised in the component repository so it will be resolved once that change has been made and the package updated. #328 

## Screenshots

<img width="1679" alt="Screen Shot 2020-01-30 at 1 32 56 PM" src="https://user-images.githubusercontent.com/532033/73483432-0aca2800-4365-11ea-9f17-5a5f8da78346.png">

