### PR TITLE
Generate release build tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 yarn-error.log
 /package-lock.json
 .DS_Store
+juju-dashboard*.tar.bz2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaas-dashboard",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A dashboard for JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"
@@ -16,9 +16,11 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "craco build",
+    "build": "craco build && yarn run generate-version-file",
     "clean": "./scripts/clean-files",
     "eslint-check": "eslint src/",
+    "generate-release-tarball": "yarn run build && ./scripts/generate-release-tarball",
+    "generate-version-file": "./scripts/generate-version-file",
     "lint": "yarn run eslint-check && yarn run prettier-check && yarn run stylelint-check",
     "prettier-check": "prettier --check 'src/**/*'",
     "serve": "yarn run start",

--- a/scripts/generate-release-tarball
+++ b/scripts/generate-release-tarball
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+VERSION=`npm version | grep jaas-dashboard | cut -d"'" -f4`
+
+tar -cjf juju-dashboard-$VERSION.tar.bz2 -C build .

--- a/scripts/generate-version-file
+++ b/scripts/generate-version-file
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+VERSION=`npm version | grep jaas-dashboard | cut -d"'" -f4`
+GIT_SHA=`git rev-parse HEAD`
+
+echo '{"version": "'$VERSION'", "git-sha": "'$GIT_SHA'"}' >> build/version.json


### PR DESCRIPTION
## Done

Generate a tarball that can be used in Juju and JAAS.

## QA

- Pull code
- Run `./run exec yarn run generate-release-tarball`
- Run `tar -ff juju-dashboard-0.1.1.tar.bz2

It should look like the build directory tar'd up.
