### PR TITLE
Adjust modal z-index and owners grouping widths

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -8,7 +8,7 @@
 
   .p-modal {
     position: fixed;
-    z-index: z("beta");
+    z-index: z("lambda");
   }
 
   &__pictogram {

--- a/src/pages/Models/_models.scss
+++ b/src/pages/Models/_models.scss
@@ -25,7 +25,7 @@
   }
 
   .cloud-group tr {
-    grid-template-columns: 1.15fr 0.75fr 0.6fr 0.75fr 0.85fr 1fr 0.5fr 0.65fr;
+    grid-template-columns: 1.15fr 0.75fr 0.6fr 1.15fr 0.85fr 1fr 0.5fr 0.65fr;
   }
 
   // Tooltips override


### PR DESCRIPTION
## Done

- Move the topology modal to be on top of the whole application.
- Increase the widths on the 'configuration' column on the model list owners grouping

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Check that the owners grouping model list table doesn't wrap on any columns.
- Check that the topology modal covers the sidebar and header.

## Details

Fixes #343 
Fixes #332 
