### PR TITLE
Persist external nav using redux store

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { NavLink, useLocation } from "react-router-dom";
 import classNames from "classnames";
 
 import { getGroupedModelStatusCounts } from "app/selectors";
+
+import { externalNavActive } from "ui/actions";
+import { isExternalNavActive } from "ui/selectors";
 
 import UserMenu from "components/UserMenu/UserMenu";
 
@@ -42,10 +45,11 @@ const pages = [
 ];
 
 const PrimaryNav = () => {
-  const [extNavOpen, setExtNavOpen] = useState(false);
   const [activeLinkValue, setActiveLinkValue] = useState("");
+  const extNavActive = useSelector(isExternalNavActive);
   const { blocked } = useSelector(getGroupedModelStatusCounts);
   const location = useLocation();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     setActiveLinkValue(location.pathname);
@@ -67,7 +71,9 @@ const PrimaryNav = () => {
 
   return (
     <nav
-      className={classNames("p-primary-nav", { "ext-nav-open": extNavOpen })}
+      className={classNames("p-primary-nav", {
+        "ext-nav-open": extNavActive,
+      })}
     >
       <div className="p-primary-nav__header">
         <a href="https://jaas.ai" className="p-primary-nav__logo">
@@ -87,7 +93,7 @@ const PrimaryNav = () => {
         </a>
         <button
           className="p-primary-nav__toggle"
-          onClick={() => setExtNavOpen(!extNavOpen)}
+          onClick={() => dispatch(externalNavActive(!extNavActive))}
         >
           <i className="p-icon--contextual-menu">Toggle external navigation</i>
         </button>

--- a/src/components/PrimaryNav/PrimaryNav.test.js
+++ b/src/components/PrimaryNav/PrimaryNav.test.js
@@ -21,12 +21,11 @@ describe("Primary Nav", () => {
 
     const primaryNav = ".p-primary-nav";
     const primaryNavToggle = ".p-primary-nav__toggle";
-
     expect(wrapper.find(primaryNav).hasClass("ext-nav-open")).toEqual(false);
     wrapper.find(primaryNavToggle).simulate("click");
-    expect(wrapper.find(primaryNav).hasClass("ext-nav-open")).toEqual(true);
-    wrapper.find(primaryNavToggle).simulate("click");
-    expect(wrapper.find(primaryNav).hasClass("ext-nav-open")).toEqual(false);
+    const actions = store.getActions();
+    const expectedPayload = { payload: true, type: "TOGGLE_EXTERNAL_NAV" };
+    expect(actions).toEqual([expectedPayload]);
   });
 
   it("applies is-selected state correctly", () => {

--- a/src/components/PrimaryNav/PrimaryNav.test.js
+++ b/src/components/PrimaryNav/PrimaryNav.test.js
@@ -28,6 +28,25 @@ describe("Primary Nav", () => {
     expect(actions).toEqual([expectedPayload]);
   });
 
+  it("external nav is active when externalNavActive in redux store is true", () => {
+    const store = mockStore({
+      ui: {
+        externalNavActive: true,
+      },
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <Router>
+          <PrimaryNav />
+        </Router>
+      </Provider>
+    );
+
+    expect(wrapper.find(".p-primary-nav").hasClass("ext-nav-open")).toEqual(
+      true
+    );
+  });
+
   it("applies is-selected state correctly", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const reduxStore = createStore(
     ui: {
       collapsibleSidebar: false,
       userMenuActive: false,
+      externalNavActive: false,
     },
   },
   // Order of the middleware is important

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -11123,6 +11123,7 @@ export default {
   },
    ui: {
     collapsibleSidebar: false,
+    externalNavActive: false,
     userMenuActive: false
   }
 }

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -2,6 +2,7 @@
 export const actionsList = {
   collapsibleSidebar: "TOGGLE_COLLAPSIBLE_SIDEBAR",
   userMenuActive: "TOGGLE_USER_MENU",
+  externalNavActive: "TOGGLE_EXTERNAL_NAV",
 };
 
 /**
@@ -20,6 +21,16 @@ export function collapsibleSidebar(toggle) {
 export function userMenuActive(toggle) {
   return {
     type: actionsList.userMenuActive,
+    payload: toggle,
+  };
+}
+
+/**
+  Persist external navigation visibility between page renders
+*/
+export function externalNavActive(toggle) {
+  return {
+    type: actionsList.externalNavActive,
     payload: toggle,
   };
 }

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -11,6 +11,9 @@ function uiReducer(state = {}, action) {
       case actionsList.userMenuActive:
         draftState.userMenuActive = action.payload;
         break;
+      case actionsList.externalNavActive:
+        draftState.externalNavActive = action.payload;
+        break;
       default:
         // no default value, fall through.
         break;

--- a/src/ui/selectors.js
+++ b/src/ui/selectors.js
@@ -8,11 +8,7 @@
   @param {Object} state The application state.
   @returns {Boolean} If the sidebar is collapsible.
 */
-export const isSidebarCollapsible = (state) => {
-  if (state?.ui) {
-    return state.ui.collapsibleSidebar;
-  }
-};
+export const isSidebarCollapsible = (state) => state?.ui?.collapsibleSidebar;
 
 /**
   Checks state to see if the user menu is active.
@@ -22,11 +18,7 @@ export const isSidebarCollapsible = (state) => {
   @param {Object} state The application state.
   @returns {Boolean} If the user menu is active
 */
-export const isUserMenuActive = (state) => {
-  if (state?.ui) {
-    return state.ui.userMenuActive;
-  }
-};
+export const isUserMenuActive = (state) => state?.ui?.userMenuActive;
 
 /**
   Checks state to see if the external nav is active.
@@ -36,8 +28,4 @@ export const isUserMenuActive = (state) => {
   @param {Object} state The application state.
   @returns {Boolean} If the external navigation menu is active
 */
-export const isExternalNavActive = (state) => {
-  if (state?.ui) {
-    return state.ui.externalNavActive;
-  }
-};
+export const isExternalNavActive = (state) => state?.ui?.externalNavActive;

--- a/src/ui/selectors.js
+++ b/src/ui/selectors.js
@@ -27,3 +27,17 @@ export const isUserMenuActive = (state) => {
     return state.ui.userMenuActive;
   }
 };
+
+/**
+  Checks state to see if the external nav is active.
+  Usage:
+    const externalNavActive = useSelector(isExternalNavActive);
+
+  @param {Object} state The application state.
+  @returns {Boolean} If the external navigation menu is active
+*/
+export const isExternalNavActive = (state) => {
+  if (state?.ui) {
+    return state.ui.externalNavActive;
+  }
+};


### PR DESCRIPTION
## Done

Persist external nav using redux store

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Open external nav and navigate between controller, model and model detail views
- External nav should remain open until user makes the decision to close it

## Details

Fixes #411 
