### PR TITLE
Revise panel

### DIFF
--- a/src/components/SlidePanel/_slide-panel.scss
+++ b/src/components/SlidePanel/_slide-panel.scss
@@ -16,7 +16,7 @@
   transform: translateX(100%);
 
   @media (min-width: $breakpoint-medium) {
-    width: 75vw;
+    width: 60vw;
   }
 
   &[aria-hidden="false"] {

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -251,7 +251,7 @@ const ModelDetails = () => {
         </div>
       </Header>
       <div className="l-content">
-        <div className="model-details" aria-disabled={panel != null}>
+        <div className="model-details">
           <InfoPanel />
           <div className="model-details__main u-overflow--scroll">
             {renderCounts(activeView, modelStatusData)}

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -212,9 +212,10 @@ const ModelDetails = () => {
     return generateApplicationRows(
       modelStatusData,
       handleAppRowClick,
-      baseAppURL
+      baseAppURL,
+      query?.entity
     );
-  }, [baseAppURL, modelStatusData, setQuery]);
+  }, [baseAppURL, modelStatusData, setQuery, query]);
 
   const unitTableRows = useMemo(
     () => generateUnitRows(modelStatusData, baseAppURL),

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -17,11 +17,6 @@
     @media (min-width: $breakpoint-m-large) {
       grid-template-columns: 350px 1fr;
     }
-
-    &[aria-disabled="true"] {
-      opacity: 0.5;
-      pointer-events: none;
-    }
   }
 }
 

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -102,7 +102,8 @@ export function generateEntityIdentifier(
 export function generateApplicationRows(
   modelStatusData,
   onRowClick,
-  baseAppURL
+  baseAppURL,
+  selectedEntity
 ) {
   if (!modelStatusData) {
     return [];
@@ -158,6 +159,7 @@ export function generateApplicationRows(
       ],
       onClick: (e) => onRowClick(e, app),
       "data-app": key,
+      class: selectedEntity === key ? "is-selected" : "",
     };
   });
 }


### PR DESCRIPTION
## Done

- Reduce panel to 60% of viewport width
- Enable background interaction when a panel is open

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View model details
- Click a model with more than one app
- Panel will open - should be 60% of viewport
- Click another app under panel and see panel content change

## Details

Fixes #685, Fixes #683 
