### PR TITLE
Topology no longer tries to render applications that don't exist.

### DIFF
--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -152,8 +152,19 @@ export default ({ modelData, width, height }) => {
       return acc;
     }, []);
   // Remove any duplicate endpoints and split into pairs.
-  const relations = [...new Set(endpoints)].map((pair) => pair.split(":"));
-
+  const deDupedRelations = [...new Set(endpoints)].map((pair) =>
+    pair.split(":")
+  );
+  // Remove relations that do not have all applications in the map.
+  // The missing application is likely a cross-model-relation which isn't
+  // fully supported yet.
+  // https://github.com/canonical-web-and-design/jaas-dashboard/issues/526
+  const applicationNames = applications.map((app) => app.name);
+  const relations = deDupedRelations.filter(
+    (relation) =>
+      applicationNames.includes(relation[0]) &&
+      applicationNames.includes(relation[1])
+  );
   useEffect(() => {
     const topo = d3
       .select(ref.current)


### PR DESCRIPTION
## Done

The topology no longer tries to render applications that don't exist from a cross model relation. This is a temporary fix until cross model relations are fully supported in the dashboard.

## QA

- Install the juju 2.8-rc2 snap
- `juju bootstrap` into a public cloud
- `juju dashboard` and connect to that dashboard to accept the self-signed cert.
  - take note of the ip address and u/p
- Follow the deployment steps in #526 
- Open config.js and change: 
  - `baseControllerURL` to the ip address and port (if any) from above.
  - `isJuju` to `true`
  - `identityProviderAvailable` to `false`
- `./run`
- Open http://0.0.0.0:8036/
- You should be able to view the details page for all your models.

## Details

Fixes #526 

## Screenshots

<img width="1670" alt="Screen Shot 2020-05-28 at 8 29 13 PM" src="https://user-images.githubusercontent.com/532033/83214727-82953d00-a122-11ea-8641-58f63ea611d7.png">

