### PR TITLE
(style) Align filter tags to filter menu

### DIFF
--- a/src/components/FilterTags/_filter-tags.scss
+++ b/src/components/FilterTags/_filter-tags.scss
@@ -80,7 +80,7 @@
     &__item {
       display: inline-block;
       font-size: 0.875rem;
-      margin-left: 0.5rem;
+      margin-right: 0.5rem;
       padding: 0;
     }
 


### PR DESCRIPTION
## Done

(fix) Align filter tags to filter menu

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Open filter menu and verify alignment

## Details

Fixes #484

## Screenshots

<img width="742" alt="Screenshot 2020-05-21 at 10 32 21" src="https://user-images.githubusercontent.com/505570/82545423-90f5be80-9b4e-11ea-9558-6b444bbd0744.png">

