### PR TITLE
fix(style): remove small gap between thead and tbody

### DIFF
--- a/src/scss/custom/_tables.scss
+++ b/src/scss/custom/_tables.scss
@@ -1,6 +1,13 @@
 // Site-wide Vanilla table overrides
 table {
   min-width: 900px;
+
+  // XXX Ant: 21.05.2020 - Unset the thead after which is causing a gap on
+  // first render. Can be removed when the following issue is resolved:
+  // https://github.com/canonical-web-and-design/vanilla-framework/issues/3087
+  thead::after {
+    content: none;
+  }
 }
 
 th,


### PR DESCRIPTION
## Done
- Reset content on thead after which resolved the extra space.

## QA
- Pull code
- Open http://0.0.0.0:8036/
- Check that the space in the issue is not there anymore

## Details
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1166

## Screenshots
On first load:
![image](https://user-images.githubusercontent.com/1413534/82604869-dd6fe700-9bac-11ea-97b3-dcdf4359f4b1.png)

