### PR TITLE
Enable panel tables on model details page

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -18,7 +18,7 @@ import {
   @returns {Object|Null} The list of model data or null if none found.
 */
 export const getModelData = (state) => {
-  if (state.juju && state.juju.modelData) {
+  if (state?.juju?.modelData) {
     return state.juju.modelData;
   }
   return null;
@@ -107,7 +107,7 @@ const getFilteredModelData = (filters) =>
 */
 const getUserCredentials = (state) => {
   let storedMacaroons = null;
-  if (state.root && state.root.bakery) {
+  if (state?.root?.bakery) {
     storedMacaroons = state.root.bakery.storage._store;
   }
   return storedMacaroons;

--- a/src/components/panels/AppsPanel/AppsPanel.js
+++ b/src/components/panels/AppsPanel/AppsPanel.js
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { getConfig } from "app/selectors";
-import SlidePanel from "components/SlidePanel/SlidePanel";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 
 import useModelStatus from "hooks/useModelStatus";
@@ -24,12 +23,7 @@ import {
 
 import "./_apps-panel.scss";
 
-export default function AppsPanel({
-  isActive,
-  onClose,
-  entity,
-  panelRowClick,
-}) {
+export default function AppsPanel({ entity, panelRowClick }) {
   // Get model status info
   const modelStatusData = useModelStatus();
 
@@ -124,42 +118,32 @@ export default function AppsPanel({
     [filteredModelStatusData, baseAppURL]
   );
 
-  // Check for loading status
-  const isLoading = !filteredModelStatusData?.applications?.[entity];
-
   return (
-    <SlidePanel
-      isActive={isActive}
-      onClose={onClose}
-      isLoading={isLoading}
-      className="apps-panel"
-    >
-      <>
-        {appPanelHeader}
-        <div className="slide-panel__tables">
-          <MainTable
-            headers={unitTableHeaders}
-            rows={unitPanelRows}
-            className="model-details__units p-main-table panel__table"
-            sortable
-            emptyStateMsg={"There are no units in this model"}
-          />
-          <MainTable
-            headers={machineTableHeaders}
-            rows={machinesPanelRows}
-            className="model-details__machines p-main-table panel__table"
-            sortable
-            emptyStateMsg={"There are no machines in this model"}
-          />
-          <MainTable
-            headers={relationTableHeaders}
-            rows={relationPanelRows}
-            className="model-details__relations p-main-table panel__table"
-            sortable
-            emptyStateMsg={"There are no relations in this model"}
-          />
-        </div>
-      </>
-    </SlidePanel>
+    <>
+      {appPanelHeader}
+      <div className="slide-panel__tables">
+        <MainTable
+          headers={unitTableHeaders}
+          rows={unitPanelRows}
+          className="model-details__units p-main-table panel__table"
+          sortable
+          emptyStateMsg={"There are no units in this model"}
+        />
+        <MainTable
+          headers={machineTableHeaders}
+          rows={machinesPanelRows}
+          className="model-details__machines p-main-table panel__table"
+          sortable
+          emptyStateMsg={"There are no machines in this model"}
+        />
+        <MainTable
+          headers={relationTableHeaders}
+          rows={relationPanelRows}
+          className="model-details__relations p-main-table panel__table"
+          sortable
+          emptyStateMsg={"There are no relations in this model"}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/panels/AppsPanel/AppsPanel.js
+++ b/src/components/panels/AppsPanel/AppsPanel.js
@@ -116,7 +116,7 @@ export default function AppsPanel({
 
   const unitPanelRows = useMemo(
     () => generateUnitRows(filteredModelStatusData, panelRowClick),
-    [panelRowClick, filteredModelStatusData]
+    [filteredModelStatusData, panelRowClick]
   );
 
   const relationPanelRows = useMemo(

--- a/src/components/panels/AppsPanel/AppsPanel.js
+++ b/src/components/panels/AppsPanel/AppsPanel.js
@@ -24,7 +24,12 @@ import {
 
 import "./_apps-panel.scss";
 
-export default function AppsPanel({ isActive, onClose, entity, panelRowClick }) {
+export default function AppsPanel({
+  isActive,
+  onClose,
+  entity,
+  panelRowClick,
+}) {
   // Get model status info
   const modelStatusData = useModelStatus();
 

--- a/src/components/panels/AppsPanel/AppsPanel.js
+++ b/src/components/panels/AppsPanel/AppsPanel.js
@@ -24,7 +24,7 @@ import {
 
 import "./_apps-panel.scss";
 
-export default function AppsPanel({ isActive, onClose, entity }) {
+export default function AppsPanel({ isActive, onClose, entity, panelRowClick }) {
   // Get model status info
   const modelStatusData = useModelStatus();
 
@@ -105,13 +105,13 @@ export default function AppsPanel({ isActive, onClose, entity }) {
   );
 
   const machinesPanelRows = useMemo(
-    () => generateMachineRows(filteredModelStatusData),
-    [filteredModelStatusData]
+    () => generateMachineRows(filteredModelStatusData, panelRowClick),
+    [filteredModelStatusData, panelRowClick]
   );
 
   const unitPanelRows = useMemo(
-    () => generateUnitRows(filteredModelStatusData, baseAppURL),
-    [baseAppURL, filteredModelStatusData]
+    () => generateUnitRows(filteredModelStatusData, panelRowClick),
+    [panelRowClick, filteredModelStatusData]
   );
 
   const relationPanelRows = useMemo(

--- a/src/components/panels/MachinesPanel/MachinesPanel.js
+++ b/src/components/panels/MachinesPanel/MachinesPanel.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback } from "react";
-import SlidePanel from "components/SlidePanel/SlidePanel";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import cloneDeep from "clone-deep";
 
@@ -16,12 +15,7 @@ import { generateStatusElement } from "app/utils";
 
 import "./_machines-panel.scss";
 
-export default function MachinesPanel({
-  isActive,
-  onClose,
-  entity: machineId,
-  panelRowClick,
-}) {
+export default function MachinesPanel({ entity: machineId, panelRowClick }) {
   const modelStatusData = useModelStatus();
   const machine = modelStatusData?.machines[machineId];
 
@@ -43,7 +37,7 @@ export default function MachinesPanel({
         {machine && (
           <div className="row">
             <div className="col-4">
-              <div className="machine-panel__id">
+              <div className="machines-panel__id">
                 <strong>
                   <span className="entity-name">
                     Machine '{machineId}' - {machine?.series}
@@ -159,35 +153,25 @@ export default function MachinesPanel({
     [filteredModelStatusDataByUnit, machineId, panelRowClick]
   );
 
-  // Check for loading status
-  const isLoading = !modelStatusData?.machines;
-
   return (
-    <SlidePanel
-      isActive={isActive}
-      onClose={onClose}
-      isLoading={isLoading}
-      className="machines-panel"
-    >
-      <>
-        {machinePanelHeader}
-        <div className="slide-panel__tables">
-          <MainTable
-            headers={unitTableHeaders}
-            rows={unitRows}
-            className="model-details__units p-main-table"
-            sortable
-            emptyStateMsg={"There are no units in this model"}
-          />
-          <MainTable
-            headers={applicationTableHeaders}
-            rows={applicationRows}
-            className="model-details__apps p-main-table"
-            sortable
-            emptyStateMsg={"There are no apps in this model"}
-          />
-        </div>
-      </>
-    </SlidePanel>
+    <>
+      {machinePanelHeader}
+      <div className="slide-panel__tables">
+        <MainTable
+          headers={unitTableHeaders}
+          rows={unitRows}
+          className="model-details__units p-main-table"
+          sortable
+          emptyStateMsg={"There are no units in this model"}
+        />
+        <MainTable
+          headers={applicationTableHeaders}
+          rows={applicationRows}
+          className="model-details__apps p-main-table"
+          sortable
+          emptyStateMsg={"There are no apps in this model"}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/panels/MachinesPanel/MachinesPanel.js
+++ b/src/components/panels/MachinesPanel/MachinesPanel.js
@@ -20,7 +20,7 @@ export default function MachinesPanel({
   isActive,
   onClose,
   entity: machineId,
-  panelRowClick
+  panelRowClick,
 }) {
   const modelStatusData = useModelStatus();
   const machine = modelStatusData?.machines[machineId];
@@ -134,13 +134,18 @@ export default function MachinesPanel({
 
   // Generate apps table content
   const applicationRows = useMemo(
-    () => generateApplicationRows(filteredModelStatusDataByApp(machineId), panelRowClick),
+    () =>
+      generateApplicationRows(
+        filteredModelStatusDataByApp(machineId),
+        panelRowClick
+      ),
     [filteredModelStatusDataByApp, machineId, panelRowClick]
   );
 
   // Generate units table content
   const unitRows = useMemo(
-    () => generateUnitRows(filteredModelStatusDataByUnit(machineId), panelRowClick),
+    () =>
+      generateUnitRows(filteredModelStatusDataByUnit(machineId), panelRowClick),
     [filteredModelStatusDataByUnit, machineId, panelRowClick]
   );
 

--- a/src/components/panels/MachinesPanel/MachinesPanel.js
+++ b/src/components/panels/MachinesPanel/MachinesPanel.js
@@ -102,7 +102,9 @@ export default function MachinesPanel({
             if (Object.entries(units).length) {
               Object.values(units).forEach((unit) => {
                 if (
+                  // Delete any app without a unit matching this machineId...
                   unit.machine !== machineId ||
+                  // ...delete any app without units at all
                   !Object.entries(units).length
                 ) {
                   delete filteredModelStatusData.applications[application];

--- a/src/components/panels/MachinesPanel/MachinesPanel.js
+++ b/src/components/panels/MachinesPanel/MachinesPanel.js
@@ -97,12 +97,20 @@ export default function MachinesPanel({
         Object.keys(filteredModelStatusData.applications).forEach(
           (application) => {
             const units =
-              filteredModelStatusData.applications[application].units;
-            Object.values(units).forEach((unit) => {
-              if (unit.machine !== machineId) {
-                delete filteredModelStatusData.applications[application];
-              }
-            });
+              filteredModelStatusData.applications[application]?.units;
+
+            if (Object.entries(units).length) {
+              Object.values(units).forEach((unit) => {
+                if (
+                  unit.machine !== machineId ||
+                  !Object.entries(units).length
+                ) {
+                  delete filteredModelStatusData.applications[application];
+                }
+              });
+            } else {
+              delete filteredModelStatusData.applications[application];
+            }
           }
         );
       return filteredModelStatusData;

--- a/src/components/panels/MachinesPanel/_machines-panel.scss
+++ b/src/components/panels/MachinesPanel/_machines-panel.scss
@@ -1,6 +1,6 @@
 @import "../panels";
 
-.machine-panel {
+.machines-panel {
   &__id {
     padding-left: 2rem;
     text-transform: capitalize;

--- a/src/components/panels/UnitsPanel/UnitsPanel.js
+++ b/src/components/panels/UnitsPanel/UnitsPanel.js
@@ -16,7 +16,12 @@ import { generateStatusElement, extractRevisionNumber } from "app/utils";
 
 import "./_units-panel.scss";
 
-export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
+export default function UnitsPanel({
+  isActive,
+  onClose,
+  entity: unitId,
+  panelRowClick,
+}) {
   const modelStatusData = useModelStatus();
   const appName = unitId?.split("/")[0];
   const unit = modelStatusData?.applications[appName]?.units[unitId];
@@ -106,14 +111,18 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
   // Generate machines table content
   const machineRows = useMemo(
     () =>
-      generateMachineRows(filteredModelStatusDataByMachine(unit, "machines")),
-    [filteredModelStatusDataByMachine, unit]
+      generateMachineRows(filteredModelStatusDataByMachine(unit, "machines"), panelRowClick),
+    [filteredModelStatusDataByMachine, panelRowClick, unit]
   );
 
   // Generate apps table content
   const applicationRows = useMemo(
-    () => generateApplicationRows(filteredModelStatusDataByApp(appName)),
-    [filteredModelStatusDataByApp, appName]
+    () =>
+      generateApplicationRows(
+        filteredModelStatusDataByApp(appName),
+        panelRowClick
+      ),
+    [filteredModelStatusDataByApp, panelRowClick, appName]
   );
 
   // Check for loading status

--- a/src/components/panels/UnitsPanel/UnitsPanel.js
+++ b/src/components/panels/UnitsPanel/UnitsPanel.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback } from "react";
-import SlidePanel from "components/SlidePanel/SlidePanel";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import cloneDeep from "clone-deep";
 
@@ -128,35 +127,25 @@ export default function UnitsPanel({
     [filteredModelStatusDataByApp, panelRowClick, appName]
   );
 
-  // Check for loading status
-  const isLoading = !modelStatusData?.machines;
-
   return (
-    <SlidePanel
-      isActive={isActive}
-      onClose={onClose}
-      isLoading={isLoading}
-      className="units-panel"
-    >
-      <>
-        {unitsPanelHeader}
-        <div className="slide-panel__tables">
-          <MainTable
-            headers={machineTableHeaders}
-            rows={machineRows}
-            className="model-details__machines p-main-table"
-            sortable
-            emptyStateMsg={"There are no machines in this model"}
-          />
-          <MainTable
-            headers={applicationTableHeaders}
-            rows={applicationRows}
-            className="model-details__apps p-main-table"
-            sortable
-            emptyStateMsg={"There are no apps in this model"}
-          />
-        </div>
-      </>
-    </SlidePanel>
+    <>
+      {unitsPanelHeader}
+      <div className="slide-panel__tables">
+        <MainTable
+          headers={machineTableHeaders}
+          rows={machineRows}
+          className="model-details__machines p-main-table"
+          sortable
+          emptyStateMsg={"There are no machines in this model"}
+        />
+        <MainTable
+          headers={applicationTableHeaders}
+          rows={applicationRows}
+          className="model-details__apps p-main-table"
+          sortable
+          emptyStateMsg={"There are no apps in this model"}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/panels/UnitsPanel/UnitsPanel.js
+++ b/src/components/panels/UnitsPanel/UnitsPanel.js
@@ -64,7 +64,7 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
     );
   }, [app, unit, unitId]);
 
-  const machinePanelHeader = useMemo(
+  const unitsPanelHeader = useMemo(
     () => generateUnitsPanelHeader(modelStatusData?.applications[unitId]),
     [modelStatusData, unitId, generateUnitsPanelHeader]
   );
@@ -80,7 +80,7 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
       className="units-panel"
     >
       <>
-        {machinePanelHeader}
+        {unitsPanelHeader}
         <div className="slide-panel__tables">
           <MainTable
             headers={machineTableHeaders}

--- a/src/components/panels/UnitsPanel/UnitsPanel.js
+++ b/src/components/panels/UnitsPanel/UnitsPanel.js
@@ -9,6 +9,7 @@ import {
   machineTableHeaders,
   applicationTableHeaders,
   generateMachineRows,
+  generateApplicationRows,
 } from "pages/Models/Details/generators";
 
 import { generateStatusElement, extractRevisionNumber } from "app/utils";
@@ -31,6 +32,22 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
           }
         });
       }
+      return filteredModelStatusData;
+    },
+    [modelStatusData]
+  );
+
+  const filteredModelStatusDataByApp = useCallback(
+    (appName) => {
+      const filteredModelStatusData = cloneDeep(modelStatusData);
+      filteredModelStatusData &&
+        Object.keys(filteredModelStatusData.applications).forEach(
+          (application) => {
+            if (application !== appName) {
+              delete filteredModelStatusData.applications[application];
+            }
+          }
+        );
       return filteredModelStatusData;
     },
     [modelStatusData]
@@ -86,10 +103,17 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
     [modelStatusData, unitId, generateUnitsPanelHeader]
   );
 
-  // Generate machines table
+  // Generate machines table content
   const machineRows = useMemo(
-    () => generateMachineRows(filteredModelStatusDataByMachine(unit)),
+    () =>
+      generateMachineRows(filteredModelStatusDataByMachine(unit, "machines")),
     [filteredModelStatusDataByMachine, unit]
+  );
+
+  // Generate apps table content
+  const applicationRows = useMemo(
+    () => generateApplicationRows(filteredModelStatusDataByApp(appName)),
+    [filteredModelStatusDataByApp, appName]
   );
 
   // Check for loading status
@@ -114,7 +138,7 @@ export default function UnitsPanel({ isActive, onClose, entity: unitId }) {
           />
           <MainTable
             headers={applicationTableHeaders}
-            rows={[]} // Temp disable
+            rows={applicationRows}
             className="model-details__apps p-main-table"
             sortable
             emptyStateMsg={"There are no apps in this model"}

--- a/src/components/panels/UnitsPanel/UnitsPanel.js
+++ b/src/components/panels/UnitsPanel/UnitsPanel.js
@@ -111,7 +111,10 @@ export default function UnitsPanel({
   // Generate machines table content
   const machineRows = useMemo(
     () =>
-      generateMachineRows(filteredModelStatusDataByMachine(unit, "machines"), panelRowClick),
+      generateMachineRows(
+        filteredModelStatusDataByMachine(unit, "machines"),
+        panelRowClick
+      ),
     [filteredModelStatusDataByMachine, panelRowClick, unit]
   );
 

--- a/src/components/panels/_panels.scss
+++ b/src/components/panels/_panels.scss
@@ -54,8 +54,4 @@
       grid-template-columns: repeat(2, 1fr);
     }
   }
-
-  &__table tr {
-    pointer-events: none;
-  }
 }

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -220,12 +220,10 @@ const ModelDetails = () => {
 
   const unitTableRows = useMemo(() => {
     const handleUnitsRowClick = (e) => {
-      if (process.env.NODE_ENV !== "production") {
-        setQuery({
-          panel: "units",
-          entity: e.currentTarget.dataset.unit,
-        });
-      }
+      setQuery({
+        panel: "units",
+        entity: e.currentTarget.dataset.unit,
+      });
     };
     return generateUnitRows(
       modelStatusData,
@@ -237,12 +235,7 @@ const ModelDetails = () => {
 
   const machinesTableRows = useMemo(() => {
     const handleMachineRowClick = (e) => {
-      if (process.env.NODE_ENV !== "production") {
-        setQuery({
-          panel: "machines",
-          entity: e.currentTarget.dataset.machine,
-        });
-      }
+      setQuery({ panel: "machines", entity: e.currentTarget.dataset.machine });
     };
     return generateMachineRows(
       modelStatusData,
@@ -286,10 +279,7 @@ const ModelDetails = () => {
         </div>
       </Header>
       <div className="l-content">
-        <div
-          className="model-details"
-          data-enable-panels={process.env.NODE_ENV !== "production"}
-        >
+        <div className="model-details">
           <InfoPanel />
           <div className="model-details__main u-overflow--scroll">
             {renderCounts(activeView, modelStatusData)}

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -11,6 +11,7 @@ import InfoPanel from "components/InfoPanel/InfoPanel";
 import Layout from "components/Layout/Layout";
 import Header from "components/Header/Header";
 import Terminal from "components/Terminal/Terminal";
+import SlidePanel from "components/SlidePanel/SlidePanel";
 
 import AppsPanel from "components/panels/AppsPanel/AppsPanel";
 import MachinesPanel from "components/panels/MachinesPanel/MachinesPanel";
@@ -356,24 +357,23 @@ const ModelDetails = () => {
                 )}
             </div>
           </div>
-          <AppsPanel
-            entity={entity}
-            isActive={activePanel === "apps"}
+
+          <SlidePanel
+            isActive={activePanel}
             onClose={() => setQuery(closePanelConfig)}
-            panelRowClick={panelRowClick}
-          />
-          <MachinesPanel
-            entity={entity}
-            isActive={activePanel === "machines"}
-            onClose={() => setQuery(closePanelConfig)}
-            panelRowClick={panelRowClick}
-          />
-          <UnitsPanel
-            entity={entity}
-            isActive={activePanel === "units"}
-            onClose={() => setQuery(closePanelConfig)}
-            panelRowClick={panelRowClick}
-          />
+            isLoading={!entity}
+            className={`${activePanel}-panel`}
+          >
+            {activePanel === "apps" && (
+              <AppsPanel entity={entity} panelRowClick={panelRowClick} />
+            )}
+            {activePanel === "machines" && (
+              <MachinesPanel entity={entity} panelRowClick={panelRowClick} />
+            )}
+            {activePanel === "units" && (
+              <UnitsPanel entity={entity} panelRowClick={panelRowClick} />
+            )}
+          </SlidePanel>
         </div>
       )}
       {generateTerminalComponent(modelUUID, controllerWSHost)}

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useCallback } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import Spinner from "@canonical/react-components/dist/components/Spinner";
 import { useDispatch, useSelector } from "react-redux";
@@ -192,6 +192,13 @@ const ModelDetails = () => {
     setQuery({ activeView: view });
   };
 
+  const panelRowClick = useCallback(
+    (entityName, entityPanel) => {
+      return setQuery({ panel: entityPanel, entity: entityName });
+    },
+    [setQuery]
+  );
+
   useEffect(() => {
     dispatch(collapsibleSidebar(true));
     return () => {
@@ -208,42 +215,26 @@ const ModelDetails = () => {
   }, [dispatch, modelUUID, modelStatusData]);
 
   const applicationTableRows = useMemo(() => {
-    const handleAppRowClick = (e) => {
-      setQuery({ panel: "apps", entity: e.currentTarget.dataset.app });
-    };
     return generateApplicationRows(
       modelStatusData,
-      handleAppRowClick,
+      panelRowClick,
       baseAppURL,
       query?.entity
     );
-  }, [baseAppURL, modelStatusData, setQuery, query]);
+  }, [baseAppURL, modelStatusData, query, panelRowClick]);
 
   const unitTableRows = useMemo(() => {
-    const handleUnitsRowClick = (e) => {
-      setQuery({
-        panel: "units",
-        entity: e.currentTarget.dataset.unit,
-      });
-    };
     return generateUnitRows(
       modelStatusData,
-      handleUnitsRowClick,
+      panelRowClick,
       baseAppURL,
       query?.entity
     );
-  }, [baseAppURL, modelStatusData, query, setQuery]);
+  }, [baseAppURL, modelStatusData, query, panelRowClick]);
 
   const machinesTableRows = useMemo(() => {
-    const handleMachineRowClick = (e) => {
-      setQuery({ panel: "machines", entity: e.currentTarget.dataset.machine });
-    };
-    return generateMachineRows(
-      modelStatusData,
-      handleMachineRowClick,
-      query?.entity
-    );
-  }, [modelStatusData, setQuery, query]);
+    return generateMachineRows(modelStatusData, panelRowClick, query?.entity);
+  }, [modelStatusData, panelRowClick, query]);
 
   const relationTableRows = useMemo(
     () => generateRelationRows(modelStatusData, baseAppURL),
@@ -261,10 +252,6 @@ const ModelDetails = () => {
 
   const { panel: activePanel, entity, activeView } = query;
   const closePanelConfig = { panel: undefined, entity: undefined };
-
-  const panelRowClick = (e, entityName, entityPanel) => {
-    return setQuery({ panel: entityPanel, entity: entityName });
-  };
 
   return (
     <Layout>

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
+import Spinner from "@canonical/react-components/dist/components/Spinner";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { useQueryParams, StringParam, withDefault } from "use-query-params";

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -262,6 +262,10 @@ const ModelDetails = () => {
   const { panel: activePanel, entity, activeView } = query;
   const closePanelConfig = { panel: undefined, entity: undefined };
 
+  const panelRowClick = (e, entityName, entityPanel) => {
+    return setQuery({ panel: entityPanel, entity: entityName });
+  };
+
   return (
     <Layout>
       <Header>
@@ -270,107 +274,121 @@ const ModelDetails = () => {
             {modelStatusData ? modelStatusData.model.name : "..."}
           </strong>
           <div className="model-details__view-selector">
-            <ButtonGroup
-              buttons={["status", "units", "machines", "relations"]}
-              label="View:"
-              activeButton={activeView}
-              setActiveButton={setActiveView}
-            />
+            {modelStatusData && (
+              <ButtonGroup
+                buttons={["status", "units", "machines", "relations"]}
+                label="View:"
+                activeButton={activeView}
+                setActiveButton={setActiveView}
+              />
+            )}
           </div>
         </div>
       </Header>
-      <div className="l-content">
-        <div className="model-details">
-          <InfoPanel />
-          <div className="model-details__main u-overflow--scroll">
-            {renderCounts(activeView, modelStatusData)}
-            {shouldShow("apps", activeView) && (
-              <MainTable
-                headers={applicationTableHeaders}
-                rows={applicationTableRows}
-                className="model-details__apps p-main-table"
-                sortable
-                emptyStateMsg={"There are no applications in this model"}
-              />
-            )}
-            {shouldShow("units", activeView) && (
-              <MainTable
-                headers={unitTableHeaders}
-                rows={unitTableRows}
-                className="model-details__units p-main-table"
-                sortable
-                emptyStateMsg={"There are no units in this model"}
-              />
-            )}
-            {shouldShow("machines", activeView) && (
-              <MainTable
-                headers={machineTableHeaders}
-                rows={machinesTableRows}
-                className="model-details__machines p-main-table"
-                sortable
-                emptyStateMsg={"There are no machines in this model"}
-              />
-            )}
-            {shouldShow("relations", activeView) && (
-              <>
-                {shouldShow("relations-title", activeView) && (
-                  <h5>Relations ({relationTableRows.length})</h5>
-                )}
-                <MainTable
-                  headers={relationTableHeaders}
-                  rows={relationTableRows}
-                  className="model-details__relations p-main-table"
-                  sortable
-                  emptyStateMsg={"There are no relations in this model"}
-                />
-                {shouldShow("relations-title", activeView) && (
-                  <h5>
-                    Cross-model relations (
-                    {consumedTableRows.length + offersTableRows.length})
-                  </h5>
-                )}
-                {consumedTableRows.length ? (
-                  <MainTable
-                    headers={consumedTableHeaders}
-                    rows={consumedTableRows}
-                    className="model-details__relations p-main-table"
-                    sortable
-                    emptyStateMsg={
-                      "There are no remote relations in this model"
-                    }
-                  />
-                ) : null}
-                {offersTableRows.length ? (
-                  <MainTable
-                    headers={offersTableHeaders}
-                    rows={offersTableRows}
-                    className="model-details__relations p-main-table"
-                    sortable
-                    emptyStateMsg={
-                      "There are no connected offers in this model"
-                    }
-                  />
-                ) : null}
-              </>
-            )}
-          </div>
+      {!modelStatusData ? (
+        <div className="model-details__loading">
+          <Spinner />
         </div>
-        <AppsPanel
-          entity={entity}
-          isActive={activePanel === "apps"}
-          onClose={() => setQuery(closePanelConfig)}
-        />
-        <MachinesPanel
-          entity={entity}
-          isActive={activePanel === "machines"}
-          onClose={() => setQuery(closePanelConfig)}
-        />
-        <UnitsPanel
-          entity={entity}
-          isActive={activePanel === "units"}
-          onClose={() => setQuery(closePanelConfig)}
-        />
-      </div>
+      ) : (
+        <div className="l-content">
+          <div className="model-details">
+            <InfoPanel />
+            <div className="model-details__main u-overflow--scroll">
+              {renderCounts(activeView, modelStatusData)}
+              {shouldShow("apps", activeView) &&
+                applicationTableRows.length > 0 && (
+                  <MainTable
+                    headers={applicationTableHeaders}
+                    rows={applicationTableRows}
+                    className="model-details__apps p-main-table"
+                    sortable
+                    emptyStateMsg={"There are no applications in this model"}
+                  />
+                )}
+              {shouldShow("units", activeView) && unitTableRows.length > 0 && (
+                <MainTable
+                  headers={unitTableHeaders}
+                  rows={unitTableRows}
+                  className="model-details__units p-main-table"
+                  sortable
+                  emptyStateMsg={"There are no units in this model"}
+                />
+              )}
+              {shouldShow("machines", activeView) &&
+                machinesTableRows.length > 0 && (
+                  <MainTable
+                    headers={machineTableHeaders}
+                    rows={machinesTableRows}
+                    className="model-details__machines p-main-table"
+                    sortable
+                    emptyStateMsg={"There are no machines in this model"}
+                  />
+                )}
+              {shouldShow("relations", activeView) &&
+                relationTableRows.length > 0 && (
+                  <>
+                    {shouldShow("relations-title", activeView) && (
+                      <h5>Relations ({relationTableRows.length})</h5>
+                    )}
+                    <MainTable
+                      headers={relationTableHeaders}
+                      rows={relationTableRows}
+                      className="model-details__relations p-main-table"
+                      sortable
+                      emptyStateMsg={"There are no relations in this model"}
+                    />
+                    {shouldShow("relations-title", activeView) && (
+                      <h5>
+                        Cross-model relations (
+                        {consumedTableRows.length + offersTableRows.length})
+                      </h5>
+                    )}
+                    {consumedTableRows.length ? (
+                      <MainTable
+                        headers={consumedTableHeaders}
+                        rows={consumedTableRows}
+                        className="model-details__relations p-main-table"
+                        sortable
+                        emptyStateMsg={
+                          "There are no remote relations in this model"
+                        }
+                      />
+                    ) : null}
+                    {offersTableRows.length ? (
+                      <MainTable
+                        headers={offersTableHeaders}
+                        rows={offersTableRows}
+                        className="model-details__relations p-main-table"
+                        sortable
+                        emptyStateMsg={
+                          "There are no connected offers in this model"
+                        }
+                      />
+                    ) : null}
+                  </>
+                )}
+            </div>
+          </div>
+          <AppsPanel
+            entity={entity}
+            isActive={activePanel === "apps"}
+            onClose={() => setQuery(closePanelConfig)}
+            panelRowClick={panelRowClick}
+          />
+          <MachinesPanel
+            entity={entity}
+            isActive={activePanel === "machines"}
+            onClose={() => setQuery(closePanelConfig)}
+            panelRowClick={panelRowClick}
+          />
+          <UnitsPanel
+            entity={entity}
+            isActive={activePanel === "units"}
+            onClose={() => setQuery(closePanelConfig)}
+            panelRowClick={panelRowClick}
+          />
+        </div>
+      )}
       {generateTerminalComponent(modelUUID, controllerWSHost)}
     </Layout>
   );

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -31,7 +31,7 @@ describe("ModelDetail Container", () => {
       </Provider>
     );
     expect(wrapper.find("Topology").length).toBe(1);
-    expect(wrapper.find(".model-details__main table").length).toBe(4);
+    expect(wrapper.find(".model-details__main table").length).toBe(2);
   });
 
   it("renders the details pane for models shared-with-me", () => {
@@ -216,7 +216,9 @@ describe("ModelDetail Container", () => {
     expect(
       wrapper.find(".slide-panel.machines-panel").prop("aria-hidden")
     ).toBe(true);
-    const machineRow = wrapper.find(`tr[data-machine="${testMachine}"]`);
+    const machineRow = wrapper.find(
+      `.model-details__main tr[data-machine="${testMachine}"]`
+    );
     machineRow.simulate("click");
     expect(
       wrapper.find(".slide-panel.machines-panel").prop("aria-hidden")

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -186,14 +186,10 @@ describe("ModelDetail Container", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find(".slide-panel.apps-panel").prop("aria-hidden")).toBe(
-      true
-    );
+    expect(wrapper.find(".slide-panel.apps-panel").length).toBe(0);
     const applicationRow = wrapper.find(`tr[data-app="${testApp}"]`);
     applicationRow.simulate("click");
-    expect(wrapper.find(".slide-panel.apps-panel").prop("aria-hidden")).toBe(
-      false
-    );
+    expect(wrapper.find(".slide-panel.apps-panel").length).toBe(1);
     expect(
       wrapper.find(".slide-panel.apps-panel .panel-header .entity-name").text()
     ).toBe("kibana");
@@ -213,16 +209,12 @@ describe("ModelDetail Container", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(
-      wrapper.find(".slide-panel.machines-panel").prop("aria-hidden")
-    ).toBe(true);
+    expect(wrapper.find(".slide-panel.machines-panel").length).toBe(0);
     const machineRow = wrapper.find(
       `.model-details__main tr[data-machine="${testMachine}"]`
     );
     machineRow.simulate("click");
-    expect(
-      wrapper.find(".slide-panel.machines-panel").prop("aria-hidden")
-    ).toBe(false);
+    expect(wrapper.find(".slide-panel.machines-panel").length).toBe(1);
     expect(
       wrapper
         .find(".slide-panel.machines-panel .panel-header .entity-name")
@@ -244,14 +236,10 @@ describe("ModelDetail Container", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find(".slide-panel.units-panel").prop("aria-hidden")).toBe(
-      true
-    );
+    expect(wrapper.find(".slide-panel.units-panel").length).toBe(0);
     const unitRow = wrapper.find(`tr[data-unit="${testUnit}"]`);
     unitRow.simulate("click");
-    expect(wrapper.find(".slide-panel.units-panel").prop("aria-hidden")).toBe(
-      false
-    );
+    expect(wrapper.find(".slide-panel.units-panel").length).toBe(1);
     expect(
       wrapper.find(".slide-panel.units-panel .panel-header .entity-name").text()
     ).toBe("kibana/0");

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -9,6 +9,14 @@
     padding-bottom: 3rem;
     padding-top: 1rem;
 
+    &__loading {
+      align-items: center;
+      display: flex;
+      justify-items: center;
+      min-height: calc(100vh - 48px);
+      width: 100%;
+    }
+
     @media (min-width: $breakpoint-medium) {
       gap: 1rem;
       grid-template-columns: 230px 1fr;

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -57,23 +57,21 @@
   }
 }
 
-@mixin model-details-main {
-  .model-details__main {
-    .subordinate-row {
-      border-top: none !important;
-    }
+@mixin model-details-subordinates {
+  .subordinate-row {
+    border-top: none !important;
+  }
 
-    .subordinate {
-      margin-right: 0.5rem;
-      padding-left: 1.5rem;
-      position: relative;
+  .subordinate {
+    margin-right: 0.5rem;
+    padding-left: 1.5rem;
+    position: relative;
 
-      &::before {
-        content: url("../../../static/images/unit-tree.svg");
-        left: 0.75rem;
-        position: absolute;
-        top: -0.25rem;
-      }
+    &::before {
+      content: url("../../../static/images/unit-tree.svg");
+      left: 0.75rem;
+      position: absolute;
+      top: -0.25rem;
     }
   }
 }
@@ -222,6 +220,6 @@
 @include model-details-layout;
 @include model-details-header;
 @include model-details-title;
-@include model-details-main;
+@include model-details-subordinates;
 @include model-details-tables;
 @include model-details-entity-icons;

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -190,8 +190,8 @@
   }
 
   .model-details__apps,
-  [data-enable-panels="true"] .model-details__machines,
-  [data-enable-panels="true"] .model-details__units {
+  .model-details__machines,
+  .model-details__units {
     tbody tr:hover {
       background-color: #e7f9ff;
       cursor: pointer;

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -183,7 +183,7 @@ export function generateApplicationRows(
         os: "Ubuntu",
         notes: "-",
       },
-      onClick: (e) => onRowClick(e, app),
+      onClick: (e) => onRowClick(e, key, "apps"),
       "data-app": key,
       className: selectedEntity === key ? "is-selected" : "",
     };
@@ -250,7 +250,7 @@ export function generateUnitRows(
           port,
           message,
         },
-        onClick: (e) => onRowClick(e, unitId),
+        onClick: (e) => onRowClick(e, unitId, "units"),
         "data-unit": unitId,
         className: selectedEntity === unitId ? "is-selected" : "",
       });
@@ -267,7 +267,8 @@ export function generateUnitRows(
                   subordinate.charm,
                   key,
                   true,
-                  baseAppURL
+                  baseAppURL,
+                  true // disable link
                 ),
                 className: "u-truncate",
               },
@@ -366,7 +367,7 @@ export function generateMachineRows(
         instanceId: machine.instanceId,
         message: machine?.agentStatus?.info,
       },
-      onClick: (e) => onRowClick(e, machineId),
+      onClick: (e) => onRowClick(e, machineId, "machines"),
       "data-machine": machineId,
       className: selectedEntity === machineId ? "is-selected" : "",
     };

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -183,7 +183,7 @@ export function generateApplicationRows(
         os: "Ubuntu",
         notes: "-",
       },
-      onClick: (e) => onRowClick(e, key, "apps"),
+      onClick: () => onRowClick(key, "apps"),
       "data-app": key,
       className: selectedEntity === key ? "is-selected" : "",
     };
@@ -250,7 +250,7 @@ export function generateUnitRows(
           port,
           message,
         },
-        onClick: (e) => onRowClick(e, unitId, "units"),
+        onClick: () => onRowClick(unitId, "units"),
         "data-unit": unitId,
         className: selectedEntity === unitId ? "is-selected" : "",
       });
@@ -367,7 +367,7 @@ export function generateMachineRows(
         instanceId: machine.instanceId,
         message: machine?.agentStatus?.info,
       },
-      onClick: (e) => onRowClick(e, machineId, "machines"),
+      onClick: () => onRowClick(machineId, "machines"),
       "data-machine": machineId,
       className: selectedEntity === machineId ? "is-selected" : "",
     };

--- a/src/scss/custom/_status_icons.scss
+++ b/src/scss/custom/_status_icons.scss
@@ -32,10 +32,15 @@
   }
 
   &.is-running,
-  &.is-started,
-  &.is-active {
+  &.is-started {
     &::before {
       color: $color-mid-light;
+    }
+  }
+
+  &.is-active {
+    &::before {
+      color: $color-positive;
     }
   }
 


### PR DESCRIPTION
## Done

- Enable panel tables on model details page
- Change active status dot to green
- Add a loading spinner to model details page
- Conditionally render model details tables based on data available

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Click on a model
- Click the first app
- Observe app panel open
- You can now navigate the tables to slice and dice across apps/units and machines
- Refresh the page
- Observe the loading spinner

## Details

Related: https://github.com/canonical-web-and-design/juju-squad/issues/1388
