### PR TITLE
Use agent status instead of instance status in machine table

### DIFF
--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -259,15 +259,15 @@ export function generateMachineRows(modelStatusData, filterByApp) {
           ),
         },
         {
-          content: generateStatusElement(machine.instanceStatus.status),
+          content: generateStatusElement(machine.agentStatus.status),
           className: "u-capitalise",
         },
         { content: splitParts(machine.hardware)["availability-zone"] },
         { content: machine.instanceId },
         {
           content: (
-            <span title={machine.instanceStatus.info}>
-              {machine.instanceStatus.info}
+            <span title={machine.agentStatus.info}>
+              {machine.agentStatus.info}
             </span>
           ),
           className: "u-truncate",

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -12,6 +12,7 @@
   }
 
   &.is-provisioning,
+  &.is-down,
   &.is-error,
   &.is-blocked {
     &::before {
@@ -21,6 +22,8 @@
 
   &.is-maintenance,
   &.is-attention,
+  &.is-stopped,
+  &.is-pending,
   &.is-alert,
   &.is-waiting {
     &::before {
@@ -29,6 +32,7 @@
   }
 
   &.is-running,
+  &.is-started,
   &.is-active {
     &::before {
       color: $color-mid-light;


### PR DESCRIPTION
## Done

The machine table now uses the agent status instead of instance status to make it more Juju-centric and provide clearer error messaging. The upcoming machine view will have the instance status data to provide a full picture.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View the model details of a few models in error, alert, running to see the different values for this table.
- Add a unit to an application and watch the statuses update(depending on the provider and update cycles you may miss some if they go fast).

## Details

Fixes #305

## Screenshots

![Screen Shot 2020-06-01 at 1 25 23 PM](https://user-images.githubusercontent.com/532033/83446885-bd41f280-a40c-11ea-8dc2-af0b15a9efed.png)
![Screen Shot 2020-06-01 at 1 27 18 PM](https://user-images.githubusercontent.com/532033/83446887-bd41f280-a40c-11ea-80d2-0d8eb606ae27.png)

