### PR TITLE
Modify height calculation to avoid the terminal jumping when resizing

### DIFF
--- a/src/components/Terminal/Terminal.js
+++ b/src/components/Terminal/Terminal.js
@@ -11,6 +11,7 @@ import "./_terminal.scss";
 
 const Terminal = ({ address, modelName }) => {
   const terminalElement = useRef(null);
+  const resizeDeltaY = useRef(0);
   const macaroons = useSelector(getMacaroons);
   const history = useHistory();
 
@@ -56,7 +57,7 @@ const Terminal = ({ address, modelName }) => {
       const viewPortHeight = window.innerHeight;
       const mousePosition = e.clientY;
       const newTerminalHeight =
-        viewPortHeight - mousePosition + terminalheaderHeight;
+        viewPortHeight - mousePosition + resizeDeltaY.current;
 
       const maximumTerminalHeight = viewPortHeight - modelDetailHeaderHeight;
       if (
@@ -69,6 +70,7 @@ const Terminal = ({ address, modelName }) => {
 
     const addResizeListener = (e) => {
       if (e.target.classList.value === "p-terminal__header") {
+        resizeDeltaY.current = e.layerY;
         document.addEventListener("mousemove", resize);
       }
     };


### PR DESCRIPTION
## Done

Modify height calculation to avoid the terminal jumping when dragging to resize.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a model details page and click to drag the header. It should not jump up a bit to align the cursor with the top of the terminal
- Try clicking a few places in the header and dragging.
- You may notice that the cursor can 'slide' on the header if you move fast, this appears to be a browser issue around keeping the coordinates in sync.
- Try this resize in multiple browsers.

## Details

Fixes #427 
