### PR TITLE
Add feature flag for WebCLI

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -12,4 +12,6 @@ var jujuDashboardConfig = {
   // only be used for superficial updates like logos. Use feature detection
   // for other environment features.
   isJuju: false,
+  // Show WebCli component if enabled for dev purposes, even if not natively supported.
+  showWebCLI: false,
 };

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -174,6 +174,7 @@ const ModelDetails = () => {
   }
 
   const { baseAppURL } = useSelector(getConfig);
+  const showWebCLIConfig = useSelector(getConfig).showWebCLI;
 
   const [query, setQuery] = useQueryParams({
     panel: StringParam,
@@ -195,8 +196,9 @@ const ModelDetails = () => {
   useEffect(() => {
     // XXX Remove me once we have the 2.9 build.
     if (
-      controllerData &&
-      controllerData[1]?.[0]?.version.indexOf("2.9") !== -1
+      (controllerData &&
+        controllerData[1]?.[0]?.version.indexOf("2.9") !== -1) ||
+      showWebCLIConfig
     ) {
       // The Web CLI is only available in Juju controller versions 2.9 and
       // above. This will allow us to only show the shell on multi-controller
@@ -204,7 +206,7 @@ const ModelDetails = () => {
       // is available.
       setShowWebCLI(true);
     }
-  }, [controllerData]);
+  }, [controllerData, showWebCLIConfig]);
 
   useEffect(() => {
     if (modelUUID !== null && modelStatusData === null) {


### PR DESCRIPTION
## Done

Add feature flag for WebCLI

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Check WebCLI does not appear
- Open `config.js`
- Change `showWebCLI` to `true`
- WebCLI should now appear on model details page


