### PR TITLE
Handle non-admins accessing the Controller view

### DIFF
--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -17,6 +17,8 @@ import {
   isLoggedIn,
 } from "./selectors";
 
+import { userIsControllerAdmin } from "./utils";
+
 export default async function connectAndListModels(reduxStore, bakery) {
   try {
     const storeState = reduxStore.getState();
@@ -32,11 +34,13 @@ export default async function connectAndListModels(reduxStore, bakery) {
     reduxStore.dispatch(updateControllerConnection(conn));
     reduxStore.dispatch(updateJujuAPIInstance(juju));
     reduxStore.dispatch(updatePingerIntervalId(intervalId));
-    fetchControllerList(conn, reduxStore);
-    if (!isJuju) {
-      // This call will be a noop if the user isn't an administrator
-      // on the JIMM controller we're connected to.
-      disableControllerUUIDMasking(conn);
+    if (userIsControllerAdmin(conn)) {
+      fetchControllerList(conn, reduxStore);
+      if (!isJuju) {
+        // This call will be a noop if the user isn't an administrator
+        // on the JIMM controller we're connected to.
+        disableControllerUUIDMasking(conn);
+      }
     }
     do {
       await reduxStore.dispatch(fetchModelList());

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -450,6 +450,9 @@ export const isLoggedIn = (state) => {
   );
 };
 
+export const getControllerConnection = (state) =>
+  state?.root?.controllerConnection;
+
 export const isConnecting = (state) => !!state.root.visitURL;
 /**
   Returns the users current controller logged in identity

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -217,3 +217,8 @@ export const debounce = (fn, wait) => {
     t = setTimeout(() => fn.apply(this, arguments), wait);
   };
 };
+
+export const userIsControllerAdmin = (conn) => {
+  const controllerAccess = conn?.info?.user?.controllerAccess;
+  return ["superuser", "admin"].includes(controllerAccess);
+};

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -252,8 +252,10 @@ export async function fetchAllModelStatuses(conn, reduxStore) {
   @param {Object} reduxStore The applications reduxStore.
 */
 export async function fetchControllerList(conn, reduxStore) {
-  const response = await conn.facades.jimM.listControllers();
-  reduxStore.dispatch(updateControllerList(response.controllers));
+  if (conn.facades.jimM) {
+    const response = await conn.facades.jimM.listControllers();
+    reduxStore.dispatch(updateControllerList(response.controllers));
+  }
 }
 
 /**

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -3,14 +3,21 @@ import { useSelector } from "react-redux";
 
 import Layout from "components/Layout/Layout";
 import Header from "components/Header/Header";
+import Notification from "@canonical/react-components/dist/components/Notification/Notification";
 import MainTable from "@canonical/react-components/dist/components/MainTable/MainTable";
 
-import { getControllerData, getModelData } from "app/selectors";
+import {
+  getControllerConnection,
+  getControllerData,
+  getModelData,
+} from "app/selectors";
 import ControllersOverview from "./ControllerOverview/ControllerOverview";
+
+import { userIsControllerAdmin } from "../../app/utils";
 
 import "./_controllers.scss";
 
-export default function Controllers() {
+function Details() {
   const controllerData = useSelector(getControllerData);
   const modelData = useSelector(getModelData);
 
@@ -81,14 +88,32 @@ export default function Controllers() {
     }));
 
   return (
+    <>
+      <ControllersOverview />
+      <div className="l-controllers-table u-overflow--scroll">
+        <h5>Controller status</h5>
+        <MainTable headers={headers} rows={rows} />
+      </div>
+    </>
+  );
+}
+
+function NoAccess() {
+  return (
+    <Notification type="caution">
+      Sorry, you do not have permission to view this page, If you think that
+      this is in error, contact your administrator.
+    </Notification>
+  );
+}
+
+export default function Controllers() {
+  const conn = useSelector(getControllerConnection);
+  return (
     <Layout>
       <Header></Header>
       <div className="l-content controllers">
-        <ControllersOverview />
-        <div className="l-controllers-table u-overflow--scroll">
-          <h5>Controller status</h5>
-          <MainTable headers={headers} rows={rows} />
-        </div>
+        {userIsControllerAdmin(conn) ? <Details /> : <NoAccess />}
       </div>
     </Layout>
   );

--- a/src/pages/Controllers/Controllers.test.js
+++ b/src/pages/Controllers/Controllers.test.js
@@ -58,4 +58,19 @@ describe("Controllers table", () => {
     );
     expect(wrapper.find("tbody tr").get(0)).toMatchSnapshot();
   });
+
+  it("renders a warning if you do not have access", () => {
+    dataDump.root.controllerConnection.info.user.controllerAccess = "";
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <MemoryRouter>
+        <Provider store={store}>
+          <Controllers />
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(
+      wrapper.find('Notification[type="caution"]').text()
+    ).toMatchSnapshot();
+  });
 });

--- a/src/pages/Controllers/__snapshots__/Controllers.test.js.snap
+++ b/src/pages/Controllers/__snapshots__/Controllers.test.js.snap
@@ -42,3 +42,5 @@ exports[`Controllers table counts models, machines, apps, and units 1`] = `
   </TableCell>
 </tr>
 `;
+
+exports[`Controllers table renders a warning if you do not have access 1`] = `"Sorry, you do not have permission to view this page, If you think that this is in error, contact your administrator."`;

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -36,7 +36,7 @@ export default {
         user: {
           displayName: 'activedev',
           identity: 'user-activedev@external',
-          controllerAccess: '',
+          controllerAccess: 'superuser',
           modelAccess: ''
         }
       },


### PR DESCRIPTION
## Done

If a user is not an administrator on the controller then do not try and request the controller data. 
If a non-admin tries to view the controller page then show a warning.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/

JAAS
- View the controller page, you should see a warning like below as you're connected to public JAAS.

Self-Bootstrap
- `juju bootstrap localhost`.
- Access the existing GUI and accept the self-signed cert `juju gui`.
- Then modify `config.js` to point to your new controller `baseControllerURL: "10.123.321.1:17070",`
- Open the Dashboard and enter the credentials from the above `juju gui` command.
- View the controller page, it should show a controller view without data, but no warning. The data for this view on a self-bootstrap is coming next.

## Details

Fixes #462 

## Screenshots

![Screen Shot 2020-05-13 at 4 39 40 PM](https://user-images.githubusercontent.com/532033/81873209-79a84700-9538-11ea-97dd-37091e852e69.png)

