### PR TITLE
Model list error link no longer falls back to the model name.

### DIFF
--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -70,7 +70,8 @@ export default function CloudGroup({ activeUser, filters }) {
               content: generateModelDetailsLink(
                 model.info.name,
                 model.info && model.info.ownerTag,
-                activeUser
+                activeUser,
+                model.info.name
               ),
             },
             {

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -64,7 +64,8 @@ export default function OwnerGroup({ activeUser, filters }) {
               content: generateModelDetailsLink(
                 model.info.name,
                 model.info && model.info.ownerTag,
-                activeUser
+                activeUser,
+                model.info.name
               ),
             },
             {

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -72,7 +72,8 @@ const generateModelNameCell = (model, groupLabel, activeUser) => {
   const link = generateModelDetailsLink(
     model.model.name,
     model.info && model.info.ownerTag,
-    activeUser
+    activeUser,
+    model.model.name
   );
   return (
     <>

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -4,9 +4,10 @@
   margin-top: 0.5rem;
 }
 
-.model-table-list_error-message a {
+.model-table-list_error-message {
   &,
-  &:visited {
+  & a,
+  & a:visited {
     color: $color-negative;
     display: block;
     font-size: 0.875rem;

--- a/src/components/ModelTableList/shared.js
+++ b/src/components/ModelTableList/shared.js
@@ -12,19 +12,18 @@ import machinesIcon from "static/images/icons/machines-icon.svg";
   @param {String} modelName The name of the model.
   @param {String} ownerTag The ownerTag of the model.
   @param {String} activeUser The ownerTag of the active user.
-  @param {String} contents The contents of the link. Optional, will default to
-    the modelName.
+  @param {String} label The contents of the link.
   @returns {Object} The React component for the link.
 */
 export function generateModelDetailsLink(
   modelName,
   ownerTag,
   activeUser,
-  contents
+  label
 ) {
   const modelDetailsPath = `/models/${modelName}`;
   if (ownerTag === activeUser) {
-    return <Link to={modelDetailsPath}>{modelName}</Link>;
+    return <Link to={modelDetailsPath}>{label}</Link>;
   }
   // Because we get some data at different times based on the multiple API calls
   // we need to check for their existence and supply reasonable fallbacks if it
@@ -33,7 +32,7 @@ export function generateModelDetailsLink(
   if (!ownerTag) {
     // We will just return an unclickable name until we get an owner tag as
     // without it we can't create a reliable link.
-    return modelName;
+    return label;
   }
   // If the owner isn't the logged in user then we need to use the
   // fully qualified path name.
@@ -41,7 +40,7 @@ export function generateModelDetailsLink(
     "user-",
     ""
   )}/${modelName}`;
-  return <Link to={sharedModelDetailsPath}>{contents || modelName}</Link>;
+  return <Link to={sharedModelDetailsPath}>{label}</Link>;
 }
 
 /**


### PR DESCRIPTION
## Done

Model list error link no longer falls back to the model name.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- In your model list does it show the model name for the error message? Or when refreshing does it flash the model name before the error message?

## Details

Fixes #599 
