### PR TITLE
Fix broken "N models" link at the top of Controllers page

### DIFF
--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -386,7 +386,7 @@ export default function Controllers() {
       <Header>
         <div className="controllers--count">
           {controllerCount} controllers,{" "}
-          <a href="/models">{modelCount} models</a>
+          <a href="/dashboard/models">{modelCount} models</a>
         </div>
       </Header>
       <div className="l-content controllers">


### PR DESCRIPTION
The `/models` link is a broken link and returns a 404. I believe this should be `/dashboard/models` (which works).

Context for this: I just started at Canonical on Monday (on the Juju team), and found this when playing with Juju locally and clicking around the GUI.