### PR TITLE
Remove space-on-right bug from models details

### DIFF
--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -13,7 +13,6 @@
   z-index: z("beta");
 }
 
-// XXX Ant: Need to work out why 100vw - sidebar width does not work
 .has-collapsible-sidebar .l-side + .l-main .header {
-  width: calc(100vw - 60px);
+  width: calc(100vw - #{$sidebar-collapsed});
 }


### PR DESCRIPTION


## Done

Remove space-on-right bug from models details

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details page
- View page across different breakpoint and verify spacing on right has been resolved

## Details

Fixes #577
