### PR TITLE
feat(controllers): show controller data on controller page for single controller environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaas-dashboard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A dashboard for JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@canonical/jaaslib": "0.6.0",
-    "@canonical/jujulib": "1.3.1",
+    "@canonical/jujulib": "1.3.2",
     "@canonical/macaroon-bakery": "0.3.0",
     "@canonical/react-components": "0.7.0",
     "@craco/craco": "5.6.4",

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -1,3 +1,5 @@
+import cloneDeep from "clone-deep";
+
 import { fetchAndStoreModelStatus } from "juju";
 
 // Action labels
@@ -99,5 +101,27 @@ export function fetchModelStatus(modelUUID) {
       return;
     }
     fetchAndStoreModelStatus(modelUUID, dispatch, getState);
+  };
+}
+
+/**
+  Updates the correct controller entry with a cloud and region fetched from
+  the supplied model info call.
+  @param {String} modelInfo The response from a modelInfo call.
+*/
+export function addControllerCloudRegion(modelInfo) {
+  return async function addControllerCloudRegion(dispatch, getState) {
+    const controllers = getState()?.juju?.controllers;
+    const model = modelInfo.results[0].result;
+    const updatedControllers = cloneDeep(controllers).map((controller) => {
+      if (controller.uuid === model.controllerUuid) {
+        controller.location = {
+          cloud: model.cloudRegion,
+          region: model.cloudTag.replace("cloud-", ""),
+        };
+      }
+      return controller;
+    });
+    dispatch(updateControllerList(updatedControllers));
   };
 }

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -74,18 +74,24 @@ function Details() {
 
   const rows =
     controllerMap &&
-    Object.values(controllerMap).map((c) => ({
-      columns: [
-        { content: c.path },
-        { content: `${c.location.cloud}/${c.location.region}` },
-        { content: c.models, className: "u-align--right" },
-        { content: c.machines, className: "u-align--right" },
-        { content: c.applications, className: "u-align--right" },
-        { content: c.units, className: "u-align--right" },
-        { content: c.version, className: "u-align--right" },
-        { content: `${c.Public}`, className: "u-align--right u-capitalise" },
-      ],
-    }));
+    Object.values(controllerMap).map((c) => {
+      const cloud = c?.location?.cloud || "unknown";
+      const region = c?.location?.region || "unknown";
+      const cloudRegion = `${cloud}/${region}`;
+      const publicAccess = c?.Public || "False";
+      return {
+        columns: [
+          { content: c.path },
+          { content: cloudRegion },
+          { content: c.models, className: "u-align--right" },
+          { content: c.machines, className: "u-align--right" },
+          { content: c.applications, className: "u-align--right" },
+          { content: c.units, className: "u-align--right" },
+          { content: c.version, className: "u-align--right" },
+          { content: publicAccess, className: "u-align--right u-capitalise" },
+        ],
+      };
+    });
 
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,10 +944,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.0.tgz#7b77ff0a6899a2e58adc1b2077d8971de019047b"
   integrity sha512-3x0DmeFP1Fu/JPT9Sn/vJcNbCI5QSMmwF4rHIH7N/3T/KxwI1dK+gjv8djOFAe3UD8wVbFNwlhOpuhdg+2A+VQ==
 
-"@canonical/jujulib@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-1.3.1.tgz#aa740ab3232c832216f92f58f505ecf30f591364"
-  integrity sha512-JzI2GkUBueq+i3Fsmdua5bQccBvNNXDPTnBpStpTLX//ALJU7i9U6eHPCoWP52PCCkYXeyCyS7kreDZgc9A26g==
+"@canonical/jujulib@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-1.3.2.tgz#57fb140d50cdf10b331f44bc9839f89cb8c109fa"
+  integrity sha512-QePq8GLdh5f081F4F0N+usN3LJE3bE2FGT5Nm6gtIUE64VVKUwaUo8WtcCqFxTfOS2HZeLxoky0Fc4B1wx6h5w==
 
 "@canonical/macaroon-bakery@0.3.0":
   version "0.3.0"


### PR DESCRIPTION
## Done

When viewing the controller details page for a Juju bootstrapped environment show the controller information.

## QA

- Bootstrap a juju environment on a public cloud using the rc-2 snap.
- Run `juju dashboard` and accept the self-signed cert warnings.
- Close that tab.
- Pull code
- Edit `config.js` 
  - `baseControllerURL` points to the ip:port value outputted in the above `juju dashboard` command.
  - 'identityProviderAvailable' is `false`.
  - `isJuju` is `true`.
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View the controller details page. You should see content similar to the screenshot below.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1272

## Screenshots

<img width="1680" alt="Screen Shot 2020-05-21 at 1 28 53 PM" src="https://user-images.githubusercontent.com/532033/82600070-86492280-9b6a-11ea-8f36-0df81de332b9.png">

