### PR TITLE
Disable controller charts if no data provided

### DIFF
--- a/src/components/DonutChart/DonutChart.js
+++ b/src/components/DonutChart/DonutChart.js
@@ -2,27 +2,36 @@ import React, { useRef, useEffect } from "react";
 import * as d3 from "d3";
 
 const DonutChart = ({ chartData }) => {
-  const ref = useRef();
+  const svgRef = useRef();
   const width = 220;
   const height = 220;
   const margin = 40;
+
+  const isDisabled =
+    (chartData?.blocked || 0) +
+    (chartData?.alert || 0) +
+    (chartData?.running || 0)
+      ? 0 > false
+      : true;
 
   useEffect(() => {
     const radius = Math.min(width, height) / 2 - margin;
 
     const svg = d3
-      .select(ref.current)
+      .select(svgRef.current)
       .attr("width", width)
       .attr("height", height)
       .append("g")
       .attr("transform", "translate(" + width / 2 + "," + height / 2 + ")");
 
-    const data = chartData;
+    const data = !isDisabled ? chartData : { disabled: 1 };
 
     const color = d3
       .scaleOrdinal()
       .domain(data)
-      .range(["is-blocked", "is-alert", "is-running"]);
+      .range(
+        !isDisabled ? ["is-blocked", "is-alert", "is-running"] : ["is-disabled"]
+      );
 
     const pie = d3.pie().value(function (d) {
       return d.value;
@@ -42,8 +51,8 @@ const DonutChart = ({ chartData }) => {
     return () => {
       svg.remove();
     };
-  }, [chartData]);
-  return <svg ref={ref} />;
+  }, [chartData, isDisabled]);
+  return <svg ref={svgRef} />;
 };
 
 export default DonutChart;

--- a/src/components/DonutChart/DonutChart.js
+++ b/src/components/DonutChart/DonutChart.js
@@ -9,10 +9,11 @@ const DonutChart = ({ chartData }) => {
 
   const isDisabled =
     (chartData?.blocked || 0) +
-    (chartData?.alert || 0) +
-    (chartData?.running || 0)
-      ? 0 > false
-      : true;
+      (chartData?.alert || 0) +
+      (chartData?.running || 0) ===
+    0
+      ? true
+      : false;
 
   useEffect(() => {
     const radius = Math.min(width, height) / 2 - margin;

--- a/src/components/DonutChart/DonutChart.test.js
+++ b/src/components/DonutChart/DonutChart.test.js
@@ -12,6 +12,7 @@ describe("Donut chart", () => {
     expect(svg.find(".is-blocked").length).toBe(1);
     expect(svg.find(".is-alert").length).toBe(1);
     expect(svg.find(".is-running").length).toBe(1);
+    expect(svg.find(".is-disabled").length).toBe(0);
   });
 
   it("renders as disabled if no data available", () => {
@@ -19,6 +20,9 @@ describe("Donut chart", () => {
       <DonutChart chartData={{ blocked: 0, alert: 0, running: 0 }} />
     );
     const svg = wrapper.find("svg").render();
+    expect(svg.find(".is-blocked").length).toBe(0);
+    expect(svg.find(".is-alert").length).toBe(0);
+    expect(svg.find(".is-running").length).toBe(0);
     expect(svg.find(".is-disabled").length).toBe(1);
   });
 });

--- a/src/components/DonutChart/DonutChart.test.js
+++ b/src/components/DonutChart/DonutChart.test.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import DonutChart from "./DonutChart";
+
+describe("Donut chart", () => {
+  it("renders appropriate segments if data available", () => {
+    const wrapper = mount(
+      <DonutChart chartData={{ blocked: 1, alert: 1, running: 1 }} />
+    );
+    const svg = wrapper.find("svg").render();
+    expect(svg.find(".is-blocked").length).toBe(1);
+    expect(svg.find(".is-alert").length).toBe(1);
+    expect(svg.find(".is-running").length).toBe(1);
+  });
+
+  it("renders as disabled if no data available", () => {
+    const wrapper = mount(
+      <DonutChart chartData={{ blocked: 0, alert: 0, running: 0 }} />
+    );
+    const svg = wrapper.find("svg").render();
+    expect(svg.find(".is-disabled").length).toBe(1);
+  });
+});

--- a/src/pages/Controllers/ControllerChart/ControllerChart.js
+++ b/src/pages/Controllers/ControllerChart/ControllerChart.js
@@ -25,19 +25,19 @@ export default function ControllerChart({ chartData, totalLabel }) {
             className="p-list__item p-legend__item is-blocked"
             data-test="legend-blocked"
           >
-            Blocked: {chartData.blocked}
+            Blocked: {chartData.blocked || 0}
           </li>
           <li
             className="p-list__item p-legend__item is-alert"
             data-test="legend-alert"
           >
-            Alerts: {chartData.alert}
+            Alerts: {chartData.alert || 0}
           </li>
           <li
             className="p-list__item p-legend__item is-running"
             data-test="legend-running"
           >
-            Running: {chartData.running}
+            Running: {chartData.running || 0}
           </li>
         </ul>
       </div>

--- a/src/pages/Controllers/ControllerChart/_controller-chart.scss
+++ b/src/pages/Controllers/ControllerChart/_controller-chart.scss
@@ -1,6 +1,10 @@
 @import "vanilla-framework/scss/vanilla";
 
 .p-chart {
+  .is-disabled {
+    fill: rgba($color-mid-light, 0.33);
+  }
+
   .is-blocked {
     fill: $color-negative;
   }


### PR DESCRIPTION
## Done

Disable controller charts if no data provided

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/controllers
- Open ControllerOverview.js
- Change line 46 to `<ControllerChart chartData={{}} totalLabel="application" />`
- Refresh page
- Verify Application chart is now disabled

<img width="1027" alt="Screenshot 2020-06-17 at 16 18 56" src="https://user-images.githubusercontent.com/505570/84916685-46685300-b0b6-11ea-95a0-df37e7874511.png">

## Details

Fixes #555 
