### PR TITLE
Add apps icon list to machines table

### DIFF
--- a/src/pages/Models/Details/ModelDetails.test.js
+++ b/src/pages/Models/Details/ModelDetails.test.js
@@ -321,4 +321,56 @@ describe("ModelDetail Container", () => {
     const noRelationsMsg = wrapper.find("[data-testid='no-integrations-msg']");
     expect(noRelationsMsg.length).toBe(1);
   });
+
+  it("should show apps appropriate number of apps on machine in hadoopspark model", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=machines",
+          ]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <ModelDetails />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const machineApps = wrapper.find(".machine-app-icons img");
+    expect(machineApps.length).toBe(10);
+  });
+
+  it("should show apps appropriate number of apps on machine in canonical-kubernetes model", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=machines",
+          ]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <ModelDetails />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const machineAppIconRows = wrapper.find(".machine-app-icons");
+
+    const machineApp1 = machineAppIconRows.at(1).find("img");
+    expect(machineApp1.length).toBe(1);
+
+    const machineApp4 = machineAppIconRows.at(4).find("img");
+    expect(machineApp4.length).toBe(2);
+
+    const machineApp6 = machineAppIconRows.at(6).find("img");
+    expect(machineApp6.length).toBe(4);
+  });
 });

--- a/src/pages/Models/Details/_model-details.scss
+++ b/src/pages/Models/Details/_model-details.scss
@@ -188,23 +188,27 @@
     th,
     td {
       &:nth-child(1) {
-        width: 20%;
+        width: 15%;
       }
 
       &:nth-child(2) {
-        width: 19%;
-      }
-
-      &:nth-child(3) {
-        width: 16%;
-      }
-
-      &:nth-child(4) {
         width: 25%;
       }
 
+      &:nth-child(3) {
+        width: 10%;
+      }
+
+      &:nth-child(4) {
+        width: 15%;
+      }
+
       &:nth-child(5) {
-        width: 35%;
+        width: 15%;
+      }
+
+      &:nth-child(6) {
+        width: 20%;
       }
     }
   }

--- a/src/pages/Models/Details/generators.js
+++ b/src/pages/Models/Details/generators.js
@@ -41,6 +41,7 @@ export const unitTableHeaders = [
 
 export const machineTableHeaders = [
   { content: "machine", sortKey: "machine" },
+  { content: "apps", sortKey: "apps" },
   { content: "state", sortKey: "state" },
   { content: "az", sortKey: "az" },
   { content: "instance id", sortKey: "instanceId" },
@@ -82,6 +83,8 @@ export function generateIconImg(name, namespace) {
   return (
     <img
       alt={name + " icon"}
+      key={name}
+      title={name}
       width="24"
       height="24"
       className="entity-icon"
@@ -409,6 +412,27 @@ export function generateMachineRows(
     return [];
   }
 
+  const generateMachineApps = (machineId) => {
+    const appsOnMachine = [];
+    const modelApplications = modelStatusData?.applications;
+    modelApplications &&
+      Object.entries(modelApplications).forEach(([appName, appInfo]) => {
+        appInfo?.units &&
+          Object.values(appInfo.units).forEach((unitInfo) => {
+            if (machineId === unitInfo.machine) {
+              appsOnMachine.push([appName, appInfo.charm]);
+            }
+          });
+      });
+
+    const apps = appsOnMachine.length
+      ? appsOnMachine.map((app) => {
+          return generateIconImg(app[0], app[1]);
+        })
+      : "None";
+    return apps;
+  };
+
   const machines = modelStatusData.machines;
   return Object.keys(machines).map((machineId) => {
     const machine = machines[machineId];
@@ -425,6 +449,10 @@ export function generateMachineRows(
               {machine.dnsName}
             </>
           ),
+        },
+        {
+          content: generateMachineApps(machineId),
+          className: "machine-app-icons",
         },
         {
           content: generateStatusElement(machine["agent-status"].status),


### PR DESCRIPTION
## Done

Add apps icon list to machines table

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Click on any model to view details page
- Click 'Machines' tab
- Verify that table now has 'apps' column showing apps icons

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1519

<img width="1557" alt="Screenshot 2021-01-12 at 12 39 49" src="https://user-images.githubusercontent.com/505570/104315744-54a71200-54d3-11eb-9fa4-2dac4d56fa5b.png">


