### PR TITLE
Fix: Controller page console errors and JAAS controller name display

### DIFF
--- a/src/app/model-poller.js
+++ b/src/app/model-poller.js
@@ -107,7 +107,12 @@ export async function connectAndPollController(
   if (!isJuju) {
     // This call will be a noop if the user isn't an administrator
     // on the JIMM controller we're connected to.
-    disableControllerUUIDMasking(conn);
+    try {
+      await disableControllerUUIDMasking(conn);
+    } catch (e) {
+      // Silently fail, if this doesn't work then the user isn't authorized
+      // to perform the action.
+    }
   }
 
   do {

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -327,7 +327,16 @@ export async function fetchControllerList(
   @param {Object} conn The controller connection instance.
 */
 export function disableControllerUUIDMasking(conn) {
-  if (conn?.facades?.jimM) {
-    conn.facades.jimM.disableControllerUUIDMasking();
-  }
+  return new Promise(async (resolve, reject) => {
+    if (conn?.facades?.jimM) {
+      try {
+        await conn.facades.jimM.disableControllerUUIDMasking();
+        resolve();
+      } catch (e) {
+        reject();
+      }
+    } else {
+      resolve();
+    }
+  });
 }

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -93,7 +93,7 @@ function Details() {
     const cloud = c?.location?.cloud || "unknown";
     const region = c?.location?.region || "unknown";
     const cloudRegion = `${cloud}/${region}`;
-    const publicAccess = c?.Public || "False";
+    const publicAccess = `${c?.Public}` || "False";
     const path = c.path === "admin/jaas" ? "JAAS" : c.path;
     return {
       columns: [

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -94,9 +94,10 @@ function Details() {
     const region = c?.location?.region || "unknown";
     const cloudRegion = `${cloud}/${region}`;
     const publicAccess = c?.Public || "False";
+    const path = c.path === "admin/jaas" ? "JAAS" : c.path;
     return {
       columns: [
-        { content: c.path },
+        { content: path },
         { content: cloudRegion },
         { content: c.models, className: "u-align--right" },
         { content: c.machines, className: "u-align--right" },


### PR DESCRIPTION
## Done

- Show JAAS instead of admin/jaas for the JAAS controller.
- Resolve the 'unauthorized' error in the console by silently failing.
- Fixed console warning about invalid prop type in the controller.

## QA

In the demo link are all three issues below resolved?

## Details

Fixes #631
Fixes #632
Fixes #633 

## Screenshots

![Screen Shot 2020-07-30 at 3 25 50 PM](https://user-images.githubusercontent.com/532033/88976259-fa91f780-d278-11ea-86d8-e9de1df1cf98.png)

