### PR TITLE
Increase the size of the icons and darken the relations and application icon outlines

### DIFF
--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -192,7 +192,7 @@ export default ({ modelData, width, height }) => {
       .attr("cy", d => (isSubordinate(d) ? 60 : 90))
       .attr("r", d => (isSubordinate(d) ? 60 : 90))
       .attr("fill", "#f5f5f5")
-      .attr("stroke-width", 1)
+      .attr("stroke-width", 3)
       .attr("stroke", "#888888")
       .call(_ => {
         // When ever a new element is added zoom the canvas to fit.
@@ -219,12 +219,16 @@ export default ({ modelData, width, height }) => {
     appIcon
       .append("image")
       .attr("xlink:href", d => generateIconPath(d.charm))
-      .attr("width", 96)
-      .attr("height", 96)
+      .attr("width", d => (isSubordinate(d) ? 96 : 126))
+      .attr("height", d => (isSubordinate(d) ? 96 : 126))
       .attr("transform", d =>
-        isSubordinate(d) ? "translate(13, 13)" : "translate(44, 44)"
+        isSubordinate(d) ? "translate(13, 13)" : "translate(30, 30)"
       )
-      .attr("clip-path", "circle(43px at 48px 48px)");
+      .attr("clip-path", d =>
+        isSubordinate(d)
+          ? "circle(43px at 48px 48px)"
+          : "circle(60px at 62px 62px)"
+      );
 
     const relationLines = topo.selectAll(".relation").data(relations);
     const relationLine = relationLines.enter().insert("g", ":first-child");
@@ -236,7 +240,8 @@ export default ({ modelData, width, height }) => {
       .attr("y1", d => getRelationPosition(d).y1)
       .attr("x2", d => getRelationPosition(d).x2)
       .attr("y2", d => getRelationPosition(d).y2)
-      .attr("stroke", "#cdcdcd");
+      .attr("stroke", "#666666")
+      .attr("stroke-width", 2);
 
     appIcons.exit().remove();
     relationLines.exit().remove();

--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -222,12 +222,12 @@ export default ({ modelData, width, height }) => {
       .attr("width", d => (isSubordinate(d) ? 96 : 126))
       .attr("height", d => (isSubordinate(d) ? 96 : 126))
       .attr("transform", d =>
-        isSubordinate(d) ? "translate(13, 13)" : "translate(30, 30)"
+        isSubordinate(d) ? "translate(13, 13)" : "translate(28, 28)"
       )
       .attr("clip-path", d =>
         isSubordinate(d)
           ? "circle(43px at 48px 48px)"
-          : "circle(60px at 62px 62px)"
+          : "circle(55px at 63px 63px)"
       );
 
     const relationLines = topo.selectAll(".relation").data(relations);


### PR DESCRIPTION
## Done

Increase the size of the icons and darken the relations and application icon outlines.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a model visualization and it should look as the screenshots show.

## Details

Fixes #324 

## Screenshots

<img width="895" alt="Screen Shot 2020-02-03 at 2 55 17 PM" src="https://user-images.githubusercontent.com/532033/73690135-50ecf780-4695-11ea-9130-628b48943efd.png">
<img width="312" alt="Screen Shot 2020-02-03 at 2 55 00 PM" src="https://user-images.githubusercontent.com/532033/73690136-50ecf780-4695-11ea-99d8-6e35c4132bca.png">
