### PR TITLE
WIP: Fade in and out different panel types on model details

### DIFF
--- a/src/animations/FadeInOut/FadeInOut.js
+++ b/src/animations/FadeInOut/FadeInOut.js
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from "react";
+
+import "./FadeInOut.scss";
+
+export default function FadeInOut({ isActive, children }) {
+  const [render, setRender] = useState(false);
+
+  useEffect(() => {
+    isActive && setRender(true);
+  }, [isActive]);
+
+  return (
+    <>
+      {render && (
+        <div
+          className={isActive ? "fade-in" : "fade-out"}
+          onAnimationEnd={() => {
+            !isActive && setRender(false);
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/animations/FadeInOut/FadeInOut.scss
+++ b/src/animations/FadeInOut/FadeInOut.scss
@@ -1,0 +1,27 @@
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.5s;
+}
+
+.fade-out {
+  animation: fadeOut 0.5s;
+}

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -17,6 +17,8 @@ import AppsPanel from "components/panels/AppsPanel/AppsPanel";
 import MachinesPanel from "components/panels/MachinesPanel/MachinesPanel";
 import UnitsPanel from "components/panels/UnitsPanel/UnitsPanel";
 
+import FadeInOut from "animations/FadeInOut/FadeInOut";
+
 import {
   getConfig,
   getControllerDataByUUID,
@@ -364,15 +366,17 @@ const ModelDetails = () => {
             isLoading={!entity}
             className={`${activePanel}-panel`}
           >
-            {activePanel === "apps" && (
+            <FadeInOut isActive={activePanel === "apps"}>
               <AppsPanel entity={entity} panelRowClick={panelRowClick} />
-            )}
-            {activePanel === "machines" && (
+            </FadeInOut>
+
+            <FadeInOut isActive={activePanel === "machines"}>
               <MachinesPanel entity={entity} panelRowClick={panelRowClick} />
-            )}
-            {activePanel === "units" && (
+            </FadeInOut>
+
+            <FadeInOut isActive={activePanel === "units"}>
               <UnitsPanel entity={entity} panelRowClick={panelRowClick} />
-            )}
+            </FadeInOut>
           </SlidePanel>
         </div>
       )}


### PR DESCRIPTION
## Done

@clagom @spencerbygraves @long-chung 

After consolidating all model details panel types within one single SlidePanel.. I experimented with a little fade in/out animation for when you switch panel types..

## QA

- Click through to demo
- Go to model details
- Click an app.. any click to another entity type within the panel will trigger the 1s fade out/in animation.. clicking an entity of the same type will not.. (looking at an app and you click another app.. no animation... looking at an app but you click a unit.. animation)..

Yay or nay?

(Gif below is illustrative but janky.. click through to demo to view in browser.)

![Screen Recording 2020-10-16 at 10 47 27 am](https://user-images.githubusercontent.com/505570/96246411-8118c400-0fa0-11eb-872a-425740c224cc.gif)

