### PR TITLE
Collapse sidebar on all screens less than 1400px

### DIFF
--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -197,3 +197,23 @@ export const generateIconPath = (namespace) => {
   }
   return `https://api.jujucharms.com/charmstore/v5/${namespace}/icon.svg`;
 };
+
+/**
+  @returns {Int || 0} Returns the current viewport width
+*/
+export const getViewportWidth = () => {
+  const de = document.documentElement;
+  return Math.max(de.clientWidth, window.innerWidth || 0);
+};
+
+/**
+ * @param {function} fn Function to debounce
+ * @param {String} wait Time in milliseconds to wait
+ */
+export const debounce = (fn, wait) => {
+  let t;
+  return function () {
+    clearTimeout(t);
+    t = setTimeout(() => fn.apply(this, arguments), wait);
+  };
+};

--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -6,7 +6,7 @@ import Topology from "components/Topology/Topology";
 import Modal from "@canonical/react-components/dist/components/Modal";
 
 import { getModelUUID, getModelStatus } from "app/selectors";
-import { extractCloudName } from "app/utils";
+import { extractCloudName, getViewportWidth } from "app/utils";
 import useAnalytics from "hooks/useAnalytics";
 
 import "./_info-panel.scss";
@@ -23,8 +23,7 @@ const expandedTopologyDimensions = () => {
 };
 
 const infoPanelDimensions = () => {
-  const de = document.documentElement;
-  const vw = Math.max(de.clientWidth, window.innerWidth || 0);
+  const vw = getViewportWidth();
   const size = vw >= 1580 ? 300 : 180;
   return size;
 };

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 import classNames from "classnames";
 import useHover from "hooks/useHover";
+import { getViewportWidth, debounce } from "app/utils";
 
 import { isSidebarCollapsible } from "ui/selectors";
 
@@ -10,16 +11,33 @@ import "./_layout.scss";
 
 const Layout = ({ children }) => {
   const [sidebarRef, isSidebarHovered] = useHover();
+  const [screenWidth, setScreenWidth] = useState(getViewportWidth());
   const sidebarCollapsible = useSelector(isSidebarCollapsible);
+  const smallScreenBreakpoint = 1400;
+  const isSmallScreen = screenWidth <= smallScreenBreakpoint ? true : false;
+
+  const handleScreenResize = () => {
+    setScreenWidth(getViewportWidth());
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", debounce(handleScreenResize, 1000));
+    return () => {
+      window.removeEventListener("resize", debounce(handleScreenResize, 1000));
+    };
+  }, []);
+
   return (
     <div
       className={classNames("l-container", {
-        "has-collapsible-sidebar": sidebarCollapsible,
+        "has-collapsible-sidebar": sidebarCollapsible || isSmallScreen,
       })}
     >
       <div
         className={classNames("l-side", {
-          "is-collapsed": sidebarCollapsible && !isSidebarHovered,
+          "is-collapsed":
+            (sidebarCollapsible && !isSidebarHovered) ||
+            (isSmallScreen && !isSidebarHovered),
         })}
         ref={sidebarRef}
       >


### PR DESCRIPTION
## Done

Collapse sidebar on all screens less than 1400px

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Change your screen resolution up and down over the 1400px breakpoint and observe navigation collapse accordingly

## Details

#404 
