### PR TITLE
fix(model details): correctly display the modelName in the expanded model topology view

### DIFF
--- a/src/components/InfoPanel/InfoPanel.js
+++ b/src/components/InfoPanel/InfoPanel.js
@@ -66,7 +66,7 @@ const InfoPanel = () => {
       {showExpandedTopology ? (
         <Modal
           close={() => setShowExpandedTopology(false)}
-          title={modelName.split("/")[1] || "Error: model not loaded..."}
+          title={modelName.split("/")[1] || modelName}
           data-test="topology-modal"
         >
           <Topology width={width} height={height} modelData={modelStatusData} />


### PR DESCRIPTION
## Done

(fix) Fall back to modelName if cannot split on slash -this prevents an erroneous "Model not loaded" message from appearing

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details pages, expand topologies and verify the title of the model appears correctly

## Details

Fixes #500 
