### PR TITLE
Show the version number and beta label in Juju.

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -258,33 +258,33 @@ const PrimaryNav = () => {
               Give feedback
             </a>
           </li>
+          {!isJuju ? (
+            <li className="p-list__item">
+              <a
+                className="p-list__link"
+                href="#_"
+                onClick={() => {
+                  sendAnalytics({
+                    category: "User",
+                    action: "Clicked 'Switch back to old GUI' link",
+                  });
+                  setShowSwitchModal(true);
+                }}
+              >
+                Switch back to the old Juju GUI
+              </a>
+            </li>
+          ) : null}
+        </ul>
+      </div>
+      <div className="p-primary-nav__bottom">
+        <ul className="p-list">
           <li className="p-list__item">
-            <a
-              className="p-list__link"
-              href="#_"
-              onClick={() => {
-                sendAnalytics({
-                  category: "User",
-                  action: "Clicked 'Switch back to old GUI' link",
-                });
-                setShowSwitchModal(true);
-              }}
-            >
-              Switch back to the old Juju GUI
-            </a>
+            <span className="version">Version {appVersion}</span>
+            <span className="p-label--new">Beta</span>
           </li>
         </ul>
       </div>
-      {!isJuju ? (
-        <div className="p-primary-nav__bottom">
-          <ul className="p-list">
-            <li className="p-list__item">
-              <span className="version">Version {appVersion}</span>
-              <span className="p-label--new">Beta</span>
-            </li>
-          </ul>
-        </div>
-      ) : null}
       <UserMenu />
     </nav>
   );


### PR DESCRIPTION
## Done

Show the version number and beta label when running in a Juju controller.
Hide the 'switch back to the GUI' when running in a Juju controller.

## QA

QA requires a build of Juju from a certain branch, best to wait until that gets merged into `develop` and an rc is cut.

