### PR TITLE
Refresh the model status data on submitting a command

### DIFF
--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -562,12 +562,44 @@ export const getWSControllerURL = createSelector(
   Returns the controller data in the format of an Object.entries output.
   [wsControllerURL, [data]]
   @param {String} controllerUUID The full controller UUID.
+  @returns {Array} The controller data in the format of an Object.entries output.
 */
 export const getControllerDataByUUID = (controllerUUID) => {
   return createSelector(getControllerData, (controllerData) => {
     if (!controllerData) return null;
-    return Object.entries(controllerData).find(
-      (controller) => controllerUUID === controller[1][0].uuid
-    );
+    const found = Object.entries(controllerData).find((controller) => {
+      // Loop through the sub controllers for each primary controller.
+      // This is typically only seen in JAAS. Outside of JAAS there is only ever
+      // a single sub controller.
+      return controller[1].find(
+        (subController) => controllerUUID === subController.uuid
+      );
+    });
+    return found;
+  });
+};
+
+/**
+  @param {String} controllerUUID The full controller UUID.
+  @returns {Object} The controllerData.
+*/
+export const getModelControllerDataByUUID = (controllerUUID) => {
+  return createSelector(getControllerData, (controllerData) => {
+    if (!controllerData) return null;
+    let modelController = null;
+    Object.entries(controllerData).some((controller) => {
+      // Loop through the sub controllers for each primary controller.
+      // This is typically only seen in JAAS. Outside of JAAS there is only ever
+      // a single sub controller.
+      const modelControllerData = controller[1].find(
+        (subController) => controllerUUID === subController.uuid
+      );
+      if (modelControllerData) {
+        modelController = modelControllerData;
+        return true;
+      }
+      return false;
+    });
+    return modelController;
   });
 };

--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -8,8 +8,6 @@ import Connection from "./connection";
 
 import "./_webcli.scss";
 
-const DEFAULT_PLACEHOLDER = "enter command";
-
 const WebCLI = ({
   controllerWSHost,
   credentials,
@@ -18,20 +16,11 @@ const WebCLI = ({
   refreshModel,
 }) => {
   const [connection, setConnection] = useState(null);
-  const [placeholder, setPlaceholder] = useState(DEFAULT_PLACEHOLDER);
   const [shouldShowHelp, setShouldShowHelp] = useState(false);
   const inputRef = useRef();
   const wsMessageStore = useRef();
   let [output, setOutput] = useState("");
   const sendAnalytics = useAnalytics();
-
-  const setDisconnectedPlaceholder = () => {
-    setPlaceholder("no web cli backend available");
-  };
-
-  const setConnectedPlaceholder = () => {
-    setPlaceholder(DEFAULT_PLACEHOLDER);
-  };
 
   const clearMessageBuffer = () => {
     wsMessageStore.current = "";
@@ -48,8 +37,8 @@ const WebCLI = ({
   useEffect(() => {
     const conn = new Connection({
       address: wsAddress,
-      onopen: setConnectedPlaceholder,
-      onclose: setDisconnectedPlaceholder,
+      onopen: () => {},
+      onclose: () => {},
       messageCallback: (message) => {
         wsMessageStore.current = wsMessageStore.current + message;
         setOutput(wsMessageStore.current);
@@ -57,10 +46,6 @@ const WebCLI = ({
     }).connect();
     setConnection(conn);
     return () => {
-      // onclose is being set to null when the component is torn down to avoid
-      // a react error where the state is being set from the
-      // `setDisconnectedPlaceholder` method above.
-      conn.onclose = null;
       conn.disconnect();
     };
   }, [wsAddress]);
@@ -112,7 +97,7 @@ const WebCLI = ({
             type="text"
             name="command"
             ref={inputRef}
-            placeholder={placeholder}
+            placeholder="enter command"
           />
         </form>
         <div className="webcli__input-help">

--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -15,7 +15,13 @@ const generateAddress = (controllerWSHost, modelUUID, protocol = "wss") => {
   return `${protocol}://${controllerWSHost}/model/${modelUUID}/commands`;
 };
 
-const WebCLI = ({ controllerWSHost, credentials, modelUUID, protocol }) => {
+const WebCLI = ({
+  controllerWSHost,
+  credentials,
+  modelUUID,
+  protocol,
+  refreshModel,
+}) => {
   const [connection, setConnection] = useState(null);
   const [placeholder, setPlaceholder] = useState(DEFAULT_PLACEHOLDER);
   const [shouldShowHelp, setShouldShowHelp] = useState(false);
@@ -68,6 +74,11 @@ const WebCLI = ({ controllerWSHost, credentials, modelUUID, protocol }) => {
       action: "WebCLI command sent",
     });
     inputRef.current.value = ""; // Clear the input after sending the message.
+    setTimeout(() => {
+      // Delay the refresh long enough so that the Juju controller has time to
+      // respond before we request the updated status.
+      refreshModel();
+    }, 500);
   };
 
   const showHelp = () => {

--- a/src/components/WebCLI/WebCLI.test.js
+++ b/src/components/WebCLI/WebCLI.test.js
@@ -27,12 +27,16 @@ describe("WebCLI", () => {
   };
 
   it("renders correctly", () => {
-    const wrapper = mount(<WebCLI />);
+    const wrapper = mount(
+      <WebCLI controllerWSHost="jimm.jujucharms.com:443" modelUUID="abc123" />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
   it("shows the help in the output when the ? is clicked", () => {
-    const wrapper = mount(<WebCLI />);
+    const wrapper = mount(
+      <WebCLI controllerWSHost="jimm.jujucharms.com:443" modelUUID="abc123" />
+    );
     act(() => {
       wrapper.find(".webcli__input-help i").simulate("click");
     });
@@ -50,11 +54,32 @@ describe("WebCLI", () => {
     });
   });
 
-  it("shows a disconnected message if no ws is connected", () => {
-    const wrapper = mount(<WebCLI />);
-    expect(wrapper.find(".webcli__input-input").prop("placeholder")).toBe(
-      "no web cli backend available"
+  it("calls to refresh the model on command submission", () => {
+    const mockRefreshModel = jest.fn();
+    new WS("ws://localhost:1234/model/abc123/commands", {
+      jsonProtocol: true,
+    });
+    const wrapper = mount(
+      <WebCLI
+        protocol="ws"
+        controllerWSHost="localhost:1234"
+        credentials={{
+          user: "spaceman",
+          password: "somelongpassword",
+        }}
+        modelUUID="abc123"
+        refreshModel={mockRefreshModel}
+      />
     );
+    wrapper.find(".webcli__input-input").instance().value = "status --color";
+    wrapper.find("form").simulate("submit", { preventDefault: () => {} });
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        expect(mockRefreshModel).toHaveBeenCalled();
+        WS.clean();
+        resolve();
+      }, 600); // the timeout is 500ms in the app
+    });
   });
 
   describe("WebCLI Output", () => {

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.js.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.js.snap
@@ -25,7 +25,10 @@ Machine  State    DNS             Inst id        Series  AZ          Message
 `;
 
 exports[`WebCLI renders correctly 1`] = `
-<WebCLI>
+<WebCLI
+  controllerWSHost="jimm.jujucharms.com:443"
+  modelUUID="abc123"
+>
   <div
     className="webcli"
   >
@@ -86,7 +89,7 @@ exports[`WebCLI renders correctly 1`] = `
           autoCorrect="off"
           className="webcli__input-input"
           name="command"
-          placeholder="no web cli backend available"
+          placeholder="enter command"
           spellCheck="false"
           type="text"
         />

--- a/src/components/WebCLI/connection.js
+++ b/src/components/WebCLI/connection.js
@@ -1,0 +1,69 @@
+class Connection {
+  constructor(options) {
+    this._messageCallback = options.messageCallback;
+    this.address = options.address;
+    this.wsOnOpen = options.onopen;
+    this.wsOnClose = options.onclose;
+  }
+
+  _messageBuffer = "";
+
+  connect() {
+    const ws = new WebSocket(this.address);
+    ws.onopen = this._wsOnOpen;
+    ws.onclose = this._wsOnClose;
+    ws.onmessage = this._handleMessage.bind(this);
+    this._ws = ws;
+    return this;
+  }
+
+  send(message) {
+    this._ws.send(message);
+  }
+
+  disconnect() {
+    this._ws.close();
+  }
+
+  _handleMessage(e) {
+    try {
+      const data = JSON.parse(e.data);
+      if (data["redirect-to"]) {
+        // This is a JAAS ccontroller and we need to instead
+        // connect to the sub controller.
+        this._ws.close();
+        this.address = data["redirect-to"];
+        this.connect();
+      }
+
+      if (data.done) {
+        // This is the last message.
+        return;
+      }
+      if (!data.output) {
+        // This is the first message, an empty object and a newline.
+        return;
+      }
+      this._pushToMessageBuffer(`\n${data?.output[0]}`);
+    } catch (e) {
+      console.log(e);
+      // XXX handle the invalid data response
+    }
+  }
+
+  _pushToMessageBuffer(message) {
+    this._messageBuffer = this._messageBuffer + message;
+    setTimeout(() => {
+      /*
+        The messageBuffer is required because the websocket returns messages
+        much faster than React wants to update the component. Doing this allows
+        us to store the messages in a buffer and then set the output every
+        cycle.
+      */
+      this._messageCallback(this._messageBuffer);
+      this._messageBuffer = "";
+    });
+  }
+}
+
+export default Connection;

--- a/src/components/WebCLI/connection.js
+++ b/src/components/WebCLI/connection.js
@@ -29,7 +29,7 @@ class Connection {
     try {
       const data = JSON.parse(e.data);
       if (data["redirect-to"]) {
-        // This is a JAAS ccontroller and we need to instead
+        // This is a JAAS controller and we need to instead
         // connect to the sub controller.
         this._ws.close();
         this.address = data["redirect-to"];

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -27,6 +27,7 @@ import {
 
 import useModelStatus from "hooks/useModelStatus";
 
+import { fetchAndStoreModelStatus } from "juju/index";
 import { fetchModelStatus } from "juju/actions";
 
 import {
@@ -203,6 +204,18 @@ const ModelDetails = () => {
     },
     [setQuery]
   );
+
+  // Until we switch to the new lib and watcher model we want to trigger a
+  // refresh of the model data when a user submits a cli command so that it
+  // doesn't look like it did nothing.
+  const refreshModel = () => {
+    fetchAndStoreModelStatus(
+      modelUUID,
+      primaryControllerData[0],
+      dispatch,
+      store.getState
+    );
+  };
 
   useEffect(() => {
     // XXX Remove me once we have the 2.9 build.
@@ -393,6 +406,7 @@ const ModelDetails = () => {
           controllerWSHost={controllerWSHost}
           credentials={credentials}
           modelUUID={modelUUID}
+          refreshModel={refreshModel}
         />
       )}
     </Layout>


### PR DESCRIPTION
## Done

- Refresh the model status data on submitting a command in the Juju Web CLI. This will be removed once we go to the new watcher.
- Split the websocket connection out into its own file to stop working against the React paradigm. 
- Correctly parse the controller/model data to connect to the correct controller in a multi-controller environment like JAAS.

## QA

- Bootstrap a new controller with Juju 2.9 (the Juju snap has the 2.9 RC available)
- Build and upload the dashboard to that controller 
  - `yarn`
  - `yarn generate-release-tarball`
  - `juju upgrade-dashboard <path to tarball>` 
- Then log in, the wCLI on the model details page should continue to work as expected.
- Run `juju deploy wordpress` in a model and it should show up in the details page above moments after submitting the command.

## Details

Fixes #1459

