### PR TITLE
fix: Stop notification overlaying sidebar

### DIFF
--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -24,10 +24,12 @@
     margin: 0 1rem 1rem;
     position: fixed;
     width: calc(100vw - 18rem);
-    z-index: z("kappa");
+    z-index: z("iota");
 
     @at-root {
-      .is-collapsed + .l-main .p-notification--information {
+      /* prettier-ignore */
+      .is-collapsed + .l-main .p-notification--information,
+      .has-collapsible-sidebar :not(.is-collapsed) + .l-main .p-notification--information {
         width: calc(100vw - 5rem);
       }
     }


### PR DESCRIPTION
## Done

(fix) Stop notification overlaying sidebar

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Do not dismiss release notification
- Browse /models and /model-details pages at small and wide resolutions

## Details

Fixes #492



