### PR TITLE
Hide banner content when inactive

### DIFF
--- a/src/components/Banner/_banner.scss
+++ b/src/components/Banner/_banner.scss
@@ -4,6 +4,7 @@
   background: $color-caution;
   color: $color-brand;
   max-height: 0;
+  overflow: hidden;
   padding: 0;
   position: relative;
   text-align: center;


### PR DESCRIPTION


## Done

Hide banner content when inactive

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models in Firefox
- Minimise vertical height of screen to 6/7 models
- Scroll down and you should not see a banner message as per #747 

## Details

Related #747