### PR TITLE
Add Settings component

### DIFF
--- a/src/app/send-analytics-hook.js
+++ b/src/app/send-analytics-hook.js
@@ -1,0 +1,22 @@
+import ReactGA from "react-ga";
+
+export default function useSendAnalytics() {
+  return ({ path, category, action }) => {
+    const disableAnalytics = localStorage.getItem("disableAnalytics");
+    if (
+      process.env.NODE_ENV !== "production" ||
+      (disableAnalytics !== "false" && disableAnalytics !== undefined)
+    ) {
+      return;
+    }
+
+    if (path) {
+      ReactGA.pageview(path);
+    } else {
+      ReactGA.event({
+        category,
+        action
+      });
+    }
+  };
+}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Router, Route, Switch } from "react-router-dom";
+import { createBrowserHistory } from "history";
 import ReactGA from "react-ga";
 
 // Components
@@ -10,22 +11,31 @@ import { Routes } from "components/Routes/Routes";
 // Pages
 import NotFound from "pages/NotFound/NotFound";
 
+import useSendAnalytics from "app/send-analytics-hook";
+
 const baseURL = process.env.REACT_APP_BASE_APP_URL;
 
 function App() {
-  let GAKey = "UA-0000000-00";
+  const disableAnalytics = localStorage.getItem("disableAnalytics");
   if (
     process.env.NODE_ENV === "production" &&
-    !localStorage.getItem("disableAnalytics")
+    (disableAnalytics === undefined || disableAnalytics === "false")
   ) {
-    GAKey = "UA-1018242-68";
+    ReactGA.initialize("UA-1018242-68");
+    ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
   }
-  // Without initializing all the time the console has warnings about ReactGA
-  // initialization falure so we just initialize it with an invalid key.
-  ReactGA.initialize(GAKey);
-  ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
+
+  const history = createBrowserHistory();
+  const sendAnalytics = useSendAnalytics();
+
+  history.listen(location => {
+    sendAnalytics({
+      path: window.location.href.replace(window.location.origin, "")
+    });
+  });
+
   return (
-    <Router basename={baseURL}>
+    <Router basename={baseURL} history={history}>
       <ErrorBoundary>
         <Switch>
           <Login>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -13,10 +13,17 @@ import NotFound from "pages/NotFound/NotFound";
 const baseURL = process.env.REACT_APP_BASE_APP_URL;
 
 function App() {
-  if (process.env.NODE_ENV === "production") {
-    ReactGA.initialize("UA-1018242-68");
-    ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
+  let GAKey = "UA-0000000-00";
+  if (
+    process.env.NODE_ENV === "production" &&
+    !localStorage.getItem("disableAnalytics")
+  ) {
+    GAKey = "UA-1018242-68";
   }
+  // Without initializing all the time the console has warnings about ReactGA
+  // initialization falure so we just initialize it with an invalid key.
+  ReactGA.initialize(GAKey);
+  ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
   return (
     <Router basename={baseURL}>
       <ErrorBoundary>

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -1,8 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`App renders without crashing and matches snapshot 1`] = `
-<BrowserRouter
+<Router
   basename="/"
+  history={
+    Object {
+      "action": "POP",
+      "block": [Function],
+      "createHref": [Function],
+      "go": [Function],
+      "goBack": [Function],
+      "goForward": [Function],
+      "length": 1,
+      "listen": [Function],
+      "location": Object {
+        "hash": "",
+        "pathname": "/",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [Function],
+      "replace": [Function],
+    }
+  }
 >
   <ErrorBoundary>
     <Switch>
@@ -14,5 +34,5 @@ exports[`App renders without crashing and matches snapshot 1`] = `
       />
     </Switch>
   </ErrorBoundary>
-</BrowserRouter>
+</Router>
 `;

--- a/src/components/FilterTags/FilterTags.js
+++ b/src/components/FilterTags/FilterTags.js
@@ -4,13 +4,15 @@ import { useSelector } from "react-redux";
 import { useHistory, useLocation } from "react-router-dom";
 import { getModelData } from "app/selectors";
 import queryString from "query-string";
-import ReactGA from "react-ga";
+
 import {
   extractCloudName,
   extractOwnerName,
   extractCredentialName,
   pluralize
 } from "app/utils";
+
+import useSendAnalytics from "app/send-analytics-hook";
 
 import "./_filter-tags.scss";
 
@@ -30,11 +32,13 @@ const FilterTags = () => {
   const filters = {};
   const modelData = useSelector(getModelData);
 
+  const sendAnalytics = useSendAnalytics();
+
   /**
-  Check if filter exists and adds to array if not
-  @param {string} string The type of filter
-  @param {string} value The name of the filter
-*/
+    Check if filter exists and adds to array if not
+    @param {string} string The type of filter
+    @param {string} value The name of the filter
+  */
   const addFilter = function(type, value) {
     filters[type] = filters[type] || [];
     if (!filters[type].includes(value)) {
@@ -148,7 +152,7 @@ const FilterTags = () => {
         className="p-filter-tags__input"
         onClick={() => {
           setFilterPanelVisibility(true);
-          ReactGA.event({
+          sendAnalytics({
             category: "User",
             action: "Opened filter panel"
           });

--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -1,13 +1,13 @@
 import React, { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import ReactGA from "react-ga";
 
 import Topology from "components/Topology/Topology";
 import Modal from "@canonical/react-components/dist/components/Modal";
 
 import { getModelUUID, getModelStatus } from "app/selectors";
 import { extractCloudName } from "app/utils";
+import useSendAnalytics from "app/send-analytics-hook";
 
 import "./_info-panel.scss";
 
@@ -39,6 +39,8 @@ const InfoPanel = () => {
 
   const { width, height } = expandedTopologyDimensions();
 
+  const sendAnalytics = useSendAnalytics();
+
   return (
     <div className="info-panel">
       {showExpandedTopology ? (
@@ -56,7 +58,7 @@ const InfoPanel = () => {
             className="p-icon--expand"
             onClick={() => {
               setShowExpandedTopology(!showExpandedTopology);
-              ReactGA.event({
+              sendAnalytics({
                 category: "User",
                 action: "Opened expanded topology"
               });

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -5,6 +5,7 @@ import Controllers from "pages/Controllers/Controllers";
 import Logs from "pages/Logs/Logs";
 import Models from "pages/Models/Models";
 import ModelDetails from "pages/Models/Details/ModelDetails";
+import Settings from "pages/Settings/Settings";
 import Usage from "pages/Usage/Usage";
 
 export const paths = {
@@ -13,7 +14,8 @@ export const paths = {
   "/models/*": { component: ModelDetails },
   "/controllers": { component: Controllers },
   "/usage": { component: Usage },
-  "/logs": { component: Logs }
+  "/logs": { component: Logs },
+  "/settings": { component: Settings }
 };
 
 export function Routes() {

--- a/src/components/UserIcon/UserIcon.js
+++ b/src/components/UserIcon/UserIcon.js
@@ -2,9 +2,10 @@ import React, { useState, useRef, useEffect } from "react";
 import classNames from "classnames";
 import { Link } from "react-router-dom";
 import { useDispatch, useStore } from "react-redux";
-import ReactGA from "react-ga";
 
 import { logOut } from "app/actions";
+
+import useSendAnalytics from "app/send-analytics-hook";
 
 import "./_user-icon.scss";
 
@@ -12,6 +13,8 @@ export default function User() {
   const [userPanelVisibility, setUserPanelVisibility] = useState(false);
   const dispatch = useDispatch();
   const node = useRef();
+
+  const sendAnalytics = useSendAnalytics();
 
   useEffect(() => {
     const closePanel = () => {
@@ -47,12 +50,13 @@ export default function User() {
   const getState = useStore().getState;
 
   useEffect(() => {
-    if (userPanelVisibility)
-      ReactGA.event({
+    if (userPanelVisibility) {
+      sendAnalytics({
         category: "User",
         action: "Opened user panel"
       });
-  }, [userPanelVisibility]);
+    }
+  }, [userPanelVisibility, sendAnalytics]);
 
   return (
     <div

--- a/src/components/UserIcon/UserIcon.js
+++ b/src/components/UserIcon/UserIcon.js
@@ -75,6 +75,9 @@ export default function User() {
           >
             Docs
           </a>
+          <Link className="p-contextual-menu__link" to="/settings">
+            Settings
+          </Link>
           <Link
             className="p-contextual-menu__link"
             to="/"

--- a/src/components/UserIcon/__snapshots__/UserIcon.test.js.snap
+++ b/src/components/UserIcon/__snapshots__/UserIcon.test.js.snap
@@ -24,6 +24,24 @@ exports[`User Icon renders without crashing and matches snapshot 1`] = `
       </a>
       <Link
         className="p-contextual-menu__link"
+        to="/settings"
+      >
+        <LinkAnchor
+          className="p-contextual-menu__link"
+          href="/settings"
+          navigate={[Function]}
+        >
+          <a
+            className="p-contextual-menu__link"
+            href="/settings"
+            onClick={[Function]}
+          >
+            Settings
+          </a>
+        </LinkAnchor>
+      </Link>
+      <Link
+        className="p-contextual-menu__link"
         onClick={[Function]}
         to="/"
       >

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -1,0 +1,38 @@
+import React from "react";
+
+import Notification from "@canonical/react-components/dist/components/Notification/Notification";
+
+import Header from "components/Header/Header";
+import Layout from "components/Layout/Layout";
+
+import "./settings.scss";
+
+export default function Settings() {
+  const toggleAnalytics = () => {};
+
+  return (
+    <Layout>
+      <Header>
+        <span className="l-content settings__header">Settings</span>
+      </Header>
+      <div className="l-content">
+        <div className="settings__toggles">
+          <Notification>
+            Changes to the options below are applied immediately.
+          </Notification>
+          <label className="row">
+            <div className="col-6">Disable Google Analytics script</div>
+            <div className="col-3">
+              <input
+                type="checkbox"
+                className="p-switch"
+                onChange={toggleAnalytics}
+              />
+              <div className="p-switch__slider"></div>
+            </div>
+          </label>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import Notification from "@canonical/react-components/dist/components/Notification/Notification";
 
 import Header from "components/Header/Header";
@@ -8,8 +7,6 @@ import Layout from "components/Layout/Layout";
 import "./settings.scss";
 
 export default function Settings() {
-  const toggleAnalytics = () => {};
-
   return (
     <Layout>
       <Header>
@@ -17,20 +14,28 @@ export default function Settings() {
       </Header>
       <div className="l-content">
         <div className="settings__toggles">
-          <Notification>
-            Changes to the options below are applied immediately.
-          </Notification>
           <label className="row">
-            <div className="col-6">Disable Google Analytics script</div>
+            <div className="col-6">Disable Analytics</div>
             <div className="col-3">
               <input
                 type="checkbox"
                 className="p-switch"
-                onChange={toggleAnalytics}
+                defaultChecked={
+                  localStorage.getItem("disableAnalytics") === "true"
+                }
+                onChange={e => {
+                  localStorage.setItem(
+                    "disableAnalytics",
+                    e.currentTarget.checked
+                  );
+                }}
               />
               <div className="p-switch__slider"></div>
             </div>
           </label>
+          <Notification>
+            You will need to refresh your browser for this change to take effect
+          </Notification>
         </div>
       </div>
     </Layout>

--- a/src/pages/Settings/Settings.js
+++ b/src/pages/Settings/Settings.js
@@ -14,6 +14,9 @@ export default function Settings() {
       </Header>
       <div className="l-content">
         <div className="settings__toggles">
+          <Notification>
+            You will need to refresh your browser for this change to take effect
+          </Notification>
           <label className="row">
             <div className="col-6">Disable Analytics</div>
             <div className="col-3">
@@ -33,9 +36,6 @@ export default function Settings() {
               <div className="p-switch__slider"></div>
             </div>
           </label>
-          <Notification>
-            You will need to refresh your browser for this change to take effect
-          </Notification>
         </div>
       </div>
     </Layout>

--- a/src/pages/Settings/settings.scss
+++ b/src/pages/Settings/settings.scss
@@ -1,0 +1,10 @@
+.settings {
+  &__header {
+    align-items: center;
+    display: grid;
+  }
+
+  &__toggles {
+    width: 550px;
+  }
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -42,7 +42,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-tooltips;
 @include vf-u-align;
 @include vf-u-layout;
-
+@include vf-p-switch;
 // Fix consecutive table bug
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2491
 table + table {


### PR DESCRIPTION
## Done

- Add Settings page.
- Add option to disable analytics.

## QA

- Pull code
- Run `./run clean && ./run exec yarn run build`
- Run `cd build && serve` (You may have to install this `npm i serve`.
- Open the path serve returns.
- Navigate around a bit.
- You notice analytics events being sent in the devtools. You can filter the requests by 'analytic'
- Click the "Settings" link in the user drop down and it should take you to the settings page.
- Toggle the option to disable analytics
- `window.localStorage.getItem('disableAnalytics')` should be `"true"`
- Refresh
- The analytics should no longer be sent
- Go to settings and re-enable
- `window.localStorage.getItem('disableAnalytics')` should be `"false"`
- Refresh
- You should see analytics again.
- Click the demo link below and view devtools network pane and see that no analytics events are sent in dev builds.

## Details

Fixes #342

## Screenshots

<img width="856" alt="Screen Shot 2020-02-13 at 4 12 24 PM" src="https://user-images.githubusercontent.com/532033/74483216-a2f30180-4e7b-11ea-809e-6d4ab25b9808.png">

