### PR TITLE
Fix memory leak on layout resize

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useSelector } from "react-redux";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 import classNames from "classnames";
@@ -15,14 +15,19 @@ const Layout = ({ children }) => {
   const sidebarCollapsible = useSelector(isSidebarCollapsible);
   const smallScreenBreakpoint = 1400;
   const isSmallScreen = screenWidth <= smallScreenBreakpoint ? true : false;
+  let isMounted = useRef(false);
 
   const handleScreenResize = () => {
-    setScreenWidth(getViewportWidth());
+    if (isMounted.current) {
+      setScreenWidth(getViewportWidth());
+    }
   };
 
   useEffect(() => {
+    isMounted.current = true;
     window.addEventListener("resize", debounce(handleScreenResize, 250));
     return () => {
+      isMounted.current = false;
       window.removeEventListener("resize", debounce(handleScreenResize, 250));
     };
   }, []);


### PR DESCRIPTION
## Done

Fix memory leak on layout resize

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Resize window
- Verify no console error about memory leaks

## Details

Fixes #417