### PR TITLE
Stop pinger on error and enhance Sentry errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jaas-dashboard",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A dashboard for JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"

--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -59,8 +59,9 @@ export default async function connectAndListModels(reduxStore, bakery) {
     } while (isLoggedIn(reduxStore.getState()));
   } catch (error) {
     // XXX Surface error to UI.
-    // XXX Send to sentry.
-    // eslint-disable-next-line no-console
-    console.log("Something went wrong: ", error);
+    // XXX Send to sentry if it's an error that's not connection related
+    // a common error returned by this is:
+    // Something went wrong:  cannot send request {"type":"ModelManager","request":"ListModels","version":5,"params":...}: connection state 3 is not open
+    console.error("Something went wrong: ", error);
   }
 }

--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/browser";
 import {
   disableControllerUUIDMasking,
   fetchAllModelStatuses,
@@ -35,6 +36,9 @@ export default async function connectAndListModels(reduxStore, bakery) {
     if (error) {
       reduxStore.dispatch(storeLoginError(error));
       return;
+    }
+    if (process.env.NODE_ENV === "production") {
+      Sentry.setTag("jujuVersion", conn?.info?.serverVersion);
     }
     reduxStore.dispatch(updateControllerConnection(conn));
     reduxStore.dispatch(updateJujuAPIInstance(juju));

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ if (process.env.NODE_ENV === "production") {
   Sentry.init({
     dsn: "https://5b54e6946be34749935c4dd2d9d01cb8@sentry.is.canonical.com/7",
   });
+  Sentry.setTag("dashboardVersion", appVersion);
 }
 
 if (!window.jaasDashboardConfig) {

--- a/src/index.js
+++ b/src/index.js
@@ -28,17 +28,28 @@ import { version as appVersion } from "../package.json";
 
 import * as serviceWorker from "./serviceWorker";
 
+if (!window.jaasDashboardConfig) {
+  console.error(
+    "Configuration values not defined unable to bootstrap application"
+  );
+}
+
+// If the baseControllerURL is `null` then set it's value to the
+// hostname:port of the server serving the application. This is done as the
+// hostname:port is not always provided by the Juju webserver but in which
+// case we can reliably connect to the API using the same hostname:port as
+// the dashboard assets are served from.
+const config = window.jaasDashboardConfig;
+if (config.baseControllerURL === null) {
+  config.baseControllerURL = window.location.host;
+}
+
 if (process.env.NODE_ENV === "production") {
   Sentry.init({
     dsn: "https://5b54e6946be34749935c4dd2d9d01cb8@sentry.is.canonical.com/7",
   });
   Sentry.setTag("dashboardVersion", appVersion);
-}
-
-if (!window.jaasDashboardConfig) {
-  console.error(
-    "Configuration values not defined unable to bootstrap application"
-  );
+  Sentry.setTag("isJuju", config.isJuju);
 }
 
 const reduxStore = createStore(
@@ -58,15 +69,6 @@ const reduxStore = createStore(
   composeWithDevTools(applyMiddleware(checkAuth, thunk))
 );
 
-// If the baseControllerURL is `null` then set it's value to the
-// hostname:port of the server serving the application. This is done as the
-// hostname:port is not always provided by the Juju webserver but in which
-// case we can reliably connect to the API using the same hostname:port as
-// the dashboard assets are served from.
-const config = window.jaasDashboardConfig;
-if (config.baseControllerURL === null) {
-  config.baseControllerURL = window.location.host;
-}
 reduxStore.dispatch(storeConfig(window.jaasDashboardConfig));
 reduxStore.dispatch(storeVersion(appVersion));
 

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -94,7 +94,11 @@ export async function loginWithBakery(
 
   // Ping to keep the connection alive.
   const intervalId = setInterval(() => {
-    conn.facades.pinger.ping();
+    conn.facades.pinger.ping().catch((e) => {
+      // If the pinger fails for whatever reason then cancel the ping.
+      console.error("pinger stopped,", e);
+      clearInterval(intervalId);
+    });
   }, 20000);
 
   return { conn, juju, intervalId };


### PR DESCRIPTION
## Done

- Stop the pinger if there is an error making the request.
- Add `jujuVersion`, `isJuju`, and `dashboardVersion` to Sentry error messages.
- Bumped version to 0.1.8 for release.

## QA

### In Juju

- Bootstrap a new Juju controller on your cloud provider of choice using the latest Juju snap.
  - `juju bootstrap google` 
- Build a release tarball of the Dashboard.
  - `./run exec yarn run generate-release-tarball`
- Upgrade the Dashboard on your new controller
  - `juju upgrade-dashboard juju-dashboard-<version>.tar.bz2`
- Access the Dashboard
  - `juju dashboard`

### In JAAS
- `./run`

### Tasks
- Open the browser console
- Disconnect your browser from the internet to break the websocket connection
- You should see a couple error messages in the console indicating that it cannot send a couple requests but you shouldn't get any unhandled errors. This may take up to 30s for the iteration to start over again, but you should only ever get them once.

![Screen Shot 2020-06-17 at 4 09 13 PM](https://user-images.githubusercontent.com/532033/84955670-e91fd200-b0b4-11ea-9883-bf2804daf619.png)

## Details

Fixes #562
Fixes #564 
