### PR TITLE
Match the logo link with the logo

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.js
+++ b/src/components/PrimaryNav/PrimaryNav.js
@@ -126,7 +126,10 @@ const PrimaryNav = () => {
         </Modal>
       ) : null}
       <div className="p-primary-nav__header">
-        <a href="https://jaas.ai" className="p-primary-nav__logo">
+        <a
+          href={isJuju ? "https://juju.is" : "https://jaas.ai"}
+          className="p-primary-nav__logo"
+        >
           <img
             className="p-primary-nav__logo-icon"
             src={logoMark}

--- a/src/components/PrimaryNav/PrimaryNav.test.js
+++ b/src/components/PrimaryNav/PrimaryNav.test.js
@@ -82,6 +82,9 @@ describe("Primary Nav", () => {
     expect(wrapper.find(".p-primary-nav__logo-text").prop("src")).toBe(
       "logo-text.svg"
     );
+    expect(wrapper.find(".p-primary-nav__logo").prop("href")).toBe(
+      "https://jaas.ai"
+    );
   });
 
   it("displays the Juju logo under Juju", () => {
@@ -97,6 +100,9 @@ describe("Primary Nav", () => {
     );
     expect(wrapper.find(".p-primary-nav__logo-text").prop("src")).toBe(
       "juju-text.svg"
+    );
+    expect(wrapper.find(".p-primary-nav__logo").prop("href")).toBe(
+      "https://juju.is"
     );
   });
 


### PR DESCRIPTION
## Done

Match the link in the PrimaryNav logo to the logo.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Does the JAAS link go to jaas.ai?
- Change `isJuju` to `true` in `config.js` and then reload.
- Does the Juju link go to juju.is?

## Details

Fixes #535 