### PR TITLE
Hide empty tables in model status view

### DIFF
--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -178,24 +178,30 @@ export default function StatusGroup({ activeUser, filters }) {
 
   return (
     <div className="status-group u-overflow--scroll">
-      <MainTable
-        headers={generateStatusTableHeaders("Blocked", blockedRows.length)}
-        rows={blockedRows}
-        sortable
-        emptyStateMsg={emptyStateMsg}
-      />
-      <MainTable
-        headers={generateStatusTableHeaders("Alert", alertRows.length)}
-        rows={alertRows}
-        sortable
-        emptyStateMsg={emptyStateMsg}
-      />
-      <MainTable
-        headers={generateStatusTableHeaders("Running", runningRows.length)}
-        rows={runningRows}
-        sortable
-        emptyStateMsg={emptyStateMsg}
-      />
+      {blockedRows.length ? (
+        <MainTable
+          headers={generateStatusTableHeaders("Blocked", blockedRows.length)}
+          rows={blockedRows}
+          sortable
+          emptyStateMsg={emptyStateMsg}
+        />
+      ) : null}
+      {alertRows.length ? (
+        <MainTable
+          headers={generateStatusTableHeaders("Alert", alertRows.length)}
+          rows={alertRows}
+          sortable
+          emptyStateMsg={emptyStateMsg}
+        />
+      ) : null}
+      {runningRows.length ? (
+        <MainTable
+          headers={generateStatusTableHeaders("Running", runningRows.length)}
+          rows={runningRows}
+          sortable
+          emptyStateMsg={emptyStateMsg}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/ModelTableList/StatusGroup.test.js
+++ b/src/components/ModelTableList/StatusGroup.test.js
@@ -11,7 +11,7 @@ import dataDump from "../../testing/complete-redux-store-dump";
 const mockStore = configureStore([]);
 
 describe("StatusGroup", () => {
-  it("by default, renders with all table headers and no data", () => {
+  it("by default, renders no tables when there is no data", () => {
     const store = mockStore({
       root: {},
       juju: {
@@ -27,10 +27,7 @@ describe("StatusGroup", () => {
       </Provider>
     );
     const tables = wrapper.find("MainTable");
-    expect(tables.length).toBe(3);
-    expect(tables.get(0).props.rows).toEqual([]);
-    expect(tables.get(1).props.rows).toEqual([]);
-    expect(tables.get(2).props.rows).toEqual([]);
+    expect(tables.length).toBe(0);
   });
 
   it("displays model data grouped by status from the redux store", () => {


### PR DESCRIPTION
## Done

To match the experience in the other views hide empty tables in the status view.

On initial load the page is blank until the data loads, we'll want to add an 'empty' page state as a follow-up.

## QA

- Load the demo, is it empty until the data loads? 
- Do the status tables only load if you have data for them?
