### PR TITLE
Send error to sentry if ErrorBoundary is triggered.

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import * as Sentry from "@sentry/browser";
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -14,15 +15,17 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, info) {
-    // Log to Sentry when enabled
-    console.log(error, info); // eslint-disable-line no-console
+    Sentry.withScope((scope) => {
+      scope.setExtras(info);
+      const eventId = Sentry.captureException(error);
+      this.setState({ eventId });
+    });
   }
 
   render() {
     const { hasError } = this.state;
     const { children } = this.props;
     if (hasError) {
-      // Render error notification
       return (
         <div className="p-notification--negative">
           <p className="p-notification__response">


### PR DESCRIPTION
## Done

Send error to sentry if ErrorBoundary is triggered.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- comment out the production check https://github.com/canonical-web-and-design/jaas-dashboard/blob/master/src/index.js#L31
- Add some code to throw an error `throw "foo"` in a react component and see that an error is sent.


