### PR TITLE
Prevent body scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "^4.0.0",
     "vanilla-framework": "2.9.1",
-    "xterm": "4.4.0",
+    "xterm": "4.5.0",
     "xterm-addon-fit": "0.3.0"
   },
   "devDependencies": {

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -100,9 +100,6 @@ const Terminal = ({ address, modelName }) => {
       <div className="p-terminal__header">
         <span className="p-terminal__handle"></span>
         <span>Juju Terminal</span>
-        <div className="p-terminal__toggle">
-          <i className="p-icon--contextual-menu">Toggle Terminal visibility</i>
-        </div>
       </div>
       <div
         className="p-terminal__shell"

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -19,7 +19,7 @@ const Terminal = ({ address, modelName }) => {
 
   const fitAddonRef = useRef({ current: null });
 
-  const terminalHeaderHeight = 40; // px
+  const terminalheaderHeight = 40; // px
   const minimumTerminalHeight = 84; // px
   const modelDetailHeaderHeight = 42; // px
 
@@ -47,7 +47,7 @@ const Terminal = ({ address, modelName }) => {
       const viewPortHeight = window.innerHeight;
       const mousePosition = e.clientY;
       const newTerminalHeight =
-        viewPortHeight - mousePosition + terminalHeaderHeight;
+        viewPortHeight - mousePosition + terminalheaderHeight;
 
       const maximumTerminalHeight = viewPortHeight - modelDetailHeaderHeight;
       if (
@@ -104,7 +104,7 @@ const Terminal = ({ address, modelName }) => {
       <div
         className="p-terminal__shell"
         style={{
-          height: `${terminalHeight - terminalHeaderHeight}px`,
+          height: `${terminalHeight - terminalheaderHeight}px`,
         }}
         ref={terminalElement}
       ></div>

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -23,11 +23,11 @@ const Terminal = ({ address, modelName }) => {
   const minimumTerminalHeight = 84; // px
   const modelDetailHeaderHeight = 42; // px
 
+  // Prevent scrolling the main content area when scrolling the terminal
+  // that is position fixed.
   const handleWheel = function (e) {
-    if (e.target.closest(".p-terminal")) {
-      document.body.classList.add("u-overflow--hidden");
-    } else {
-      document.body.classList.remove("u-overflow--hidden");
+    if (e.target.classList.contains("xterm-cursor-layer")) {
+      e.preventDefault();
     }
   };
 

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -32,7 +32,7 @@ const Terminal = ({ address, modelName }) => {
   };
 
   useEffect(() => {
-    window.addEventListener("wheel", handleWheel);
+    window.addEventListener("wheel", handleWheel, { passive: false });
     // If the model name is found after a juju switch then
     // switch to that route.
     const switchFound = (model) => {

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -23,7 +23,16 @@ const Terminal = ({ address, modelName }) => {
   const minimumTerminalHeight = 84; // px
   const modelDetailHeaderHeight = 42; // px
 
+  const handleWheel = function (e) {
+    if (e.target.closest(".p-terminal")) {
+      document.body.classList.add("u-overflow--hidden");
+    } else {
+      document.body.classList.remove("u-overflow--hidden");
+    }
+  };
+
   useEffect(() => {
+    window.addEventListener("wheel", handleWheel);
     // If the model name is found after a juju switch then
     // switch to that route.
     const switchFound = (model) => {
@@ -77,6 +86,7 @@ const Terminal = ({ address, modelName }) => {
       // remove resize listener
       window.removeEventListener("mousedown", addResizeListener);
       window.removeEventListener("mouseup", removeResizeListener);
+      window.removeEventListener("wheel", handleWheel);
     };
     // Because the user can switch the model details UI from within the
     // component the `modelName` passed above will change as the UI

--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -26,7 +26,7 @@ const Terminal = ({ address, modelName }) => {
   // Prevent scrolling the main content area when scrolling the terminal
   // that is position fixed.
   const handleWheel = function (e) {
-    if (e.target.classList.contains("xterm-cursor-layer")) {
+    if (e.target.closest(".p-terminal")) {
       e.preventDefault();
     }
   };

--- a/src/components/Terminal/_terminal.scss
+++ b/src/components/Terminal/_terminal.scss
@@ -46,15 +46,6 @@ $terminal-header-height: 40px;
       pointer-events: none;
     }
   }
-
-  &__toggle {
-    text-align: center;
-    transform: rotate(180deg);
-
-    .is-visible & {
-      transform: rotate(0);
-    }
-  }
 }
 
 .xterm-screen {

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -17,10 +17,6 @@
   &--visible {
     overflow: visible;
   }
-
-  &--hidden {
-    overflow: hidden;
-  }
 }
 
 // Display overrides

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -17,6 +17,10 @@
   &--visible {
     overflow: visible;
   }
+
+  &--hidden {
+    overflow: hidden;
+  }
 }
 
 // Display overrides

--- a/yarn.lock
+++ b/yarn.lock
@@ -12627,10 +12627,10 @@ xterm-addon-fit@0.3.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.3.0.tgz#341710741027de9d648a9f84415a01ddfdbbe715"
   integrity sha512-kvkiqHVrnMXgyCH9Xn0BOBJ7XaWC/4BgpSWQy3SueqximgW630t/QOankgqkvk11iTOCwWdAY9DTyQBXUMN3lw==
 
-xterm@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0.tgz#5915d3c4c8800fadbcf555a0a603c672ab9df589"
-  integrity sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig==
+xterm@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.5.0.tgz#c7fd145c6cf91c9f2ef07011a9b35026cf4bfecc"
+  integrity sha512-4t12tsvtYnv13FBJwewddxdI/j4kSonmbQQv50j34R/rPIFbUNGtptbprmuUlTDAKvHLMDZ/Np2XcpNimga/HQ==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Done

- Bump xterm
- Remove redundant code
- Prevent body scroll when scrolling in the terminal

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details page
- Hover over terminal
- Scroll terminal and verify that model details table does not scroll also

## Details

Fixes #419 
