### PR TITLE
Rename status to apps

### DIFF
--- a/src/components/panels/AppsPanel/AppsPanel.js
+++ b/src/components/panels/AppsPanel/AppsPanel.js
@@ -9,9 +9,7 @@ import {
   generateEntityIdentifier,
   unitTableHeaders,
   machineTableHeaders,
-  relationTableHeaders,
   generateMachineRows,
-  generateRelationRows,
   generateUnitRows,
 } from "pages/Models/Details/generators";
 
@@ -113,11 +111,6 @@ export default function AppsPanel({ entity, panelRowClick }) {
     [filteredModelStatusData, panelRowClick]
   );
 
-  const relationPanelRows = useMemo(
-    () => generateRelationRows(filteredModelStatusData, baseAppURL),
-    [filteredModelStatusData, baseAppURL]
-  );
-
   return (
     <>
       {appPanelHeader}
@@ -135,13 +128,6 @@ export default function AppsPanel({ entity, panelRowClick }) {
           className="model-details__machines p-main-table panel__table"
           sortable
           emptyStateMsg={"There are no machines in this model"}
-        />
-        <MainTable
-          headers={relationTableHeaders}
-          rows={relationPanelRows}
-          className="model-details__relations p-main-table panel__table"
-          sortable
-          emptyStateMsg={"There are no relations in this model"}
         />
       </div>
     </>

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -49,11 +49,11 @@ import "./_model-details.scss";
 
 const shouldShow = (segment, activeView) => {
   switch (activeView) {
-    case "status":
-      if (segment === "relations-title") {
-        return false;
+    case "apps":
+      if (segment === "apps") {
+        return true;
       }
-      return true;
+      return false;
     case "units":
     case "machines":
     case "relations":
@@ -108,7 +108,7 @@ const renderCounts = (activeView, modelStatusData) => {
   let primaryEntity = null;
   let secondaryEntities = null;
   switch (activeView) {
-    case "status":
+    case "apps":
       primaryEntity = {
         count: Object.keys(modelStatusData?.applications).length,
         label: "application",
@@ -296,7 +296,7 @@ const ModelDetails = () => {
           <div className="model-details__view-selector">
             {modelStatusData && (
               <ButtonGroup
-                buttons={["status", "units", "machines", "relations"]}
+                buttons={["apps", "units", "machines", "relations"]}
                 label="View:"
                 activeButton={activeView}
                 setActiveButton={setActiveView}

--- a/src/pages/Models/Details/ModelDetails.js
+++ b/src/pages/Models/Details/ModelDetails.js
@@ -192,7 +192,7 @@ const ModelDetails = () => {
   const [query, setQuery] = useQueryParams({
     panel: StringParam,
     entity: StringParam,
-    activeView: withDefault(StringParam, "status"),
+    activeView: withDefault(StringParam, "apps"),
   });
 
   const setActiveView = (view) => {

--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -33,7 +33,7 @@ describe("ModelDetail Container", () => {
     expect(wrapper.find("Topology").length).toBe(1);
   });
 
-  it("renders the main tables", () => {
+  it("renders the main table", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(
       <Provider store={store}>
@@ -46,7 +46,7 @@ describe("ModelDetail Container", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find(".model-details__main table").length).toBe(2);
+    expect(wrapper.find(".model-details__main table").length).toBe(1);
   });
 
   it("renders the status strip", () => {
@@ -65,59 +65,6 @@ describe("ModelDetail Container", () => {
     expect(wrapper.find("StatusStrip").length).toBe(1);
   });
 
-  it("renders the details pane for models shared-with-me", () => {
-    const store = mockStore(dataDump);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/pizza@external/hadoopspark"]}>
-          <QueryParamProvider ReactRouterRoute={Route}>
-            <TestRoute path="/models/*">
-              <ModelDetails />
-            </TestRoute>
-          </QueryParamProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(".model-details__main table").length).toBe(4);
-  });
-
-  it("renders the machine details section", () => {
-    const store = mockStore(dataDump);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/pizza@external/mymodel"]}>
-          <QueryParamProvider ReactRouterRoute={Route}>
-            <TestRoute path="/models/*">
-              <ModelDetails />
-            </TestRoute>
-          </QueryParamProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper
-        .find(".model-details__main table")
-        .at(2)
-        .hasClass("model-details__machines")
-    ).toBe(true);
-  });
-
-  it("subordinate rows render correct amount", () => {
-    const store = mockStore(dataDump);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/sub-test"]}>
-          <QueryParamProvider ReactRouterRoute={Route}>
-            <TestRoute path="/models/*">
-              <ModelDetails />
-            </TestRoute>
-          </QueryParamProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(".model-details__main .subordinate").length).toEqual(2);
-  });
-
   it("view toggles hide and show tables", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(
@@ -131,27 +78,85 @@ describe("ModelDetail Container", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find(".model-details__main table").length).toBe(4);
+    expect(
+      wrapper.find(".model-details__main > .model-details__apps").length
+    ).toBe(1);
     wrapper.find("ButtonGroup button[value='units']").simulate("click");
-    expect(wrapper.find(".model-details__main table").length).toBe(1);
     expect(
-      wrapper.find(".model-details__main table.model-details__units").length
+      wrapper.find(".model-details__main > .model-details__units").length
     ).toBe(1);
-
     wrapper.find("ButtonGroup button[value='machines']").simulate("click");
-    expect(wrapper.find(".model-details__main table").length).toBe(1);
     expect(
-      wrapper.find(".model-details__main table.model-details__machines").length
+      wrapper.find(".model-details__main > .model-details__machines").length
     ).toBe(1);
-
     wrapper.find("ButtonGroup button[value='relations']").simulate("click");
-    expect(wrapper.find(".model-details__main table").length).toBe(1);
     expect(
-      wrapper.find(".model-details__main table.model-details__relations").length
+      wrapper.find(".model-details__main > .model-details__relations").length
     ).toBe(1);
+    wrapper.find("ButtonGroup button[value='apps']").simulate("click");
+    expect(
+      wrapper.find(".model-details__main > .model-details__apps").length
+    ).toBe(1);
+  });
 
-    wrapper.find("ButtonGroup button[value='status']").simulate("click");
-    expect(wrapper.find(".model-details__main table").length).toBe(4);
+  it("renders the details pane for models shared-with-me", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/pizza@external/hadoopspark"]}>
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <ModelDetails />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".model-details__main table").length).toBe(1);
+  });
+
+  it("renders the machine details section", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/mymodel?activeView=machines",
+          ]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <ModelDetails />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find(".model-details__main table")
+        .hasClass("model-details__machines")
+    ).toBe(true);
+  });
+
+  it("subordinate rows render correct amount", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=units",
+          ]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <ModelDetails />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".subordinate").length).toEqual(2);
   });
 
   it("supports local charms", () => {
@@ -227,7 +232,11 @@ describe("ModelDetail Container", () => {
     const testMachine = "1";
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/pizza@external/hadoopspark"]}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=machines",
+          ]}
+        >
           <QueryParamProvider ReactRouterRoute={Route}>
             <TestRoute path="/models/*">
               <ModelDetails />
@@ -254,7 +263,11 @@ describe("ModelDetail Container", () => {
     const testUnit = "client/0";
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/pizza@external/hadoopspark"]}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=units",
+          ]}
+        >
           <QueryParamProvider ReactRouterRoute={Route}>
             <TestRoute path="/models/*">
               <ModelDetails />

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -12,7 +12,7 @@ import {
 } from "app/utils";
 
 export const applicationTableHeaders = [
-  { content: "app", sortKey: "app" },
+  { content: "Local apps", sortKey: "app" },
   { content: "status", sortKey: "status" },
   { content: "version", className: "u-align--right", sortKey: "version" },
   { content: "scale", className: "u-align--right", sortKey: "scale" },
@@ -163,13 +163,13 @@ export function generateApplicationRows(
           className: "u-align--right",
         },
         {
-          "data-test-column": "store",
-          content: store,
-        },
-        {
           "data-test-column": "revision",
           content: rev,
           className: "u-align--right",
+        },
+        {
+          "data-test-column": "store",
+          content: store,
         },
         { "data-test-column": "os", content: "Ubuntu" },
         { "data-test-column": "notes", content: "-" },

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -163,13 +163,13 @@ export function generateApplicationRows(
           className: "u-align--right",
         },
         {
+          "data-test-column": "store",
+          content: store,
+        },
+        {
           "data-test-column": "revision",
           content: rev,
           className: "u-align--right",
-        },
-        {
-          "data-test-column": "store",
-          content: store,
         },
         { "data-test-column": "os", content: "Ubuntu" },
         { "data-test-column": "notes", content: "-" },


### PR DESCRIPTION
## Done

- Rename status to apps in model details view
- Rename apps table to 'Local apps'
- Remove all tables from apps view but apps
- Remove relations table from apps panel
- Switch order of 'rev' and 'store' in apps table

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details and verify changes above appear as expected

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1512,
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1506,
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1504,
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1505,
