### PR TITLE
Support URL basename

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import ReactGA from "react-ga";
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import { createBrowserHistory } from "history";
 import ReactGA from "react-ga";
 
 // Components
@@ -11,8 +10,6 @@ import { Routes } from "components/Routes/Routes";
 
 // Pages
 import NotFound from "pages/NotFound/NotFound";
-
-import useSendAnalytics from "app/send-analytics-hook";
 
 import { getConfig } from "app/selectors";
 
@@ -27,17 +24,8 @@ function App() {
     ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
   }
 
-  const history = createBrowserHistory();
-  const sendAnalytics = useSendAnalytics();
-
-  history.listen(location => {
-    sendAnalytics({
-      path: window.location.href.replace(window.location.origin, "")
-    });
-  });
-
   return (
-    <Router basename={baseAppURL} history={history}>
+    <Router basename={baseAppURL}>
       <ErrorBoundary>
         <Switch>
           <Login>

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -16,6 +16,6 @@ describe("App", () => {
         <App />
       </Provider>
     );
-    expect(wrapper.find("Router").prop("basename")).toBe("/");
+    expect(wrapper.find("BrowserRouter").prop("basename")).toBe("/");
   });
 });

--- a/src/components/Routes/Routes.js
+++ b/src/components/Routes/Routes.js
@@ -1,5 +1,5 @@
-import React from "react";
-import { Route, Redirect } from "react-router-dom";
+import React, { useEffect } from "react";
+import { Route, Redirect, useLocation } from "react-router-dom";
 
 import Controllers from "pages/Controllers/Controllers";
 import Logs from "pages/Logs/Logs";
@@ -7,6 +7,7 @@ import Models from "pages/Models/Models";
 import ModelDetails from "pages/Models/Details/ModelDetails";
 import Settings from "pages/Settings/Settings";
 import Usage from "pages/Usage/Usage";
+import useSendAnalytics from "app/send-analytics-hook";
 
 export const paths = {
   "/": { redirect: "/models" },
@@ -19,6 +20,16 @@ export const paths = {
 };
 
 export function Routes() {
+  const sendAnalytics = useSendAnalytics();
+  const location = useLocation();
+
+  useEffect(() => {
+    // Send an analytics event when the URL changes.
+    sendAnalytics({
+      path: window.location.href.replace(window.location.origin, "")
+    });
+  }, [location, sendAnalytics]);
+
   return Object.entries(paths).map(path => {
     if (path[1].redirect) {
       return (


### PR DESCRIPTION
## Done
- Replace the low level Router with BrowserRouter to support basename.

## QA

- Build and run using Juju, the app should load and the URL should be prefixed by the basename.
- To test this locally: 
- - Open App.js and change line 40 from `<Router basename={baseAppURL} ...` to `<Router basename="/dashboard" ..`.
- - Load the app, it should load and the URL should start with /dashboard/...
