### PR TITLE
Allow the user menu to be toggled without authentication.

### DIFF
--- a/src/app/check-auth.js
+++ b/src/app/check-auth.js
@@ -18,6 +18,7 @@ const actionWhitelist = [
   "CLEAR_MODEL_DATA",
   "STORE_VISIT_URL",
   "TOGGLE_COLLAPSIBLE_SIDEBAR",
+  "TOGGLE_USER_MENU",
 ];
 
 // When updating this list be sure to update the mangle.reserved list in


### PR DESCRIPTION
## Done

Allow the user menu to be toggled without authentication.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Can you open and close the user menu in the bottom left?

## Details

Fixes #624 
