### PR TITLE
Create a link to go back to the old GUI 

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -9,6 +9,7 @@ import { externalNavActive } from "ui/actions";
 import { isExternalNavActive } from "ui/selectors";
 
 import UserMenu from "components/UserMenu/UserMenu";
+import Modal from "@canonical/react-components/dist/components/Modal";
 
 // Image imports
 import logoMark from "static/images/logo/logo-mark.svg";
@@ -47,6 +48,7 @@ const pages = [
 
 const PrimaryNav = () => {
   const [activeLinkValue, setActiveLinkValue] = useState("");
+  const [showSwitchModal, setShowSwitchModal] = useState(false);
   const extNavActive = useSelector(isExternalNavActive);
   const { blocked } = useSelector(getGroupedModelStatusCounts);
   const location = useLocation();
@@ -78,6 +80,43 @@ const PrimaryNav = () => {
         "ext-nav-open": extNavActive,
       })}
     >
+      {showSwitchModal ? (
+        <Modal
+          close={() => setShowSwitchModal(false)}
+          title={"Switch back to the old Juju GUI"}
+        >
+          <p>
+            We're sorry to see you go, we would really appreciate it if you
+            could take a moment to tell us why you prefer the old GUI using the
+            methods below.
+          </p>
+          <p>
+            <a
+              className="p-list__link"
+              href="https://github.com/canonical-web-and-design/jaas-dashboard/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Create an issue on GitHub
+            </a>
+            <a
+              rel="noopener noreferrer"
+              target="_blank"
+              className="p-list__link"
+              href="#_"
+              onClick={(e) => {
+                e.preventDefault();
+                window.usabilla_live("click");
+              }}
+            >
+              Give feedback
+            </a>
+          </p>
+          <a href="https://jujucharms.com/new" className="p-button--neutral">
+            Click here to go back to the old Juju GUI
+          </a>
+        </Modal>
+      ) : null}
       <div className="p-primary-nav__header">
         <a href="https://jaas.ai" className="p-primary-nav__logo">
           <img
@@ -216,6 +255,17 @@ const PrimaryNav = () => {
             <span className="p-label--new">Alpha</span>
           </li>
         </ul>
+      </div>
+      <div className="p-primary-nav__bottom">
+        <li className="p-list__item">
+          <a
+            className="p-list__link"
+            href="#_"
+            onClick={() => setShowSwitchModal(true)}
+          >
+            Switch back to the old Juju GUI
+          </a>
+        </li>
       </div>
       <UserMenu />
     </nav>

--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -92,17 +92,17 @@ const PrimaryNav = () => {
           </p>
           <p>
             <a
-              className="p-list__link"
               href="https://github.com/canonical-web-and-design/jaas-dashboard/issues/new"
               target="_blank"
               rel="noopener noreferrer"
             >
               Create an issue on GitHub
             </a>
+          </p>
+          <p>
             <a
               rel="noopener noreferrer"
               target="_blank"
-              className="p-list__link"
               href="#_"
               onClick={(e) => {
                 e.preventDefault();
@@ -258,15 +258,17 @@ const PrimaryNav = () => {
       </div>
       {!isJuju ? (
         <div className="p-primary-nav__bottom">
-          <li className="p-list__item">
-            <a
-              className="p-list__link"
-              href="#_"
-              onClick={() => setShowSwitchModal(true)}
-            >
-              Switch back to the old Juju GUI
-            </a>
-          </li>
+          <ul className="p-list">
+            <li className="p-list__item">
+              <a
+                className="p-list__link"
+                href="#_"
+                onClick={() => setShowSwitchModal(true)}
+              >
+                Switch back to the old Juju GUI
+              </a>
+            </li>
+          </ul>
         </div>
       ) : null}
       <UserMenu />

--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -256,17 +256,19 @@ const PrimaryNav = () => {
           </li>
         </ul>
       </div>
-      <div className="p-primary-nav__bottom">
-        <li className="p-list__item">
-          <a
-            className="p-list__link"
-            href="#_"
-            onClick={() => setShowSwitchModal(true)}
-          >
-            Switch back to the old Juju GUI
-          </a>
-        </li>
-      </div>
+      {!isJuju ? (
+        <div className="p-primary-nav__bottom">
+          <li className="p-list__item">
+            <a
+              className="p-list__link"
+              href="#_"
+              onClick={() => setShowSwitchModal(true)}
+            >
+              Switch back to the old Juju GUI
+            </a>
+          </li>
+        </div>
+      ) : null}
       <UserMenu />
     </nav>
   );

--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -251,8 +251,8 @@ const PrimaryNav = () => {
             </a>
           </li>
           <li className="p-list__item">
-            <span className="version">Version 0.0.2</span>
-            <span className="p-label--new">Alpha</span>
+            <span className="version">Version 0.1.0</span>
+            <span className="p-label--new">Beta</span>
           </li>
         </ul>
       </div>

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -65,10 +65,6 @@
     }
   }
 
-  .p-modal .p-list__link {
-    display: block;
-  }
-
   .p-list__item {
     padding: 0;
 

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -22,14 +22,6 @@
     &__dialog {
       max-width: 400px;
     }
-
-    .p-list__link {
-      display: block;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
   }
 
   &__logo {
@@ -73,6 +65,10 @@
     }
   }
 
+  .p-modal .p-list__link {
+    display: block;
+  }
+
   .p-list__item {
     padding: 0;
 
@@ -100,6 +96,10 @@
       position: relative;
       top: 0.275rem;
     }
+  }
+
+  .p-modal .p-list__link:hover {
+    text-decoration: underline;
   }
 
   .p-primary-nav__bottom {

--- a/src/components/PrimaryNav/_primary-nav.scss
+++ b/src/components/PrimaryNav/_primary-nav.scss
@@ -11,8 +11,25 @@
 
   a,
   a:hover {
-    color: $color-light;
     text-decoration: none;
+  }
+
+  .p-modal {
+    // Temporary override for the 'back to old gui' popup.
+    position: fixed;
+    z-index: z("beta");
+
+    &__dialog {
+      max-width: 400px;
+    }
+
+    .p-list__link {
+      display: block;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   &__logo {


### PR DESCRIPTION
## Done

Added a link to the sidebar that opens a modal guiding users to the old GUI on JAAS. The link will only show up in JAAS unless we get confirmation that 2.8 will contain both UI's then we will expand this to handle that use case.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- You should see a link to switch back to the old GUI
- Click the link and a modal should pop up
- Click the link to the old GUI and it should work.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1167
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1172

## Screenshots

![Screen Shot 2020-04-22 at 1 36 45 PM](https://user-images.githubusercontent.com/532033/80025773-6b698c80-849e-11ea-968e-86b539f37c31.png)
![Screen Shot 2020-04-22 at 3 20 52 PM](https://user-images.githubusercontent.com/532033/80035234-f0f43900-84ac-11ea-9550-ac461e88a6ed.png)


