### PR TITLE
Format code snippets in form help text

### DIFF
--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -186,8 +186,7 @@ function RegisterAController({ onClose }) {
       <h5>Register a Controller</h5>
       <p className="p-form-help-text">
         Controller information can be retrieved using the{" "}
-        <code>juju show-controller</code>
-        command.
+        <code>juju show-controller</code> command.
       </p>
       <form
         className="p-form p-form--stacked"
@@ -283,9 +282,8 @@ function RegisterAController({ onClose }) {
               />
               <p className="p-form-help-text">
                 The password will be what you used when running{" "}
-                <code>juju register</code>
-                or if unchanged from the default it can be retrieved by running{" "}
-                <code>juju dashboard</code>.
+                <code>juju register</code> or if unchanged from the default it
+                can be retrieved by running <code>juju dashboard</code>.
               </p>
             </div>
           </div>

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -185,7 +185,8 @@ function RegisterAController({ onClose }) {
     <SlidePanel onClose={onClose}>
       <h5>Register a Controller</h5>
       <p className="p-form-help-text">
-        Controller information can be retrieved using the `juju show-controller`
+        Controller information can be retrieved using the{" "}
+        <code>juju show-controller</code>
         command.
       </p>
       <form
@@ -281,9 +282,10 @@ function RegisterAController({ onClose }) {
                 required=""
               />
               <p className="p-form-help-text">
-                The password will be what you used when running `juju register`
-                or if unchanged from the default it can be retrieved by running
-                `juju dashboard`.
+                The password will be what you used when running{" "}
+                <code>juju register</code>
+                or if unchanged from the default it can be retrieved by running{" "}
+                <code>juju dashboard</code>.
               </p>
             </div>
           </div>

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -323,7 +323,7 @@ function RegisterAController({ onClose }) {
             </div>
           </div>
         </div>
-        <div className="row horizonal-rule">
+        <div className="row horizontal-rule">
           <div className="col-8 col-start-large-5">
             <input
               type="checkbox"

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -51,7 +51,7 @@
   }
 
   .slide-panel__content {
-    max-width: 550px;
+    max-width: 560px;
 
     .row {
       grid-gap: 0;

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -75,8 +75,15 @@
       position: absolute;
     }
 
-    .p-form-help-text.identity-provider {
-      padding-left: 2rem;
+    .p-form-help-text {
+      code {
+        display: inline-block;
+        margin: 0.25rem 0.25rem;
+      }
+
+      &.identity-provider {
+        padding-left: 2rem;
+      }
     }
 
     .controller-link-message {

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -62,7 +62,7 @@
       padding-top: 1rem;
     }
 
-    .horizonal-rule {
+    .horizontal-rule {
       border-bottom: 1px solid $color-mid-x-light;
     }
 


### PR DESCRIPTION
## Done

Format code snippets in form help text

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036
- Go to controllers
- Click "Register a new controller"
- Verify code snippets display as code snippets in help text

## Details

Fixes #616
