### PR TITLE
Fix back button navigation with model grouping

### DIFF
--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -22,23 +22,22 @@ export default function Models() {
   const queryStrings = queryString.parse(location.search);
   // If it doesn't exist, fall back to grouping by status
   const groupedByFilter = queryStrings.groupedby || "status";
-  // Set initial state using filter from URL
-  const [groupedBy, setGroupedBy] = useState(groupedByFilter);
-  // Assign updated filter back to queryStrings obj
-  queryStrings.groupedby = groupedBy;
-  // Stringify the obj again to push back to URL
-  const updatedQs = queryString.stringify(queryStrings);
-  // Add as an effect so UI is updated on each component render (e.g. Back button)
-  useEffect(() => {
+
+  const [groupModelsBy, setGroupModelsBy] = useState(groupedByFilter);
+
+  const updateFilterQuery = groupedBy => {
+    queryStrings.groupedby = groupedBy;
+    const updatedQs = queryString.stringify(queryStrings);
     history.push({
       pathname: "/models",
       search: groupedBy === "status" ? null : updatedQs
     });
-  }, [history, groupedBy, updatedQs]);
+    setGroupModelsBy(groupedBy);
+  };
 
   const { blocked, alert, running } = useSelector(getGroupedModelStatusCounts);
   const models = blocked + alert + running;
-
+  console.log(groupModelsBy);
   return (
     <Layout>
       <Header>
@@ -52,14 +51,17 @@ export default function Models() {
               "alert"
             )}, ${running} running`}
           </div>
-          <ModelGroupToggle setGroupedBy={setGroupedBy} groupedBy={groupedBy} />
+          <ModelGroupToggle
+            setGroupedBy={updateFilterQuery}
+            groupedBy={groupModelsBy}
+          />
           <FilterTags />
           <UserIcon />
         </div>
       </Header>
       <div className="l-content">
         <div className="models">
-          <ModelTableList groupedBy={groupedBy} />
+          <ModelTableList groupedBy={groupModelsBy} />
         </div>
       </div>
     </Layout>

--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useHistory, useLocation } from "react-router-dom";
 import queryString from "query-string";
@@ -24,6 +24,9 @@ export default function Models() {
   const groupedByFilter = queryStrings.groupedby || "status";
 
   const [groupModelsBy, setGroupModelsBy] = useState(groupedByFilter);
+  if (groupModelsBy !== groupedByFilter) {
+    setGroupModelsBy(groupedByFilter);
+  }
 
   const updateFilterQuery = groupedBy => {
     queryStrings.groupedby = groupedBy;
@@ -37,7 +40,7 @@ export default function Models() {
 
   const { blocked, alert, running } = useSelector(getGroupedModelStatusCounts);
   const models = blocked + alert + running;
-  console.log(groupModelsBy);
+
   return (
     <Layout>
       <Header>


### PR DESCRIPTION
## Done

When using the back button after toggling the model grouping it now correctly updates the UI.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Play with the model grouping buttons, they should update the UI as expected
- Hit the back button, it should navigate back through the groupings.
- Refresh with a grouping query string in the URL, it should render that grouping.

## Details

Fixes #330

