### PR TITLE
Add entity counts to each view in the model details page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 .DS_Store
 juju-dashboard*.tar.bz2
 coverage/
+.dotrun.json

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -152,16 +152,21 @@ export const extractOwnerName = (tag) => {
 };
 
 /**
-  Returns (s) string if the value is more then one
+  Pluralizes the supplied word based on the provided dataset.
   @param {string} value The integer to be checked
   @param {string} string The item name to be pluralized
   @returns {string} The item pluralized if required
 */
 export const pluralize = (value, string) => {
-  if (value === 0 || value > 1) {
-    return string + "s";
+  const special = {
+    running: "running",
+  };
+  if (value === 1) {
+    return string;
+  } else if (special[string]) {
+    return special[string];
   }
-  return string;
+  return `${string}s`;
 };
 
 /**

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -159,7 +159,10 @@ export const extractOwnerName = (tag) => {
 */
 export const pluralize = (value, string) => {
   const special = {
+    active: "active",
     running: "running",
+    unknown: "unknown",
+    waiting: "waiting",
   };
   if (value === 1) {
     return string;

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -160,7 +160,12 @@ export const extractOwnerName = (tag) => {
 export const pluralize = (value, string) => {
   const special = {
     active: "active",
+    allocating: "allocating",
+    down: "down",
+    joined: "joined",
+    lost: "lost",
     running: "running",
+    started: "started",
     unknown: "unknown",
     waiting: "waiting",
   };

--- a/src/components/Counts/Counts.js
+++ b/src/components/Counts/Counts.js
@@ -5,7 +5,7 @@ import "./_counts.scss";
 
 const Counts = ({ primaryEntity, secondaryEntities }) => {
   const statuses = secondaryEntities
-    .map((entity) => {
+    ?.map((entity) => {
       return `${entity.count} ${pluralize(entity.count, entity.label)}`;
     })
     .join(", ");

--- a/src/components/Counts/Counts.js
+++ b/src/components/Counts/Counts.js
@@ -10,10 +10,10 @@ const Counts = ({ primaryEntity, secondaryEntities }) => {
     })
     .join(", ");
   return (
-    <div className="entity-counts">
+    <small className="entity-counts">
       {primaryEntity.count}{" "}
       {pluralize(primaryEntity.count, primaryEntity.label)}: {statuses}
-    </div>
+    </small>
   );
 };
 

--- a/src/components/Counts/Counts.js
+++ b/src/components/Counts/Counts.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { pluralize } from "app/utils";
+
+import "./_counts.scss";
+
+const Counts = ({ primaryEntity, secondaryEntities }) => {
+  const statuses = secondaryEntities
+    .map((entity) => {
+      return `${entity.count} ${pluralize(entity.count, entity.label)}`;
+    })
+    .join(", ");
+  return (
+    <div className="entity-counts">
+      {primaryEntity.count}{" "}
+      {pluralize(primaryEntity.count, primaryEntity.label)}: {statuses}
+    </div>
+  );
+};
+
+export default Counts;

--- a/src/components/Counts/Counts.test.js
+++ b/src/components/Counts/Counts.test.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import Counts from "./Counts";
+
+describe("Counts", () => {
+  it("shows the primaryEntity content without any secondaryEntities provided", () => {
+    const wrapper = mount(
+      <Counts primaryEntity={{ count: 1, label: "application" }} />
+    );
+    expect(wrapper.find(".entity-counts").text()).toBe("1 application: ");
+  });
+
+  it("shows the secondaryEntities content if provided", () => {
+    const wrapper = mount(
+      <Counts
+        primaryEntity={{ count: 1, label: "application" }}
+        secondaryEntities={[
+          { count: 1, label: "machine" },
+          { count: 2, label: "running" },
+        ]}
+      />
+    );
+    expect(wrapper.find(".entity-counts").text()).toBe(
+      "1 application: 1 machine, 2 running"
+    );
+  });
+
+  it("pluralizes multiple values on primaryEntity and secondaryEntities", () => {
+    const wrapper = mount(
+      <Counts
+        primaryEntity={{ count: 3, label: "application" }}
+        secondaryEntities={[
+          { count: 7, label: "machine" },
+          { count: 2, label: "running" },
+        ]}
+      />
+    );
+    expect(wrapper.find(".entity-counts").text()).toBe(
+      "3 applications: 7 machines, 2 running"
+    );
+  });
+});

--- a/src/components/Counts/_counts.scss
+++ b/src/components/Counts/_counts.scss
@@ -1,0 +1,5 @@
+.entity-counts {
+  font-size: 0.875rem;
+  line-height: 0.875rem;
+  margin-bottom: 1rem;
+}

--- a/src/components/Counts/_counts.scss
+++ b/src/components/Counts/_counts.scss
@@ -1,5 +1,5 @@
 .entity-counts {
-  font-size: 0.875rem;
   line-height: 0.875rem;
   margin-bottom: 1rem;
+  vertical-align: top;
 }

--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -3,8 +3,6 @@
 @import "../../scss/functions/z-index";
 
 .info-panel {
-  padding: 1rem 0;
-
   @media (min-width: $breakpoint-small) {
     display: grid;
     gap: 1rem;

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom";
 import cloneDeep from "clone-deep";
 
 import ButtonGroup from "components/ButtonGroup/ButtonGroup";
+import Counts from "components/Counts/Counts";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 import Layout from "components/Layout/Layout";
 import Header from "components/Header/Header";
@@ -128,6 +129,22 @@ const shouldShow = (segment, activeView) => {
   }
 };
 
+const generateApplicationSecondaryCounts = (modelStatusData) =>
+  Object.entries(
+    Object.entries(modelStatusData.applications).reduce(
+      (counts, application) => {
+        const status = application[1].status.status;
+        if (counts[status]) {
+          counts[status] = counts[status] += 1;
+        } else {
+          counts[status] = 1;
+        }
+        return counts;
+      },
+      {}
+    )
+  ).map((statusSet) => ({ count: statusSet[1], label: statusSet[0] }));
+
 const ModelDetails = () => {
   const { 0: modelName } = useParams();
   const dispatch = useDispatch();
@@ -243,13 +260,24 @@ const ModelDetails = () => {
           <InfoPanel />
           <div className="model-details__main u-overflow--scroll">
             {shouldShow("apps", activeView) && (
-              <MainTable
-                headers={applicationTableHeaders}
-                rows={applicationTableRows}
-                className="model-details__apps p-main-table"
-                sortable
-                emptyStateMsg={"There are no applications in this model"}
-              />
+              <>
+                <Counts
+                  primaryEntity={{
+                    count: applicationTableRows.length,
+                    label: "application",
+                  }}
+                  secondaryEntities={generateApplicationSecondaryCounts(
+                    modelStatusData
+                  )}
+                />
+                <MainTable
+                  headers={applicationTableHeaders}
+                  rows={applicationTableRows}
+                  className="model-details__apps p-main-table"
+                  sortable
+                  emptyStateMsg={"There are no applications in this model"}
+                />
+              </>
             )}
             {shouldShow("units", activeView) && (
               <MainTable

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -36,7 +36,7 @@ describe("ModelDetail Container", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={["/models/space-man@external/frontend-ci"]}
+          initialEntries={["/models/spaceman@external/hadoopspark"]}
         >
           <TestRoute path="/models/*">
             <ModelDetails />

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -6,6 +6,7 @@
     display: grid;
     grid-template-columns: 1fr;
     margin-bottom: 2rem;
+    padding-top: 1rem;
     padding-bottom: 3rem;
 
     @media (min-width: $breakpoint-medium) {

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -6,8 +6,8 @@
     display: grid;
     grid-template-columns: 1fr;
     margin-bottom: 2rem;
-    padding-top: 1rem;
     padding-bottom: 3rem;
+    padding-top: 1rem;
 
     @media (min-width: $breakpoint-medium) {
       gap: 1rem;


### PR DESCRIPTION
## Done

- Added counts to the top of each entity view in the model details page.
- Updated pluralizer to support special case words.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a few models and look at the counts on each entity view.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1412
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1413
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1414

## Screenshots

![Screen Shot 2020-09-14 at 4 55 20 PM](https://user-images.githubusercontent.com/532033/93146050-1b889d80-f6ab-11ea-9547-b4eb34399829.png)

