### PR TITLE
Set a `unitCount` value per application when filtering in model details

### DIFF
--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -32,59 +32,69 @@ import "./_model-details.scss";
   @param {String} appName The name of the application to filter the data by.
 */
 const filterModelStatusData = (modelStatusData, appName) => {
-  if (!modelStatusData || appName === "") {
-    return modelStatusData;
-  }
-  const filteredData = cloneDeep(modelStatusData);
-  const application = filteredData.applications[appName];
-  // remove the units from the application objects that are not
-  // the filter-by app.
-  const subordinateTo = application.subordinateTo || [];
-  Object.keys(filteredData.applications).forEach((key) => {
-    if (key !== appName && !subordinateTo.includes(key)) {
-      filteredData.applications[key].units = {};
+  if (modelStatusData) {
+    const filteredData = cloneDeep(modelStatusData);
+    Object.keys(filteredData.applications).forEach((key) => {
+      filteredData.applications[key].unitsCount = Object.keys(
+        filteredData.applications[key].units
+      ).length;
+    });
+    if (appName === "") {
+      return filteredData;
     }
-  });
-  // Loop through all of the units of the remaining applications that are
-  // listed in the subordinateTo list. This is done because although
-  // a subordinate is supposed to be installed on each unit, that's not
-  // always the case.
-  subordinateTo.forEach((parentName) => {
-    const units = filteredData.applications[parentName].units;
-    Object.entries(units).forEach((entry) => {
-      const found = Object.entries(entry[1].subordinates).find(
-        (ele) => ele[0].split("/")[0] === appName
-      );
-      if (!found) {
-        delete units[entry[0]];
+
+    const application = filteredData.applications[appName];
+    // remove the units from the application objects that are not
+    // the filter-by app.
+    const subordinateTo = application.subordinateTo || [];
+    Object.keys(filteredData.applications).forEach((key) => {
+      if (key !== appName && !subordinateTo.includes(key)) {
+        filteredData.applications[key].units = {};
       }
     });
-  });
+    // Loop through all of the units of the remaining applications that are
+    // listed in the subordinateTo list. This is done because although
+    // a subordinate is supposed to be installed on each unit, that's not
+    // always the case.
+    subordinateTo.forEach((parentName) => {
+      const units = filteredData.applications[parentName].units;
+      Object.entries(units).forEach((entry) => {
+        const found = Object.entries(entry[1].subordinates).find(
+          (ele) => ele[0].split("/")[0] === appName
+        );
+        if (!found) {
+          delete units[entry[0]];
+        }
+      });
+    });
 
-  // Remove all the machines that the selected application isn't installed on.
-  const appMachines = new Set();
-  for (let unitId in application.units) {
-    const unit = application.units[unitId];
-    appMachines.add(unit.machine);
-  }
-  subordinateTo.forEach((subAppName) => {
-    // this will be the parent of the subordinate and grab the machines from it
-    const parent = filteredData.applications[subAppName];
-    for (let unitId in parent.units) {
-      const unit = parent.units[unitId];
+    // Remove all the machines that the selected application isn't installed on.
+    const appMachines = new Set();
+    for (let unitId in application.units) {
+      const unit = application.units[unitId];
       appMachines.add(unit.machine);
     }
-  });
-  for (let machineId in filteredData.machines) {
-    if (!appMachines.has(machineId)) delete filteredData.machines[machineId];
+    subordinateTo.forEach((subAppName) => {
+      // this will be the parent of the subordinate and grab the machines from it
+      const parent = filteredData.applications[subAppName];
+      for (let unitId in parent.units) {
+        const unit = parent.units[unitId];
+        appMachines.add(unit.machine);
+      }
+    });
+    for (let machineId in filteredData.machines) {
+      if (!appMachines.has(machineId)) delete filteredData.machines[machineId];
+    }
+
+    // Remove all relations that don't involve the selected application.
+    filteredData.relations = modelStatusData.relations.filter(
+      (relation) => relation.key.indexOf(appName) > -1
+    );
+
+    return filteredData;
+  } else {
+    return modelStatusData;
   }
-
-  // Remove all relations that don't involve the selected application.
-  filteredData.relations = modelStatusData.relations.filter(
-    (relation) => relation.key.indexOf(appName) > -1
-  );
-
-  return filteredData;
 };
 
 const ModelDetails = () => {

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -235,4 +235,27 @@ describe("ModelDetail Container", () => {
       wrapper.find(".model-details__apps tr[data-app='cockroachdb']").length
     ).toBe(1);
   });
+
+  it("displays the correct scale value", () => {
+    const store = mockStore(dataDump);
+    const testApp = "kibana";
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/new-search-aggregate"]}>
+          <TestRoute path="/models/*">
+            <ModelDetails />
+          </TestRoute>
+        </MemoryRouter>
+      </Provider>
+    );
+    const applicationRow = wrapper.find(`tr[data-app="${testApp}"]`);
+    expect(applicationRow.find("td[data-test-column='scale']").text()).toBe(
+      "1"
+    );
+    // Filtering the tables shouldn't effect the scale count
+    applicationRow.simulate("click");
+    expect(applicationRow.find("td[data-test-column='scale']").text()).toBe(
+      "1"
+    );
+  });
 });

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -109,25 +109,36 @@ export function generateApplicationRows(
     return {
       columns: [
         {
+          "data-test-column": "name",
           content: generateEntityLink(app.charm || "", key, false, baseAppURL),
           className: "u-truncate",
         },
         {
+          "data-test-column": "status",
           content: app.status ? generateStatusElement(app.status.status) : "-",
           className: "u-capitalise u-truncate",
         },
-        { content: app.workloadVersion || "-", className: "u-align--right" },
         {
+          "data-test-column": "version",
+          content: app.workloadVersion || "-",
+          className: "u-align--right",
+        },
+        {
+          "data-test-column": "scale",
           content: app.unitsCount,
           className: "u-align--right",
         },
-        { content: "CharmHub" },
         {
+          "data-test-column": "store",
+          content: "CharmHub",
+        },
+        {
+          "data-test-column": "revision",
           content: extractRevisionNumber(app.charm) || "-",
           className: "u-align--right",
         },
-        { content: "Ubuntu" },
-        { content: "-" },
+        { "data-test-column": "os", content: "Ubuntu" },
+        { "data-test-column": "notes", content: "-" },
       ],
       className: filterByApp === key ? "is-selected" : "",
       onClick: onRowClick,

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -118,7 +118,7 @@ export function generateApplicationRows(
         },
         { content: app.workloadVersion || "-", className: "u-align--right" },
         {
-          content: Object.keys(app.units || {}).length,
+          content: app.unitsCount,
           className: "u-align--right",
         },
         { content: "CharmHub" },


### PR DESCRIPTION
## Done
- Set a `unitCount` value per application when filtering to render the correct scaling value even if filtered out
- Added data attributes to table cells for testing

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go into a model details page and check the scale values on in the application table are correct
- Click on an application to filter it
- See that the scaling counts on all application remains correct

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/543

## Screenshots

| Not filtered  | Filter application with units | Filter application without units
| ------------- | ------------- | ------------- |
| 
![Screenshot_2020-06-03 JAAS Dashboard](https://user-images.githubusercontent.com/1413534/83692803-993d0780-a5ec-11ea-8774-521c750ecfd3.png)
  | 
![Screenshot_2020-06-03 JAAS Dashboard(1)](https://user-images.githubusercontent.com/1413534/83692817-9e9a5200-a5ec-11ea-90e8-d39856d37dfa.png)
  | 
![Screenshot_2020-06-03 JAAS Dashboard(2)](https://user-images.githubusercontent.com/1413534/83692827-a22dd900-a5ec-11ea-854f-20b0fa289de4.png)
  |
