### PR TITLE
Make is-provisioning error red

### DIFF
--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -11,6 +11,7 @@
     top: -6px;
   }
 
+  &.is-provisioning,
   &.is-error,
   &.is-blocked {
     &::before {


### PR DESCRIPTION
## Done

Make is-provisioning error red

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details page 
- Scroll down to 'machine' table
- Verify any provisioning errors are red

## Details

Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/308

## Screenshots

<img width="1436" alt="Screenshot 2020-03-13 at 14 54 41" src="https://user-images.githubusercontent.com/505570/76632156-a8a33c00-653a-11ea-95e1-8bfb15b5b191.png">

