### PR TITLE
Change the store column value for local charms

### DIFF
--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -234,6 +234,13 @@ describe("ModelDetail Container", () => {
     expect(
       wrapper.find(".model-details__apps tr[data-app='cockroachdb']").length
     ).toBe(1);
+    expect(
+      wrapper
+        .find(
+          ".model-details__apps tr[data-app='cockroachdb'] td[data-test-column='store']"
+        )
+        .text()
+    ).toBe("Local");
   });
 
   it("displays the correct scale value", () => {

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -130,7 +130,7 @@ export function generateApplicationRows(
         },
         {
           "data-test-column": "store",
-          content: "CharmHub",
+          content: app.charm.indexOf("local:") === 0 ? "Local" : "CharmHub",
         },
         {
           "data-test-column": "revision",


### PR DESCRIPTION
## Done

If a charm was deployed locally then use "Local" as the `store` value and "CharmHub" otherwise.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View your models, do they show "CharmHub" under store?
- View the 'local-test' model, does it show "Local"? Ask me for access if you don't currently have it.

## Details

Fixes #545

## Screenshots

![Screen Shot 2020-06-30 at 11 51 20 AM](https://user-images.githubusercontent.com/532033/86159777-08acf680-bac8-11ea-9ab0-4991da6b4bdf.png)

