### PR TITLE
Add isProduction check for analytics

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,9 +15,10 @@ import { getConfig } from "app/selectors";
 import useLocalStorage from "hooks/useLocalStorage";
 
 function App() {
+  const isProduction = process.env.NODE_ENV === "production" ?? true;
   const { baseAppURL } = useSelector(getConfig);
   const [disableAnalytics] = useLocalStorage("disableAnalytics", false);
-  if (!disableAnalytics || disableAnalytics === "false") {
+  if (isProduction && (!disableAnalytics || disableAnalytics === "false")) {
     ReactGA.initialize("UA-1018242-68");
     ReactGA.pageview(window.location.href.replace(window.location.origin, ""));
   }

--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -3,7 +3,8 @@ import ReactGA from "react-ga";
 export default function useAnalytics() {
   return ({ path, category, action }) => {
     const disableAnalytics = localStorage.getItem("disableAnalytics");
-    if (disableAnalytics === "true") {
+    const isProduction = process.env.NODE_ENV === "production" ?? true;
+    if (!isProduction || disableAnalytics === "true") {
       return;
     }
 


### PR DESCRIPTION
## Done

Add `isProduction` check for analytics so that stats are not distorted by development

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Sanity check code
