### PR TITLE
Fix focus ring errors styling

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -51,3 +51,13 @@ $color-navigation-background: $color-brand;
 @include vf-u-layout;
 @include vf-u-truncate;
 @include vf-p-switch;
+
+// Fixes focus styles until fix implemented in Vanilla
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3352
+:focus-visible {
+  outline: 0.1875rem solid $color-focus;
+}
+
+:focus:not(:focus-visible) {
+  outline: 0;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -51,9 +51,3 @@ $color-navigation-background: $color-brand;
 @include vf-u-layout;
 @include vf-u-truncate;
 @include vf-p-switch;
-
-// Fix consecutive table bug
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/2491
-table + table {
-  margin-top: 1.5rem;
-}


### PR DESCRIPTION
## Done

- Remove redundant override
- Fix focus ring errors styling

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Tab through the page with the keyboard and verify focus styles appear consistently
- Navigate using mouse and verify that no focus rings appear

## Details

Fixes #711
