### PR TITLE
fix(model details): Prevent entity icons from expanding to height of table row

### DIFF
--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -123,8 +123,10 @@
 
   .entity-icon {
     border-radius: 50%;
+    height: 1.5rem;
     margin-right: 0.5rem;
     position: relative;
+    width: 1.5rem;
   }
 }
 


### PR DESCRIPTION
## Done

(fix) Prevent entity icons from expanding to the height of table row

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to the model details page
- Verify all icons are the same size and there are no squircles

## Details

Fixes #449
