### PR TITLE
fix: Correct model detail double padding

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -3,7 +3,7 @@
 @import "../../scss/functions/z-index";
 
 .info-panel {
-  padding: 1rem;
+  padding: 1rem 0;
 
   @media (min-width: $breakpoint-small) {
     display: grid;

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -8,6 +8,7 @@
   padding-bottom: 14rem;
 
   @media (min-width: $breakpoint-medium) {
+    gap: 1rem;
     grid-template-columns: 230px 1fr;
   }
 


### PR DESCRIPTION
## Done

[Fix] Correct model detail double padding

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to details page - check the padding

## Details

#488 

## Screenshots

<img width="920" alt="Screenshot 2020-05-20 at 16 32 10" src="https://user-images.githubusercontent.com/505570/82465709-7d4b4900-9ab7-11ea-93a4-5501443ea0c9.png">
