### PR TITLE
Render any login error messages.

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -13,6 +13,7 @@ export const actionsList = {
   logOut: "LOG_OUT",
   storeBakery: "STORE_BAKERY",
   storeConfig: "STORE_CONFIG",
+  storeLoginError: "STORE_LOGIN_ERROR",
   storeUserPass: "STORE_USER_PASS",
   storeVersion: "STORE_VERSION",
   storeVisitURL: "STORE_VISIT_URL",
@@ -41,6 +42,16 @@ export function storeConfig(config) {
   return {
     type: actionsList.storeConfig,
     payload: config,
+  };
+}
+
+/**
+  @param {String} error The error message to store.
+*/
+export function storeLoginError(error) {
+  return {
+    type: actionsList.storeLoginError,
+    payload: error,
   };
 }
 

--- a/src/app/check-auth.js
+++ b/src/app/check-auth.js
@@ -6,6 +6,7 @@ import { isLoggedIn } from "app/selectors";
 
 const actionWhitelist = [
   "STORE_BAKERY",
+  "STORE_LOGIN_ERROR",
   "STORE_CONFIG",
   "STORE_USER_PASS",
   "STORE_VERSION",

--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -6,6 +6,7 @@ import {
 } from "juju";
 import { fetchModelList } from "juju/actions";
 import {
+  storeLoginError,
   updateControllerConnection,
   updateJujuAPIInstance,
   updatePingerIntervalId,
@@ -25,12 +26,16 @@ export default async function connectAndListModels(reduxStore, bakery) {
     const credentials = getUserPass(storeState);
     const { identityProviderAvailable, isJuju } = getConfig(storeState);
     const wsControllerURL = getWSControllerURL(storeState);
-    const { conn, juju, intervalId } = await loginWithBakery(
+    const { conn, error, juju, intervalId } = await loginWithBakery(
       wsControllerURL,
       credentials,
       bakery,
       identityProviderAvailable
     );
+    if (error) {
+      reduxStore.dispatch(storeLoginError(error));
+      return;
+    }
     reduxStore.dispatch(updateControllerConnection(conn));
     reduxStore.dispatch(updateJujuAPIInstance(juju));
     reduxStore.dispatch(updatePingerIntervalId(intervalId));

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -14,6 +14,9 @@ function rootReducer(state = {}, action) {
       case actionsList.storeConfig:
         draftState.config = action.payload;
         break;
+      case actionsList.storeLoginError:
+        draftState.loginError = action.payload;
+        break;
       case actionsList.storeUserPass:
         draftState.credentials = action.payload;
         break;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -73,6 +73,13 @@ export const getUserPass = (state) => {
 };
 
 /**
+  Fetches a login error from state
+  @param {Object} state The application state.
+  @returns {String|Undefined} The error message if any.
+*/
+export const getLoginError = (state) => state?.root?.loginError;
+
+/**
   Fetches the juju api instance from state.
   @param {Object} state The application state.
   @returns {Object|Null} The juju api instance or null if none found.

--- a/src/components/LogIn/LogIn.js
+++ b/src/components/LogIn/LogIn.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector, useStore } from "react-redux";
-import { isLoggedIn, getBakery, getConfig } from "app/selectors";
+import { isLoggedIn, getBakery, getConfig, getLoginError } from "app/selectors";
 import { connectAndStartPolling, storeUserPass } from "app/actions";
 
 import Spinner from "@canonical/react-components/dist/components/Spinner";
@@ -12,6 +12,7 @@ import "./_login.scss";
 export default function LogIn({ children }) {
   const { identityProviderAvailable } = useSelector(getConfig);
   const userIsLoggedIn = useSelector(isLoggedIn);
+  const loginError = useSelector(getLoginError);
 
   if (!userIsLoggedIn) {
     return (
@@ -24,6 +25,7 @@ export default function LogIn({ children }) {
             ) : (
               <UserPassForm />
             )}
+            {generateErrorMessage(loginError)}
           </div>
         </div>
         <main>{children}</main>
@@ -31,6 +33,31 @@ export default function LogIn({ children }) {
     );
   }
   return children;
+}
+
+/**
+  Generates the necessary elements to render the error message.
+  @param {String} loginError The error message from the store.
+  @returns {Object} A component for the error message.
+*/
+function generateErrorMessage(loginError) {
+  if (!loginError) {
+    return null;
+  }
+  let loginErrorMessage = null;
+  switch (loginError) {
+    case '"user-" is not a valid user tag':
+      loginErrorMessage = "Invalid user name";
+      break;
+    default:
+      loginErrorMessage = loginError;
+  }
+  return (
+    <p className="error-message">
+      <i className="p-icon--error" />
+      {loginErrorMessage}
+    </p>
+  );
 }
 
 function IdentityProviderForm() {

--- a/src/components/LogIn/LogIn.test.js
+++ b/src/components/LogIn/LogIn.test.js
@@ -66,4 +66,23 @@ describe("LogIn", () => {
     expect(wrapper.find("LogIn main").text()).toBe("App content");
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("renders a login error if one exists", () => {
+    const store = mockStore({
+      root: {
+        loginError: "Invalid user name",
+        config: {
+          identityProviderAvailable: false,
+        },
+      },
+    });
+    const wrapper = mount(
+      <Provider store={store}>
+        <LogIn>App content</LogIn>
+      </Provider>
+    );
+    expect(wrapper.find("LogIn .error-message").text()).toBe(
+      "Invalid user name"
+    );
+  });
 });

--- a/src/components/LogIn/_login.scss
+++ b/src/components/LogIn/_login.scss
@@ -27,6 +27,14 @@
     .p-icon--spinner {
       top: -2px;
     }
+
+    .error-message {
+      margin-top: 0.5rem;
+
+      .p-icon--error {
+        margin-right: 0.5rem;
+      }
+    }
   }
 
   &__logo {

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -85,7 +85,13 @@ export async function loginWithBakery(
     credentials,
     identityProviderAvailable
   );
-  const conn = await juju.login(loginParams);
+  let conn = null;
+  try {
+    conn = await juju.login(loginParams);
+  } catch (error) {
+    return { error };
+  }
+
   // Ping to keep the connection alive.
   const intervalId = setInterval(() => {
     conn.facades.pinger.ping();


### PR DESCRIPTION
## Done

If there is an error message when logging in via the user/pass dialog then render that error.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Install the juju 2.8-rc2 snap
- `juju bootstrap` into a public cloud
- `juju dashboard` and connect to that dashboard to accept the self-signed cert.
  - take note of the ip address and u/p
- Open config.js and change: 
  - `baseControllerURL` to the ip address and port (if any) from above.
  - `isJuju` to `true`
  - `identityProviderAvailable` to `false`
- Open http://0.0.0.0:8036/
- Submit the form with an invalid username and password.
- Use the above u/p to log in successfully. 

## Details

Fixes #388 

## Screenshots

<img width="308" alt="Screen Shot 2020-05-25 at 9 08 26 AM" src="https://user-images.githubusercontent.com/532033/82825637-d2e17600-9e68-11ea-8e6a-6e823b83eb04.png">
<img width="299" alt="Screen Shot 2020-05-25 at 9 08 37 AM" src="https://user-images.githubusercontent.com/532033/82825639-d37a0c80-9e68-11ea-9b21-46bef30003f2.png">

