### PR TITLE
Release banner and beta label

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useSelector } from "react-redux";
+import Notification from "@canonical/react-components/dist/components/Notification/Notification";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 import classNames from "classnames";
 import useHover from "hooks/useHover";
@@ -49,7 +50,24 @@ const Layout = ({ children }) => {
         <PrimaryNav />
       </div>
       <main className="l-main" id="main-content">
-        {children}
+        <div data-test="main-children">{children}</div>
+        {!localStorage.getItem("release20_04") && (
+          <Notification
+            type="information"
+            close={() => {
+              localStorage.setItem("release20_04", true);
+            }}
+          >
+            Welcome the new JAAS Dashboard! This dashboard replaces the previous
+            Juju GUI here on jaas.ai and on your local Juju Controller from Juju
+            2.8.{" "}
+            <span className="u-hide--small">
+              Read more and join the discussion about this new product{" "}
+              <a href="#_">on Discourse</a>. We would love to hear your
+              feedback!
+            </span>
+          </Notification>
+        )}
       </main>
     </div>
   );

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -58,8 +58,8 @@ const Layout = ({ children }) => {
               localStorage.setItem("release20_04", true);
             }}
           >
-            Welcome the new JAAS Dashboard! This dashboard replaces the previous
-            Juju GUI here on jaas.ai and on your local Juju Controller from Juju
+            Welcome the new JAAS Dashboard! This dashboard is the replacement
+            for the Juju GUI in JAAS and individual Juju Controllers from Juju
             2.8.{" "}
             <span className="u-hide--small">
               Read more and join the discussion about this new product{" "}

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -29,8 +29,8 @@ describe("Layout", () => {
         </Router>
       </Provider>
     );
-    expect(wrapper.find("#main-content").html()).toStrictEqual(
-      `<main class="l-main" id="main-content">content</main>`
+    expect(wrapper.find("[data-test='main-children']").html()).toStrictEqual(
+      `<div data-test="main-children">content</div>`
     );
   });
 });

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -18,6 +18,20 @@
     padding-left: $sidebar-collapsed;
     width: 100vw;
   }
+
+  .p-notification--information {
+    bottom: 0;
+    margin: 0 1rem 1rem;
+    position: fixed;
+    width: calc(100vw - 18rem);
+    z-index: z("kappa");
+
+    @at-root {
+      .is-collapsed + .l-main .p-notification--information {
+        width: calc(100vw - 5rem);
+      }
+    }
+  }
 }
 
 .has-collapsible-sidebar .is-collapsed + .l-main {

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -41,6 +41,7 @@ $color-navigation-background: $color-brand;
 @include vf-p-table-sortable;
 @include vf-p-tooltips;
 @include vf-u-align;
+@include vf-u-hide;
 @include vf-u-layout;
 @include vf-p-switch;
 


### PR DESCRIPTION
## Done

- Add a notification to layout with dismissal persisting to cookie

Note: will add blog and discourse links when available

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify that release notification appears
- Dismiss notification
- Refresh page and notification should not appear again

<img width="1000" alt="Screenshot 2020-04-22 at 22 49 35" src="https://user-images.githubusercontent.com/505570/80037490-93cba800-84eb-11ea-99e6-a1f5010a8fd6.png">
