### PR TITLE
Connect to and start polling models when registering a new controller

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -29,24 +29,14 @@ export const getModelData = (state) => {
   @param {Object} state The application state.
   @returns {Object|Null} The list of controller data or null if none found.
 */
-export const getControllerData = (state) => {
-  if (state.juju && state.juju.controllers) {
-    return state.juju.controllers;
-  }
-  return null;
-};
+export const getControllerData = (state) => state?.juju?.controllers;
 
 /**
   Fetches the bakery from state.
   @param {Object} state The application state.
   @returns {Object|Null} The bakery instance or null if none found.
 */
-export const getBakery = (state) => {
-  if (state.root && state.root.bakery) {
-    return state.root.bakery;
-  }
-  return null;
-};
+export const getBakery = (state) => state?.root?.bakery;
 
 /**
   Fetches the application config from state.

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -5,7 +5,6 @@ import { fetchAndStoreModelStatus } from "juju";
 // Action labels
 export const actionsList = {
   clearModelData: "CLEAR_MODEL_DATA",
-  fetchModelList: "FETCH_MODEL_LIST",
   updateControllerList: "UPDATE_CONTROLLER_LIST",
   updateModelInfo: "UPDATE_MODEL_INFO",
   updateModelStatus: "UPDATE_MODEL_STATUS",
@@ -70,23 +69,6 @@ export function updateModelInfo(modelInfo) {
 }
 
 // Thunks
-
-/**
-  Fetches the model list from the supplied Juju controller. Requires that the
-  user is logged in to dispatch the retrieved data from listModels.
-  @param {Object} conn The controller connection.
-  @returns {Object} models The list of model objects under the key `userModels`.
-*/
-export function fetchModelList(conn) {
-  return async function fetchModelList(dispatch, getState) {
-    const models = await conn.facades.modelManager.listModels({
-      tag: conn.info.user.identity,
-    });
-    dispatch(updateModelList(models), {
-      wsControllerURL: conn.transport._ws.url,
-    });
-  };
-}
 
 /**
   Returns the model status that's stored in the database if it exists or makes

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -238,17 +238,21 @@ async function fetchModelInfo(conn, modelUUID) {
   Loops through each model UUID to fetch the status. Uppon receiving the status
   dispatches to store that status data.
   @param {Object} conn The connection to the controller.
+  @param {Array} modelUUIDList A list of the model uuid's to connect to.
   @param {Object} reduxStore The applications reduxStore.
   @returns {Promise} Resolves when the queue fetching the model statuses has
     completed. Does not reject.
 */
-export async function fetchAllModelStatuses(wsControllerURL, conn, reduxStore) {
+export async function fetchAllModelStatuses(
+  wsControllerURL,
+  modelUUIDList,
+  conn,
+  reduxStore
+) {
   const getState = reduxStore.getState;
-  const modelList = getState().juju.models;
   const dispatch = reduxStore.dispatch;
   const queue = new Limiter({ concurrency: 5 });
-  const modelUUIDs = Object.keys(modelList);
-  modelUUIDs.forEach((modelUUID) => {
+  modelUUIDList.forEach((modelUUID) => {
     queue.push(async (done) => {
       if (isLoggedIn(wsControllerURL, getState())) {
         await fetchAndStoreModelStatus(

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector, useStore } from "react-redux";
 import cloneDeep from "clone-deep";
 import classNames from "classnames";
 
@@ -8,7 +8,8 @@ import Header from "components/Header/Header";
 import SlidePanel from "components/SlidePanel/SlidePanel";
 import MainTable from "@canonical/react-components/dist/components/MainTable/MainTable";
 
-import { getControllerData, getModelData } from "app/selectors";
+import { getBakery, getControllerData, getModelData } from "app/selectors";
+import { connectAndStartPolling } from "app/actions";
 import useLocalStorage from "hooks/useLocalStorage";
 import ControllersOverview from "./ControllerOverview/ControllerOverview";
 
@@ -151,6 +152,9 @@ function Details() {
 
 function RegisterAController({ onClose }) {
   const [formValues, setFormValues] = useState({});
+  const dispatch = useDispatch();
+  const reduxStore = useStore();
+  const bakery = useSelector(getBakery);
   const [additionalControllers, setAdditionalControllers] = useLocalStorage(
     "additionalControllers",
     []
@@ -167,6 +171,7 @@ function RegisterAController({ onClose }) {
       true, // additional controller
     ]);
     setAdditionalControllers(additionalControllers);
+    dispatch(connectAndStartPolling(reduxStore, bakery));
     onClose(); // Close the SlidePanel
   }
 

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -218,7 +218,7 @@ function RegisterAController({ onClose }) {
                 id="full-name-stacked"
                 name="controllerName"
                 onChange={handleInputChange}
-                required="true"
+                required={true}
               />
               <p className="p-form-help-text">
                 Must be a valid alpha-numeric Juju controller name. <br />
@@ -245,7 +245,7 @@ function RegisterAController({ onClose }) {
                 id="full-name-stacked"
                 name="wsControllerHost"
                 onChange={handleInputChange}
-                required="true"
+                required={true}
               />
               <p className="p-form-help-text">
                 You'll typically want to use the public IP:Port address for the
@@ -270,7 +270,6 @@ function RegisterAController({ onClose }) {
                 id="full-name-stacked"
                 name="username"
                 onChange={handleInputChange}
-                required=""
               />
               <p className="p-form-help-text">
                 The username you use to access the controller.
@@ -293,7 +292,6 @@ function RegisterAController({ onClose }) {
                 id="full-name-stacked"
                 name="password"
                 onChange={handleInputChange}
-                required=""
               />
               <p className="p-form-help-text">
                 The password will be what you used when running{" "}
@@ -316,7 +314,6 @@ function RegisterAController({ onClose }) {
               name="identityProvider"
               defaultChecked={false}
               onChange={handleInputChange}
-              required=""
             />
             <label htmlFor="identityProviderAvailable">
               An identity provider is available.{" "}
@@ -345,7 +342,7 @@ function RegisterAController({ onClose }) {
               name="certificateAccepted"
               defaultChecked={false}
               onChange={handleInputChange}
-              required="true"
+              required={true}
             />
             <label htmlFor="certificateHasBeenAccepted">
               The SSL certificate, if any, has been accepted.{" "}


### PR DESCRIPTION
## Done

When a new controller is registered with the dashboard immediately connect to it and start polling the models.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Bootstrap a new controller & register it with the dashboard, it should immediately show up in the controller list and the models should appear in the model list.

## Details

Fixes #603 

