### PR TITLE
Convert the error messages on the model list page into links.

### DIFF
--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -48,7 +48,7 @@ const generateWarningMessage = (model, activeUser) => {
   const title = messages.join("; ");
   const link = generateModelDetailsLink(
     model.model.name,
-    model.info && model.info.ownerTag,
+    model?.info?.ownerTag,
     activeUser,
     title
   );

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -40,14 +40,21 @@ function generateStatusTableHeaders(label, count) {
 /**
   Generates the warning message for the model name cell.
   @param {Object} model The full model data.
+  @param {String} activeUser The active user name.
   @return {Object} The react component for the warning message.
 */
-const generateWarningMessage = (model) => {
+const generateWarningMessage = (model, activeUser) => {
   const { messages } = getModelStatusGroupData(model);
   const title = messages.join("; ");
+  const link = generateModelDetailsLink(
+    model.model.name,
+    model.info && model.info.ownerTag,
+    activeUser,
+    title
+  );
   return (
     <span className="model-table-list_error-message" title={title}>
-      {title}
+      {link}
     </span>
   );
 };
@@ -70,7 +77,9 @@ const generateModelNameCell = (model, groupLabel, activeUser) => {
   return (
     <>
       <div>{link}</div>
-      {groupLabel === "blocked" ? generateWarningMessage(model) : null}
+      {groupLabel === "blocked"
+        ? generateWarningMessage(model, activeUser)
+        : null}
     </>
   );
 };

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -4,19 +4,21 @@
   margin-top: 0.5rem;
 }
 
-.model-table-list_error-message a,
-.model-table-list_error-message a:visited {
-  color: $color-negative;
-  display: block;
-  font-size: 0.875rem;
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  @media (max-width: $breakpoint-large) {
-    display: inline-block;
+.model-table-list_error-message a {
+  &,
+  &:visited {
+    color: $color-negative;
+    display: block;
+    font-size: 0.875rem;
     max-width: 200px;
-    padding-right: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    @media (max-width: $breakpoint-large) {
+      display: inline-block;
+      max-width: 200px;
+      padding-right: 1rem;
+    }
   }
 }

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -4,7 +4,8 @@
   margin-top: 0.5rem;
 }
 
-.model-table-list_error-message {
+.model-table-list_error-message a,
+.model-table-list_error-message a:visited {
   color: $color-negative;
   display: block;
   font-size: 0.875rem;

--- a/src/components/ModelTableList/shared.js
+++ b/src/components/ModelTableList/shared.js
@@ -12,9 +12,16 @@ import machinesIcon from "static/images/icons/machines-icon.svg";
   @param {String} modelName The name of the model.
   @param {String} ownerTag The ownerTag of the model.
   @param {String} activeUser The ownerTag of the active user.
+  @param {String} contents The contents of the link. Optional, will default to
+    the modelName.
   @returns {Object} The React component for the link.
 */
-export function generateModelDetailsLink(modelName, ownerTag, activeUser) {
+export function generateModelDetailsLink(
+  modelName,
+  ownerTag,
+  activeUser,
+  contents
+) {
   const modelDetailsPath = `/models/${modelName}`;
   if (ownerTag === activeUser) {
     return <Link to={modelDetailsPath}>{modelName}</Link>;
@@ -34,7 +41,7 @@ export function generateModelDetailsLink(modelName, ownerTag, activeUser) {
     "user-",
     ""
   )}/${modelName}`;
-  return <Link to={sharedModelDetailsPath}>{modelName}</Link>;
+  return <Link to={sharedModelDetailsPath}>{contents || modelName}</Link>;
 }
 
 /**


### PR DESCRIPTION
## Done

Convert the error messages on the model list page into links to the respective model details page.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Are the error links in the model details page links to the model details page?

## Details

Fixes #595 
