### PR TITLE
Close topology on Escape key click

### DIFF
--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
@@ -49,12 +49,25 @@ const InfoPanel = () => {
 
   const sendAnalytics = useAnalytics();
 
+  // Close topology, if open, on Escape key press
+  useEffect(() => {
+    const closeOnEscape = function (e) {
+      if (e.key === "Escape" && showExpandedTopology) {
+        setShowExpandedTopology(false);
+      }
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  });
+
   return (
     <div className="info-panel">
       {showExpandedTopology ? (
         <Modal
           close={() => setShowExpandedTopology(false)}
-          title={modelName.split("/")[1]}
+          title={modelName.split("/")[1] || ""}
           data-test="topology-modal"
         >
           <Topology width={width} height={height} modelData={modelStatusData} />

--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -67,7 +67,7 @@ const InfoPanel = () => {
       {showExpandedTopology ? (
         <Modal
           close={() => setShowExpandedTopology(false)}
-          title={modelName.split("/")[1] || ""}
+          title={modelName.split("/")[1] || "Error: model not loading"}
           data-test="topology-modal"
         >
           <Topology width={width} height={height} modelData={modelStatusData} />


### PR DESCRIPTION
## Done

- Close topology on Escape key click
- Add error text to title of topology as I had instances when refreshing where model would not load but topology modal was still onscreen
- Add conditional so that expand button would not appear unless modelName exists

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to models details page 
- Open topology
- Hit Escape key
- Verify topology closes
