### PR TITLE
Fix topology modal window

### DIFF
--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -22,6 +22,13 @@ const expandedTopologyDimensions = () => {
   };
 };
 
+const infoPanelDimensions = () => {
+  const de = document.documentElement;
+  const vw = Math.max(de.clientWidth, window.innerWidth || 0);
+  const size = vw >= 1580 ? 300 : 180;
+  return size;
+};
+
 const InfoPanel = () => {
   const { 0: modelName } = useParams();
   const [showExpandedTopology, setShowExpandedTopology] = useState(false);
@@ -38,6 +45,7 @@ const InfoPanel = () => {
     : "";
 
   const { width, height } = expandedTopologyDimensions();
+  const topologySize = infoPanelDimensions();
 
   const sendAnalytics = useAnalytics();
 
@@ -53,7 +61,12 @@ const InfoPanel = () => {
         </Modal>
       ) : (
         <div className="info-panel__pictogram">
-          <Topology width={300} height={300} modelData={modelStatusData} />
+          <Topology
+            width={topologySize}
+            height={topologySize}
+            modelData={modelStatusData}
+            data-test="topology"
+          />
           <i
             className="p-icon--expand"
             onClick={() => {

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -9,6 +9,10 @@
   .p-modal {
     position: fixed;
     z-index: z("lambda");
+
+    &__dialog {
+      width: 90%;
+    }
   }
 
   &__pictogram {


### PR DESCRIPTION
## Done
- Fix topology modal window in Chrome and FF
- Fix the initial render of the infoPanel topology on smaller screen size

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go int oa model
- See the mini topology renders correctly
- Now shrink the screen size down until the infoPanel resizes
- Refresh and see the mini topology renders correctly
- Check the model topology renders correctly
- Check the model in both Chrome and FF

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/403
