### PR TITLE
Filter by dropdown selections

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -74,6 +74,18 @@ export const getPingerIntervalId = state => {
 // ---- Utility selectors
 
 /**
+  Returns a selector for the filtered model data.
+  @param {Object} filters The filters to filter the model data by.
+  @returns {Object} A selector for the filtered model data.
+*/
+const getFilteredModelData = filters =>
+  createSelector(getModelData, modelData =>
+    filterModelData(filters, modelData)
+  );
+
+// ---- Utility functions
+
+/**
   Pull the users macaroon credentials from state.
   @param {Object} state The application state.
   @returns {Object} The macaroons extracted from the bakery in state.
@@ -447,11 +459,15 @@ export const getModelStatus = modelUUID => {
   @returns {Object} The filtered and grouped model data.
 */
 export const getGroupedByStatusAndFilteredModelData = filters =>
-  createSelector(getModelData, modelData => {
-    const filtered = filterModelData(filters, modelData);
-    const grouped = groupModelsByStatus(filtered);
-    return grouped;
-  });
+  createSelector(getFilteredModelData(filters), groupModelsByStatus);
+
+/**
+  Returns the model data filtered and grouped by cloud.
+  @param {Object} filters The filters to filter the model data by.
+  @returns {Object} The filtered and grouped model data.
+*/
+export const getGroupedByCloudAndFilteredModelData = filters =>
+  createSelector(getFilteredModelData(filters), groupModelsByCloud);
 
 /**
   Returns the model statuses sorted by status.
@@ -497,16 +513,6 @@ export const getGroupedApplicationsDataByStatus = createSelector(
 export const getGroupedModelDataByOwner = createSelector(
   getModelData,
   groupModelsByOwner
-);
-
-/**
-  Returns the model statuses sorted by cloud.
-  @returns {Function} The memoized selector to return the models
-    grouped by cloud.
-*/
-export const getGroupedModelDataByCloud = createSelector(
-  getModelData,
-  groupModelsByCloud
 );
 
 /**

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -338,10 +338,20 @@ const filterModelData = (filters, modelData) => {
         case "cloud":
           return !values.includes(data.model.cloudTag.replace("cloud-", ""));
         case "credential":
+          if (data.info) {
+            return !values.includes(
+              data.info.cloudCredentialTag.split("@")[1].split("_")[1]
+            );
+          }
           break;
         case "region":
-          break;
+          return !values.includes(data.model.region);
         case "owner":
+          if (data.info) {
+            return !values.includes(
+              data.info.ownerTag.split("@")[0].replace("user-", "")
+            );
+          }
           break;
       }
       return false;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -470,6 +470,14 @@ export const getGroupedByCloudAndFilteredModelData = filters =>
   createSelector(getFilteredModelData(filters), groupModelsByCloud);
 
 /**
+  Returns the model data filtered and grouped by owner.
+  @param {Object} filters The filters to filter the model data by.
+  @returns {Object} The filtered and grouped model data.
+*/
+export const getGroupedByOwnerAndFilteredModelData = filters =>
+  createSelector(getFilteredModelData(filters), groupModelsByOwner);
+
+/**
   Returns the model statuses sorted by status.
   @returns {Function} The memoized selector to return the sorted model statuses.
 */
@@ -503,16 +511,6 @@ export const getGroupedUnitsDataByStatus = createSelector(
 export const getGroupedApplicationsDataByStatus = createSelector(
   getModelData,
   groupApplicationsByStatus
-);
-
-/**
-  Returns the model statuses sorted by owner.
-  @returns {Function} The memoized selector to return the models
-    grouped by owner.
-*/
-export const getGroupedModelDataByOwner = createSelector(
-  getModelData,
-  groupModelsByOwner
 );
 
 /**

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -6,7 +6,8 @@ import {
   extractCloudName,
   getApplicationStatusGroup,
   getMachineStatusGroup,
-  getUnitStatusGroup
+  getUnitStatusGroup,
+  extractCredentialName
 } from "./utils";
 
 // ---- Selectors for top level keys
@@ -348,11 +349,11 @@ const filterModelData = (filters, modelData) => {
     const remove = Object.entries(filterSegments).some(([segment, values]) => {
       switch (segment) {
         case "cloud":
-          return !values.includes(data.model.cloudTag.replace("cloud-", ""));
+          return !values.includes(extractCloudName(data.model.cloudTag));
         case "credential":
           if (data.info) {
             return !values.includes(
-              data.info.cloudCredentialTag.split("@")[1].split("_")[1]
+              extractCredentialName(data.info.cloudCredentialTag)
             );
           }
           break;
@@ -360,9 +361,7 @@ const filterModelData = (filters, modelData) => {
           return !values.includes(data.model.region);
         case "owner":
           if (data.info) {
-            return !values.includes(
-              data.info.ownerTag.split("@")[0].replace("user-", "")
-            );
+            return !values.includes(extractOwnerName(data.info.ownerTag));
           }
           break;
       }

--- a/src/components/FilterTags/FilterTags.js
+++ b/src/components/FilterTags/FilterTags.js
@@ -20,9 +20,14 @@ const FilterTags = () => {
   const history = useHistory();
   const location = useLocation();
 
-  const queryParams = queryString.parse(location.search);
-  const queryParamsActiveFilters = queryParams.activeFilters;
-
+  const queryParams = queryString.parse(location.search, {
+    arrayFormat: "comma"
+  });
+  let queryParamsActiveFilters = queryParams.activeFilters;
+  if (typeof queryParamsActiveFilters === "string") {
+    // Maintain a consistent type returned from the parsing of the querystring.
+    queryParamsActiveFilters = [queryParamsActiveFilters];
+  }
   const [filterPanelVisibility, setFilterPanelVisibility] = useState(false);
   const [activeFilters, setActiveFilters] = useState(
     queryParamsActiveFilters || []
@@ -108,7 +113,9 @@ const FilterTags = () => {
     const queryParams = queryString.parse(location.search);
     queryParams.activeFilters = activeFilters;
     history.push({
-      search: queryString.stringify(queryParams)
+      search: queryString.stringify(queryParams, {
+        arrayFormat: "comma"
+      })
     });
   }, [activeFilters, history, location.search]);
 

--- a/src/components/FilterTags/FilterTags.js
+++ b/src/components/FilterTags/FilterTags.js
@@ -186,7 +186,7 @@ const FilterTags = () => {
             activeFilters.length > 0 &&
             activeFilters.map(activeFilter => (
               <span className="p-filter-tags__active-filter" key={activeFilter}>
-                {activeFilter}
+                {activeFilter.replace(":", ": ")}
                 <i
                   className="p-icon--close"
                   onClick={() => removeActiveFilter(activeFilter)}
@@ -210,12 +210,10 @@ const FilterTags = () => {
                   {filters[filterBy].map(filter => (
                     <li key={filter} className="p-filter-panel__item">
                       <button
-                        onClick={() =>
-                          addActiveFilter(`${filterBy}: ${filter}`)
-                        }
+                        onClick={() => addActiveFilter(`${filterBy}:${filter}`)}
                         className={classNames("p-filter-panel__button", {
                           "is-selected": activeFilters.includes(
-                            `${filterBy}: ${filter}`
+                            `${filterBy}:${filter}`
                           )
                         })}
                         type="button"

--- a/src/components/FilterTags/FilterTags.test.js
+++ b/src/components/FilterTags/FilterTags.test.js
@@ -152,7 +152,7 @@ describe("Filter pills", () => {
       .at(0)
       .simulate("click");
     const searchParams = new URLSearchParams(history.location.search);
-    expect(searchParams.get("activeFilters")).toEqual("cloud: google");
+    expect(searchParams.get("activeFilters")).toEqual("cloud:google");
     wrapper
       .find(selectedActiveFilterClose)
       .at(0)
@@ -183,13 +183,13 @@ describe("Filter pills", () => {
       .at(1)
       .simulate("click");
     expect(history.location.search).toEqual(
-      "?activeFilters=cloud%3A%20google&activeFilters=cloud%3A%20aws"
+      "?activeFilters=cloud%3Agoogle,cloud%3Aaws"
     );
     wrapper
       .find(selectedActiveFilterClose)
       .at(0)
       .simulate("click");
-    expect(history.location.search).toEqual("?activeFilters=cloud%3A%20aws");
+    expect(history.location.search).toEqual("?activeFilters=cloud%3Aaws");
     wrapper
       .find(selectedActiveFilterClose)
       .at(0)

--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -6,7 +6,7 @@ import {
   getModelStatusGroupData,
   extractOwnerName
 } from "app/utils";
-import { getGroupedModelDataByCloud } from "app/selectors";
+import { getGroupedByCloudAndFilteredModelData } from "app/selectors";
 import {
   generateControllerUUID,
   generateModelDetailsLink,
@@ -53,9 +53,12 @@ function generateCloudTableHeaders(cloud, count) {
   ];
 }
 
-export default function CloudGroup({ activeUser }) {
-  const groupedModelDataByCloud = useSelector(getGroupedModelDataByCloud);
-  const cloudRows = generateModelTableDataByCloud(groupedModelDataByCloud);
+export default function CloudGroup({ activeUser, filters }) {
+  const groupedAndFilteredData = useSelector(
+    getGroupedByCloudAndFilteredModelData(filters)
+  );
+
+  const cloudRows = generateModelTableDataByCloud(groupedAndFilteredData);
   let cloudTables = [];
   let cloudModels = {};
   for (const cloud in cloudRows) {

--- a/src/components/ModelTableList/CloudGroup.test.js
+++ b/src/components/ModelTableList/CloudGroup.test.js
@@ -44,4 +44,18 @@ describe("CloudGroup", () => {
     expect(tables.get(0).props.rows.length).toEqual(15);
     expect(tables.get(1).props.rows.length).toEqual(2);
   });
+
+  it("fetches filtered data if filters supplied", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <CloudGroup filters={["cloud:aws"]} />
+        </Provider>
+      </MemoryRouter>
+    );
+    const tables = wrapper.find("MainTable");
+    expect(tables.length).toBe(1);
+    expect(tables.get(0).props.rows.length).toBe(2);
+  });
 });

--- a/src/components/ModelTableList/ModelTableList.js
+++ b/src/components/ModelTableList/ModelTableList.js
@@ -9,15 +9,15 @@ import OwnerGroup from "./OwnerGroup";
 
 import "./_model-table-list.scss";
 
-export default function ModelTableList({ groupedBy }) {
+export default function ModelTableList({ filters, groupedBy }) {
   const activeUser = useSelector(getActiveUserTag);
   switch (groupedBy) {
     case "status":
     default:
-      return <StatusGroup activeUser={activeUser} />;
+      return <StatusGroup activeUser={activeUser} filters={filters} />;
     case "cloud":
-      return <CloudGroup activeUser={activeUser} />;
+      return <CloudGroup activeUser={activeUser} filters={filters} />;
     case "owner":
-      return <OwnerGroup activeUser={activeUser} />;
+      return <OwnerGroup activeUser={activeUser} filters={filters} />;
   }
 }

--- a/src/components/ModelTableList/ModelTableList.test.js
+++ b/src/components/ModelTableList/ModelTableList.test.js
@@ -26,33 +26,50 @@ describe("ModelTableList", () => {
     expect(wrapper.find("OwnerGroup").length).toBe(0);
   });
 
-  it("displays all data from redux store when grouping by status", () => {
+  it("displays all data from redux store when grouping by...", () => {
     const store = mockStore(dataDump);
-    const wrapper = mount(
-      <MemoryRouter>
-        <Provider store={store}>
-          <ModelTableList groupedBy="status" />
-        </Provider>
-      </MemoryRouter>
-    );
-    const statusGroup = wrapper.find("StatusGroup");
-    expect(statusGroup.length).toBe(1);
-    expect(statusGroup.prop("activeUser")).toBe("user-activedev@external");
-    expect(wrapper.find("OwnerGroup").length).toBe(0);
+    const user = "user-activedev@external";
+    const tables = [
+      ["status", "StatusGroup"],
+      ["owner", "OwnerGroup"],
+      ["cloud", "CloudGroup"]
+    ];
+    tables.forEach(table => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Provider store={store}>
+            <ModelTableList groupedBy={table[0]} />
+          </Provider>
+        </MemoryRouter>
+      );
+      const Group = wrapper.find(table[1]);
+      expect(Group.length).toBe(1);
+      expect(Group.prop("activeUser")).toBe(user);
+      tables.forEach(otherTable => {
+        if (otherTable[0] !== table[0]) {
+          expect(wrapper.find(otherTable[1]).length).toBe(0);
+        }
+      });
+    });
   });
 
-  it("displays all data from redux store when grouping by owner", () => {
+  it("passes the filters to the group components", () => {
     const store = mockStore(dataDump);
-    const wrapper = mount(
-      <MemoryRouter>
-        <Provider store={store}>
-          <ModelTableList groupedBy="owner" />
-        </Provider>
-      </MemoryRouter>
-    );
-    const ownerGroup = wrapper.find("OwnerGroup");
-    expect(ownerGroup.length).toBe(1);
-    expect(ownerGroup.prop("activeUser")).toBe("user-activedev@external");
-    expect(wrapper.find("StatusGroup").length).toBe(0);
+    const tables = [
+      { groupedBy: "status", component: "StatusGroup" },
+      { groupedBy: "status", component: "StatusGroup" },
+      { groupedBy: "status", component: "StatusGroup" }
+    ];
+    const filters = ["cloud:aws"];
+    tables.forEach(table => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Provider store={store}>
+            <ModelTableList groupedBy={table.groupedBy} filters={filters} />
+          </Provider>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(table.component).prop("filters")).toBe(filters);
+    });
   });
 });

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -2,7 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import { generateStatusElement, getModelStatusGroupData } from "app/utils";
-import { getGroupedModelDataByOwner } from "app/selectors";
+import { getGroupedByOwnerAndFilteredModelData } from "app/selectors";
 import {
   generateControllerUUID,
   generateModelDetailsLink,
@@ -48,9 +48,11 @@ function generateOwnerTableHeaders(owner, count) {
   ];
 }
 
-export default function OwnerGroup({ activeUser }) {
-  const groupedModelDataByOwner = useSelector(getGroupedModelDataByOwner);
-  const ownerRows = generateModelTableDataByOwner(groupedModelDataByOwner);
+export default function OwnerGroup({ activeUser, filters }) {
+  const groupedAndFilteredData = useSelector(
+    getGroupedByOwnerAndFilteredModelData(filters)
+  );
+  const ownerRows = generateModelTableDataByOwner(groupedAndFilteredData);
   let ownerTables = [];
   let ownerModels = {};
   for (const owner in ownerRows) {

--- a/src/components/ModelTableList/OwnerGroup.test.js
+++ b/src/components/ModelTableList/OwnerGroup.test.js
@@ -47,4 +47,16 @@ describe("OwnerGroup", () => {
     expect(tables.get(3).props.rows.length).toEqual(3);
     expect(tables.get(4).props.rows.length).toEqual(2);
   });
+
+  it("fetches filtered data if filters supplied", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <OwnerGroup filters={["cloud:aws"]} />
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(wrapper.find("tbody TableRow").length).toBe(2);
+  });
 });

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -8,7 +8,7 @@ import {
   extractOwnerName
 } from "app/utils";
 
-import { getGroupedModelDataByStatus } from "app/selectors";
+import { getGroupedByStatusAndFilteredModelData } from "app/selectors";
 
 import {
   generateControllerUUID,
@@ -149,13 +149,16 @@ function generateModelTableDataByStatus(groupedModels, activeUser) {
   return modelData;
 }
 
-export default function StatusGroup({ activeUser }) {
-  const groupedModelDataByStatus = useSelector(getGroupedModelDataByStatus);
+export default function StatusGroup({ activeUser, filters }) {
+  const groupedAndFilteredData = useSelector(
+    getGroupedByStatusAndFilteredModelData(filters)
+  );
+
   const {
     blockedRows,
     alertRows,
     runningRows
-  } = generateModelTableDataByStatus(groupedModelDataByStatus, activeUser);
+  } = generateModelTableDataByStatus(groupedAndFilteredData, activeUser);
 
   return (
     <div className="status-group">

--- a/src/components/ModelTableList/StatusGroup.test.js
+++ b/src/components/ModelTableList/StatusGroup.test.js
@@ -48,4 +48,16 @@ describe("StatusGroup", () => {
     expect(tables.get(1).props.rows.length).toEqual(4);
     expect(tables.get(2).props.rows.length).toEqual(7);
   });
+
+  it("fetches filtered data if filters supplied", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <StatusGroup filters={["cloud:aws"]} />
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(wrapper.find("tbody TableRow").length).toBe(2);
+  });
 });

--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -18,7 +18,14 @@ export default function Models() {
   // Grab filter from 'groupedby' query in URL and assign to variable
   const history = useHistory();
   const location = useLocation();
-  const queryStrings = queryString.parse(location.search);
+  const queryStrings = queryString.parse(location.search, {
+    arrayFormat: "comma"
+  });
+  let activeFilters = queryStrings.activeFilters;
+  if (typeof activeFilters === "string") {
+    // Maintain a consistent type returned from the parsing of the querystring.
+    activeFilters = [activeFilters];
+  }
   // If it doesn't exist, fall back to grouping by status
   const groupedByFilter = queryStrings.groupedby || "status";
 

--- a/src/pages/Models/Models.js
+++ b/src/pages/Models/Models.js
@@ -69,7 +69,7 @@ export default function Models() {
       </Header>
       <div className="l-content">
         <div className="models">
-          <ModelTableList groupedBy={groupModelsBy} />
+          <ModelTableList groupedBy={groupModelsBy} filters={activeFilters} />
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Done

When selecting filter options from the drop down filter the table list.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View the model list and select some items from the filter dropdown, it should filter the resulting mode list.
- Switch between the groupings (status, cloud, owner) the filters should persist.
- Refresh, the filters should persist.

## Details

Fixes #125
