### PR TITLE
Register controller UX tweaks

### DIFF
--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -40,15 +40,21 @@ export default async function connectAndListModels(
       controllerList = controllerList.concat(additionalControllers);
     }
     controllerList.forEach(async (controllerData) => {
-      const { conn, error, juju, intervalId } = await loginWithBakery(
-        ...controllerData
-      );
-
-      if (error) {
-        reduxStore.dispatch(storeLoginError(error));
-        return;
+      let conn, error, juju, intervalId;
+      try {
+        ({ conn, error, juju, intervalId } = await loginWithBakery(
+          ...controllerData
+        ));
+        if (error) {
+          reduxStore.dispatch(storeLoginError(error));
+          return;
+        }
+      } catch (e) {
+        return console.log("unable to log into controller", e, controllerData);
       }
 
+      // XXX Now that we can register multiple controllers this needs
+      // to be set per controller.
       if (process.env.NODE_ENV === "production") {
         Sentry.setTag("jujuVersion", conn?.info?.serverVersion);
       }

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -194,7 +194,10 @@ function RegisterAController({ onClose }) {
       >
         <div className="p-form__group row">
           <div className="col-4">
-            <label htmlFor="full-name-stacked" className="p-form__label">
+            <label
+              htmlFor="full-name-stacked"
+              className="p-form__label is-required"
+            >
               Controller name
             </label>
           </div>
@@ -218,7 +221,10 @@ function RegisterAController({ onClose }) {
 
         <div className="p-form__group row">
           <div className="col-4">
-            <label htmlFor="full-name-stacked" className="p-form__label">
+            <label
+              htmlFor="full-name-stacked"
+              className="p-form__label is-required"
+            >
               Full hostname
             </label>
           </div>
@@ -331,8 +337,9 @@ function RegisterAController({ onClose }) {
               onChange={handleInputChange}
               required="true"
             />
-            <label htmlFor="certificateHasBeenAccepted">
-              The SSL certificate, if any, has been accepted.
+            <label htmlFor="certificateHasBeenAccepted" className="is-required">
+              The SSL certificate, if any, has been accepted.{" "}
+              <span className="required-star">*</span>
             </label>
           </div>
         </div>

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -180,7 +180,19 @@ function RegisterAController({ onClose }) {
   const controllerIP = formValues?.wsControllerURL
     ? formValues.wsControllerURL.replace("wss://", "").replace("/api", "")
     : "";
-  const dashboardLink = `https://${controllerIP}/dashboard`;
+
+  function generateTheControllerLink(controllerIP) {
+    if (!controllerIP) {
+      return "the controller";
+    }
+    const dashboardLink = `https://${controllerIP}/dashboard`;
+    return (
+      <a href={dashboardLink} target="_blank" rel="noopener noreferrer">
+        the controller
+      </a>
+    );
+  }
+
   /* eslint-disable jsx-a11y/label-has-associated-control */
   return (
     <SlidePanel onClose={onClose}>
@@ -323,12 +335,8 @@ function RegisterAController({ onClose }) {
           <div className="col-8 col-start-large-5">
             <i className="p-icon--warning"></i>
             <div className="controller-link-message">
-              Visit{" "}
-              <a href={dashboardLink} target="_blank" rel="noopener noreferrer">
-                the controller
-              </a>{" "}
-              to accept the certificate on this controller to enable a secure
-              connection
+              Visit {generateTheControllerLink(controllerIP)} to accept the
+              certificate on this controller to enable a secure connection
             </div>
           </div>
         </div>

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import cloneDeep from "clone-deep";
+import classNames from "classnames";
 
 import Layout from "components/Layout/Layout";
 import Header from "components/Header/Header";
@@ -295,7 +296,11 @@ function RegisterAController({ onClose }) {
           </div>
         </div>
 
-        <div className="p-form__group row">
+        <div
+          className={classNames("p-form__group row", {
+            "u-hide": formValues.username && formValues.password,
+          })}
+        >
           <div className="col-8 col-start-large-5">
             <input
               type="checkbox"

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -198,20 +198,20 @@ function RegisterAController({ onClose }) {
     <SlidePanel onClose={onClose}>
       <h5>Register a Controller</h5>
       <p className="p-form-help-text">
-        Controller information can be retrieved using the{" "}
-        <code>juju show-controller</code> command.
+        Information can be retrieved using the <code>juju show-controller</code>{" "}
+        command.
       </p>
       <form
         className="p-form p-form--stacked"
         onSubmit={handleRegisterAController}
       >
         <div className="p-form__group row">
-          <div className="col-4">
+          <div className="col-3">
             <label
               htmlFor="full-name-stacked"
               className="p-form__label is-required"
             >
-              Controller name
+              Name
             </label>
           </div>
 
@@ -233,12 +233,12 @@ function RegisterAController({ onClose }) {
         </div>
 
         <div className="p-form__group row">
-          <div className="col-4">
+          <div className="col-3">
             <label
               htmlFor="full-name-stacked"
               className="p-form__label is-required"
             >
-              Full hostname
+              Host
             </label>
           </div>
 
@@ -252,16 +252,16 @@ function RegisterAController({ onClose }) {
                 required="true"
               />
               <p className="p-form-help-text">
-                You'll typically want to use the public IP address for the
+                You'll typically want to use the public IP:Port address for the
                 controller. <br />
-                e.g. wss://123.456.789.0:17070/api
+                e.g. 123.456.789.0:17070
               </p>
             </div>
           </div>
         </div>
 
         <div className="p-form__group row">
-          <div className="col-4">
+          <div className="col-3">
             <label htmlFor="full-name-stacked" className="p-form__label">
               Username
             </label>
@@ -284,7 +284,7 @@ function RegisterAController({ onClose }) {
         </div>
 
         <div className="p-form__group row">
-          <div className="col-4">
+          <div className="col-3">
             <label htmlFor="full-name-stacked" className="p-form__label">
               Password
             </label>
@@ -313,7 +313,7 @@ function RegisterAController({ onClose }) {
             "u-hide": formValues.username && formValues.password,
           })}
         >
-          <div className="col-8 col-start-large-5">
+          <div className="col-8 col-start-large-4">
             <input
               type="checkbox"
               id="identityProviderAvailable"
@@ -332,7 +332,7 @@ function RegisterAController({ onClose }) {
           </div>
         </div>
         <div className="row">
-          <div className="col-8 col-start-large-5">
+          <div className="col-8 col-start-large-4">
             <i className="p-icon--warning"></i>
             <div className="controller-link-message">
               Visit {generateTheControllerLink(controllerIP)} to accept the
@@ -341,7 +341,7 @@ function RegisterAController({ onClose }) {
           </div>
         </div>
         <div className="row horizontal-rule">
-          <div className="col-8 col-start-large-5">
+          <div className="col-8 col-start-large-4">
             <input
               type="checkbox"
               id="certificateHasBeenAccepted"

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -160,7 +160,7 @@ function RegisterAController({ onClose }) {
     e.preventDefault();
     // XXX Validate form values
     additionalControllers.push([
-      formValues.wsControllerURL, // wsControllerURL
+      `wss://${formValues.wsControllerHost}/api`, // wsControllerURL
       { user: formValues.username, password: formValues.password }, // credentials
       null, // bakery
       formValues.identityProviderAvailable, // identityProviderAvailable
@@ -176,10 +176,6 @@ function RegisterAController({ onClose }) {
       e.target.type === "checkbox" ? e.target.checked : e.target.value;
     setFormValues(newFormValues);
   }
-
-  const controllerIP = formValues?.wsControllerURL
-    ? formValues.wsControllerURL.replace("wss://", "").replace("/api", "")
-    : "";
 
   function generateTheControllerLink(controllerIP) {
     if (!controllerIP) {
@@ -247,7 +243,7 @@ function RegisterAController({ onClose }) {
               <input
                 type="text"
                 id="full-name-stacked"
-                name="wsControllerURL"
+                name="wsControllerHost"
                 onChange={handleInputChange}
                 required="true"
               />
@@ -335,8 +331,9 @@ function RegisterAController({ onClose }) {
           <div className="col-8 col-start-large-4">
             <i className="p-icon--warning"></i>
             <div className="controller-link-message">
-              Visit {generateTheControllerLink(controllerIP)} to accept the
-              certificate on this controller to enable a secure connection
+              Visit {generateTheControllerLink(formValues?.wsControllerHost)} to
+              accept the certificate on this controller to enable a secure
+              connection
             </div>
           </div>
         </div>
@@ -350,7 +347,7 @@ function RegisterAController({ onClose }) {
               onChange={handleInputChange}
               required="true"
             />
-            <label htmlFor="certificateHasBeenAccepted" className="is-required">
+            <label htmlFor="certificateHasBeenAccepted">
               The SSL certificate, if any, has been accepted.{" "}
               <span className="required-star">*</span>
             </label>

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -51,7 +51,7 @@
   }
 
   .slide-panel__content {
-    max-width: 560px;
+    max-width: 540px;
 
     .row {
       grid-gap: 0;

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -89,6 +89,10 @@
     .controller-link-message {
       padding-left: 2rem;
     }
+
+    .required-star {
+      color: $color-negative;
+    }
   }
 
   .controllers--registered-tooltip {


### PR DESCRIPTION
## Done

- Required fields are now marked as such.
- The 'Identity Provider' checkbox how hides if you provide a U/P.
- The user no longer needs to provide the protocol and path for the controller; just the IP.
- The 'Visit Controller' link now only becomes a link when you provide an IP.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- The bugs listed below should be resolved

## Details

Fixes #601 
Fixes #611 
Fixes #613 
Fixes #617 
Fixes #618 

## Screenshots

![Screen Shot 2020-07-23 at 10 12 58 AM](https://user-images.githubusercontent.com/532033/88310758-4834c000-cccd-11ea-93cb-ed10173f1578.png)

