### PR TITLE
fix(model details): remove redundant table header

### DIFF
--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -42,7 +42,6 @@ export const relationTableHeaders = [
   { content: "requirer" },
   { content: "interface" },
   { content: "type" },
-  { content: "message" },
 ];
 
 export function generateIconImg(name, namespace) {

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -3,8 +3,12 @@
   text-transform: capitalize;
 
   // Capitalise only the first letter of a string
-  &--first-letter::first-letter {
-    text-transform: uppercase;
+  &--first-letter {
+    display: inline-block;
+
+    &::first-letter {
+      text-transform: uppercase;
+    }
   }
 }
 


### PR DESCRIPTION
@hatched I removed this header as there is no content being generated for the column - correct?

## Done

(fix) Remove redundant table header
(fix) Correct first letter capitalisation util 

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View model details page for model with relations info
- View relations table and verify headers match columns

## Details

Fixes #486