### PR TITLE
Temporarily remove the terminal component from rendering.

### DIFF
--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -7,7 +7,6 @@ import cloneDeep from "clone-deep";
 import Filter from "components/Filter/Filter";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 import Layout from "components/Layout/Layout";
-import Terminal from "components/Terminal/Terminal";
 import Header from "components/Header/Header";
 
 import { getModelUUID, getModelStatus } from "app/selectors";
@@ -214,10 +213,6 @@ const ModelDetails = () => {
           </div>
         </div>
       </div>
-      <Terminal
-        address="wss://shell.jujugui.org:443/ws/"
-        modelName={modelName}
-      />
     </Layout>
   );
 };

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -8,11 +8,6 @@ import dataDump from "testing/complete-redux-store-dump";
 
 import ModelDetails from "./ModelDetails";
 
-jest.mock("components/Terminal/Terminal", () => {
-  const Terminal = () => <div className="terminal"></div>;
-  return Terminal;
-});
-
 jest.mock("components/Topology/Topology", () => {
   const Topology = () => <div className="topology"></div>;
   return Topology;
@@ -80,20 +75,6 @@ describe("ModelDetail Container", () => {
       </Provider>
     );
     expect(wrapper.find(".subordinate").length).toEqual(2);
-  });
-
-  it("renders the terminal", () => {
-    const store = mockStore(dataDump);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/test1"]}>
-          <TestRoute path="/models/*">
-            <ModelDetails />
-          </TestRoute>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Terminal").length).toBe(1);
   });
 
   it("clicking an application row filters the results", () => {


### PR DESCRIPTION
## Done

Temporarily remove the terminal component from rendering.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View one of the model details pages, no terminal should render.
