### PR TITLE
Add keyboard navigation to primary navigation

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useSelector, useStore } from "react-redux";
+import { useSelector, useStore, useDispatch } from "react-redux";
 import { isLoggedIn, getWSControllerURL } from "app/selectors";
 import Notification from "@canonical/react-components/dist/components/Notification/Notification";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
@@ -8,17 +8,21 @@ import useHover from "hooks/useHover";
 import useLocalStorage from "hooks/useLocalStorage";
 import { getViewportWidth, debounce } from "app/utils";
 
+import { userMenuActive, externalNavActive } from "ui/actions";
 import { isSidebarCollapsible } from "ui/selectors";
 
 import "./_layout.scss";
 
 const Layout = ({ children }) => {
   const [sidebarRef, isSidebarHovered] = useHover();
+  const [sidebarInFocus, setSidebarInFocus] = useState(false);
   const [screenWidth, setScreenWidth] = useState(getViewportWidth());
   const [releaseNotification, setReleaseNotification] = useLocalStorage(
     "releaseNotification",
     false
   );
+  const containerRef = useRef(null);
+  const dispatch = useDispatch();
 
   const store = useStore();
   const userIsLoggedIn = isLoggedIn(
@@ -36,6 +40,30 @@ const Layout = ({ children }) => {
     }
   };
 
+  // If any item in the primary nav receives focus, the primary nav should expand
+  useEffect(() => {
+    const container = containerRef.current;
+    const containerInFocus = container.addEventListener("focusin", (e) => {
+      const inPrimaryNav = e.target.closest(".p-primary-nav");
+      if (inPrimaryNav && !sidebarInFocus) {
+        setSidebarInFocus(true);
+        if (e.target.closest(".user-menu")) {
+          dispatch(userMenuActive(true));
+        }
+        if (e.target.closest(".p-list.is-external")) {
+          dispatch(externalNavActive(true));
+        } else {
+          dispatch(externalNavActive(false));
+        }
+      } else if (!inPrimaryNav) {
+        setSidebarInFocus(false);
+        dispatch(userMenuActive(false));
+      }
+    });
+
+    return container.removeEventListener("focusin", containerInFocus);
+  }, [sidebarInFocus, dispatch]);
+
   useEffect(() => {
     isMounted.current = true;
     window.addEventListener("resize", debounce(handleScreenResize, 250));
@@ -46,49 +74,56 @@ const Layout = ({ children }) => {
   }, []);
 
   return (
-    <div
-      className={classNames("l-container", {
-        "has-collapsible-sidebar": sidebarCollapsible || isSmallScreen,
-      })}
-    >
+    <>
+      <a className="skip-main" href="#main-content">
+        Skip to main content
+      </a>
+
       <div
-        className={classNames("l-side", {
-          "is-collapsed":
-            (sidebarCollapsible && !isSidebarHovered) ||
-            (isSmallScreen && !isSidebarHovered),
+        className={classNames("l-container", {
+          "has-collapsible-sidebar": sidebarCollapsible || isSmallScreen,
         })}
-        ref={sidebarRef}
+        ref={containerRef}
       >
-        <PrimaryNav />
+        <div
+          className={classNames("l-side", {
+            "is-collapsed":
+              (sidebarCollapsible && !isSidebarHovered && !sidebarInFocus) ||
+              (isSmallScreen && !isSidebarHovered && !sidebarInFocus),
+          })}
+          ref={sidebarRef}
+        >
+          <PrimaryNav />
+        </div>
+        <main className="l-main" id="main-content">
+          <div data-test="main-children">{children}</div>
+          {userIsLoggedIn && !releaseNotification && (
+            <Notification
+              type="information"
+              close={() => {
+                setReleaseNotification(true);
+              }}
+            >
+              Welcome to the new Juju Dashboard! This dashboard is the
+              replacement for the Juju GUI in JAAS and individual Juju
+              Controllers from Juju 2.8.{" "}
+              <span className="u-hide--small">
+                Read more and join the discussion about this new dashboard{" "}
+                <a
+                  className="p-link--external"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  href="https://discourse.juju.is/t/jaas-dashboard-the-new-juju-gui/2978"
+                >
+                  on Discourse
+                </a>
+                . We would love to hear your feedback.
+              </span>
+            </Notification>
+          )}
+        </main>
       </div>
-      <main className="l-main" id="main-content">
-        <div data-test="main-children">{children}</div>
-        {userIsLoggedIn && !releaseNotification && (
-          <Notification
-            type="information"
-            close={() => {
-              setReleaseNotification(true);
-            }}
-          >
-            Welcome to the new Juju Dashboard! This dashboard is the replacement
-            for the Juju GUI in JAAS and individual Juju Controllers from Juju
-            2.8.{" "}
-            <span className="u-hide--small">
-              Read more and join the discussion about this new dashboard{" "}
-              <a
-                className="p-link--external"
-                target="_blank"
-                rel="noreferrer noopener"
-                href="https://discourse.juju.is/t/jaas-dashboard-the-new-juju-gui/2978"
-              >
-                on Discourse
-              </a>
-              . We would love to hear your feedback.
-            </span>
-          </Notification>
-        )}
-      </main>
-    </div>
+    </>
   );
 };
 

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -2,6 +2,35 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/functions/z-index";
 
+.skip-main {
+  height: 1px;
+  left: -9999px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
+
+  &:focus,
+  &:active {
+    background-color: $color-navigation-dark;
+    border: 4px solid $color-caution;
+    border-radius: 5px;
+    color: $color-x-light;
+    font-size: 1rem;
+    height: auto;
+    left: 50%;
+    margin: 1rem;
+    margin-left: -15%;
+    outline: none;
+    overflow: auto;
+    padding: 1rem;
+    text-align: center;
+    top: auto;
+    width: 30%;
+    z-index: 9999;
+  }
+}
+
 .l-container {
   display: flex;
   min-height: 100vh;


### PR DESCRIPTION
## Done

- Add 'skip to main content' link
- Make primary nav accessible via keyboard

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Run through side navigation with keyboard

## Details

Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/660
