### PR TITLE
Set maximum terminal height on drag

### DIFF
--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -15,12 +15,13 @@ const Terminal = ({ address, modelName }) => {
   const history = useHistory();
 
   // save default terminal height in the state object
-  let [terminalHeight, setTerminalHeight] = useState(200);
+  const [terminalHeight, setTerminalHeight] = useState(200);
 
   const fitAddonRef = useRef({ current: null });
 
   const terminalHeaderHeight = 40; // px
   const minimumTerminalHeight = 84; // px
+  const modelDetailHeaderHeight = 42; // px
 
   useEffect(() => {
     // If the model name is found after a juju switch then
@@ -47,7 +48,12 @@ const Terminal = ({ address, modelName }) => {
       const mousePosition = e.clientY;
       const newTerminalHeight =
         viewPortHeight - mousePosition + terminalHeaderHeight;
-      if (newTerminalHeight >= minimumTerminalHeight) {
+
+      const maximumTerminalHeight = viewPortHeight - modelDetailHeaderHeight;
+      if (
+        newTerminalHeight < maximumTerminalHeight &&
+        newTerminalHeight >= minimumTerminalHeight
+      ) {
         setTerminalHeight(newTerminalHeight);
       }
     };

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -1,9 +1,18 @@
 @import "vanilla-framework/scss/vanilla";
 @import "xterm/css/xterm";
+@import "../../scss/functions/z-index";
 
 $terminal-header-height: 40px;
 
 .p-terminal {
+  background-color: $color-x-dark;
+  bottom: 0;
+  color: $color-x-light;
+  position: fixed;
+  transition: height 0.15s;
+  width: 100%;
+  z-index: z("delta");
+
   &,
   &__toggle {
     @include vf-animation(transform, brisk, ease-in-out);
@@ -18,16 +27,6 @@ $terminal-header-height: 40px;
     top: 0;
     width: 2rem;
   }
-
-  background-color: $color-x-dark;
-  bottom: 0;
-  color: $color-x-light;
-  position: fixed;
-  // Disable until connection issue fixed
-  // https://github.com/canonical-web-and-design/jaas-dashboard/issues/107
-  // transform: translateY(160px);
-  transition: height 0.15s;
-  width: 100%;
 
   &.is-visible {
     transform: translateY(0);


### PR DESCRIPTION
## Done

Set maximum terminal height on drag

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details page
- Drag terminal up
- See that it doesn't obscure page header

## Details

Fix #415

