### PR TITLE
Remove the 'configuration' header in the model list tables and move the column next to the model name.

### DIFF
--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -35,9 +35,9 @@ function generateCloudTableHeaders(cloud, count) {
       content: generateStatusElement(cloud, count, false),
       sortKey: cloud.toLowerCase(),
     },
+    { content: "", sortKey: "summary" }, // The unit/machines/apps counts
     { content: "Owner", sortKey: "owner" },
     { content: "Status", sortKey: "status" },
-    { content: "Configuration", sortKey: "summary" },
     { content: "Region", sortKey: "region" },
     { content: "Credential", sortKey: "credential" },
     { content: "Controller", sortKey: "controller" },
@@ -74,6 +74,11 @@ export default function CloudGroup({ activeUser, filters }) {
               ),
             },
             {
+              "data-test-column": "summary",
+              content: getStatusValue(model, "summary"),
+              className: "u-overflow--visible",
+            },
+            {
               "data-test-column": "owner",
               content: extractOwnerName(model.info.ownerTag),
             },
@@ -81,11 +86,6 @@ export default function CloudGroup({ activeUser, filters }) {
               "data-test-column": "status",
               content: generateStatusElement(highestStatus),
               className: "u-capitalise",
-            },
-            {
-              "data-test-column": "summary",
-              content: getStatusValue(model, "summary"),
-              className: "u-overflow--visible",
             },
             {
               "data-test-column": "region",

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -31,8 +31,8 @@ function generateOwnerTableHeaders(owner, count) {
       content: generateStatusElement(owner, count, false),
       sortKey: owner.toLowerCase(),
     },
+    { content: "", sortKey: "summary" }, // The unit/machines/apps counts
     { content: "Status", sortKey: "statusˇ" },
-    { content: "Configuration", sortKey: "summary" },
     { content: "Cloud/Region", sortKey: "cloud" },
     { content: "Credential", sortKey: "credential" },
     { content: "Controller", sortKey: "controller" },
@@ -68,14 +68,14 @@ export default function OwnerGroup({ activeUser, filters }) {
               ),
             },
             {
-              "data-test-column": "status",
-              content: generateStatusElement(highestStatus),
-              className: "u-capitalise",
-            },
-            {
               "data-test-column": "summary",
               content: getStatusValue(model, "summary"),
               className: "u-overflow--visible",
+            },
+            {
+              "data-test-column": "status",
+              content: generateStatusElement(highestStatus),
+              className: "u-capitalise",
             },
             {
               "data-test-column": "cloud",

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -24,8 +24,8 @@ function generateStatusTableHeaders(label, count) {
       content: generateStatusElement(label, count),
       sortKey: label.toLowerCase(),
     },
+    { content: "", sortKey: "summary" }, // The unit/machines/apps counts
     { content: "Owner", sortKey: "owner" },
-    { content: "Configuration", sortKey: "summary" },
     { content: "Cloud/Region", sortKey: "cloud" },
     { content: "Credential", sortKey: "credential" },
     { content: "Controller", sortKey: "controller" },
@@ -104,17 +104,17 @@ function generateModelTableDataByStatus(groupedModels, activeUser) {
             content: generateModelNameCell(model, groupLabel, activeUser),
           },
           {
+            "data-test-column": "summary",
+            content: getStatusValue(model, "summary"),
+            className: "u-overflow--visible",
+          },
+          {
             "data-test-column": "owner",
             content: (
               <a href="#_" className="p-link--soft">
                 {owner}
               </a>
             ),
-          },
-          {
-            "data-test-column": "summary",
-            content: getStatusValue(model, "summary"),
-            className: "u-overflow--visible",
           },
           {
             "data-test-column": "cloud",


### PR DESCRIPTION
## Done

Remove the 'configuration' header in the model list tables and move the column next to the model name.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- See the new layout in the model list view in all 3 groupings (status, owner, cloud)

![Screen Shot 2020-06-25 at 1 50 16 PM](https://user-images.githubusercontent.com/532033/85792194-5d2f2b00-b6f0-11ea-8697-ac6d1bcb7a21.png)
![Screen Shot 2020-06-25 at 1 51 13 PM](https://user-images.githubusercontent.com/532033/85792195-5e605800-b6f0-11ea-9f21-22a712724399.png)
![Screen Shot 2020-06-25 at 1 52 49 PM](https://user-images.githubusercontent.com/532033/85792198-5ef8ee80-b6f0-11ea-986f-e0286b94856d.png)




