### PR TITLE
Convert JAAS Dashboard to Juju Dashboard.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,7 @@
     "document": true,
     "localStorage": true,
     "windowLocation": true,
-    "jaasDashboardConfig": true,
+    "jujuDashboardConfig": true,
     "lightningjs": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jaas-dashboard",
+  "name": "juju-dashboard",
   "version": "0.1.8",
-  "description": "A dashboard for JAAS (Juju as a service)",
+  "description": "A dashboard for Juju and JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"
   },

--- a/public/config.js
+++ b/public/config.js
@@ -1,7 +1,7 @@
 // If a new key is added to this config then be sure to also add the key and
 // value to the golang template in config.js.go.
 // eslint-disable-next-line no-unused-vars
-var jaasDashboardConfig = {
+var jujuDashboardConfig = {
   // API host to allow app to connect and retrieve models
   baseControllerURL: "jimm.jujucharms.com",
   // Configurable base url to allow deploying to different paths.

--- a/public/config.js.go
+++ b/public/config.js.go
@@ -1,4 +1,4 @@
-var jaasDashboardConfig = {
+var jujuDashboardConfig = {
   // API host to allow app to connect and retrieve models
   baseControllerURL: null,
   // Configurable base url to allow deploying to different paths.

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/app-icon.png">
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/app-icon.png" />
     <script src="/config.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>JAAS Dashboard</title>
+    <title>Juju Dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "JAAS",
-  "name": "JAAS",
+  "short_name": "Juju",
+  "name": "Juju",
   "icons": [
     {
       "src": "favicon.ico",

--- a/scripts/generate-release-tarball
+++ b/scripts/generate-release-tarball
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-VERSION=`npm version | grep jaas-dashboard | cut -d"'" -f4`
+VERSION=`npm version | grep juju-dashboard | cut -d"'" -f4`
 
 tar -cjf juju-dashboard-$VERSION.tar.bz2 -C build .

--- a/scripts/generate-version-file
+++ b/scripts/generate-version-file
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=`npm version | grep jaas-dashboard | cut -d"'" -f4`
+VERSION=`npm version | grep juju-dashboard | cut -d"'" -f4`
 GIT_SHA=`git rev-parse HEAD`
 
 echo '{"version": "'$VERSION'", "git-sha": "'$GIT_SHA'"}' >> build/version.json

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -65,7 +65,7 @@ const Layout = ({ children }) => {
               setReleaseNotification(true);
             }}
           >
-            Welcome to the new JAAS Dashboard! This dashboard is the replacement
+            Welcome to the new Juju Dashboard! This dashboard is the replacement
             for the Juju GUI in JAAS and individual Juju Controllers from Juju
             2.8.{" "}
             <span className="u-hide--small">

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ import { version as appVersion } from "../package.json";
 
 import * as serviceWorker from "./serviceWorker";
 
-if (!window.jaasDashboardConfig) {
+if (!window.jujuDashboardConfig) {
   console.error(
     "Configuration values not defined unable to bootstrap application"
   );
@@ -39,7 +39,7 @@ if (!window.jaasDashboardConfig) {
 // hostname:port is not always provided by the Juju webserver but in which
 // case we can reliably connect to the API using the same hostname:port as
 // the dashboard assets are served from.
-const config = window.jaasDashboardConfig;
+const config = window.jujuDashboardConfig;
 if (config.baseControllerURL === null) {
   config.baseControllerURL = window.location.host;
 }
@@ -69,7 +69,7 @@ const reduxStore = createStore(
   composeWithDevTools(applyMiddleware(checkAuth, thunk))
 );
 
-reduxStore.dispatch(storeConfig(window.jaasDashboardConfig));
+reduxStore.dispatch(storeConfig(window.jujuDashboardConfig));
 reduxStore.dispatch(storeVersion(appVersion));
 
 const bakery = new Bakery({


### PR DESCRIPTION
## Done

Converted the appropriate instances of "JAAS Dashboard" to "Juju Dashboard'

The repo name has not yet been changed.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- The application should work as expected
- `./run exec yarn run generate-release-tarball` Should generate a tarball with the apprioriate version number in it.

## Details

Fixes #571
