### PR TITLE
Add sidenav width override

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -4,6 +4,7 @@
 // Vanilla overrides
 $increase-font-size-on-larger-screens: false;
 $color-link-visited: $color-link;
+$application-layout--side-nav-width-collapsed: 3rem;
 
 // Import settings
 @import "settings";


### PR DESCRIPTION
## Done

Add sidenav width override

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Verify side nav now collapses as expected when reducing screen width

## Details

Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/814


