### PR TITLE
Do not munge class names to fix issues with jujulib names.

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -67,7 +67,7 @@ module.exports = function ({ env }) {
                     ],
                   },
                   // Added for profiling in devtools
-                  keep_classnames: isEnvProductionProfile,
+                  keep_classnames: true,
                   keep_fnames: true,
                   output: {
                     ecma: 5,


### PR DESCRIPTION
## Done

Due to how jujulib works it requires the class and function names to not be munged. This stops the munging of the class names but unfortunately bloating the size of the application. We will be rewriting how jujulib works in the near future so this is only a temporary setback.

## QA

No QA it'll need to be QA'd on staging.

