### PR TITLE
Allow custom classes to be passed into the slide panel

### DIFF
--- a/src/components/SlidePanel/SlidePanel.js
+++ b/src/components/SlidePanel/SlidePanel.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
+import classnames from "classnames";
 
 import "./_slide-panel.scss";
 
-function SlidePanel({ children, onClose, isActive }) {
+function SlidePanel({ children, onClose, isActive, className }) {
   // If Escape key is pressed when slide panel is open, close it
   useEffect(() => {
     if (!isActive) return;
@@ -27,7 +28,10 @@ function SlidePanel({ children, onClose, isActive }) {
   }, [isActive, onClose]);
 
   return (
-    <div className="slide-panel" aria-hidden={!isActive}>
+    <div
+      className={classnames("slide-panel", className)}
+      aria-hidden={!isActive}
+    >
       <button
         className="p-modal__close"
         aria-label="Close active modal"

--- a/src/components/SlidePanel/SlidePanel.test.js
+++ b/src/components/SlidePanel/SlidePanel.test.js
@@ -65,4 +65,13 @@ describe("Slide Panel", () => {
     );
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("accepts classnames and adds them to the wrapper", () => {
+    const wrapper = shallow(
+      <SlidePanel isActive={true} className="test-class" />
+    );
+    expect(wrapper.find(".slide-panel").prop("className")).toBe(
+      "slide-panel test-class"
+    );
+  });
 });

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector, useStore } from "react-redux";
+import { Link } from "react-router-dom";
 import cloneDeep from "clone-deep";
 import classNames from "classnames";
 
@@ -386,7 +387,7 @@ export default function Controllers() {
       <Header>
         <div className="controllers--count">
           {controllerCount} controllers,{" "}
-          <a href="/models">{modelCount} models</a>
+          <Link to="/models">{modelCount} models</Link>
         </div>
       </Header>
       <div className="l-content controllers">

--- a/src/pages/Controllers/Controllers.js
+++ b/src/pages/Controllers/Controllers.js
@@ -194,7 +194,11 @@ function RegisterAController({ onClose, showRegisterAController }) {
   }
 
   return (
-    <SlidePanel onClose={onClose} isActive={showRegisterAController}>
+    <SlidePanel
+      onClose={onClose}
+      isActive={showRegisterAController}
+      className="register-a-controller__slide-panel"
+    >
       <h5>Register a Controller</h5>
       <p className="p-form-help-text">
         Information can be retrieved using the <code>juju show-controller</code>{" "}

--- a/src/pages/Controllers/_controllers.scss
+++ b/src/pages/Controllers/_controllers.scss
@@ -45,9 +45,8 @@
     }
   }
 
-  .register-a-controller {
-    margin-top: 1rem;
-    text-align: right;
+  .register-a-controller__slide-panel {
+    width: inherit;
   }
 
   .slide-panel__content {

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -244,6 +244,7 @@ const ModelDetails = () => {
         <SlidePanel
           isActive={slidePanelActive}
           onClose={() => setSlidePanelData({})}
+          className="slide-panel__application-details"
         >
           <>
             {appSlidePanelHeader}

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -195,7 +195,7 @@
 }
 
 @mixin model-details-slidepanel-apps {
-  .slide-panel {
+  .slide-panel__application-details {
     @media (max-width: $breakpoint-medium) {
       top: 8rem;
     }


### PR DESCRIPTION
## Done

The previous app panel work for the model details incorrectly set a global width and top value for the slide panel which broke the UI for the register controllers panel. This change adds the ability to pass in a className for the slide panel so that each usage of the panel can customize its placement.

As a driveby this also fixes the model link in the controllers page so that it will correctly link when being run with a different basepath.

## QA

- Build the dashboard and run it in a self-bootstrapped environment using [this guide](https://github.com/canonical-web-and-design/jaas-dashboard#uploading-the-tarball-to-a-juju-controller)
- Switch to the controller page and click the models link at the top, does it go back to the models list?
- Deploy an application to a model
- Click that application, does the app panel expand as expected?
- In the controller page, click to 'register a controller', is it properly rendered?
- Try both slide panels in a mobile view to make sure it constrains as expected.

## Details

Fixes #671
Fixes #669 


