### PR TITLE
Always collapse sidebar on model details pages

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSelector, useStore } from "react-redux";
+import { useLocation } from "react-router-dom";
 import { isLoggedIn, getWSControllerURL } from "app/selectors";
 import Notification from "@canonical/react-components/dist/components/Notification/Notification";
 import Logo from "components/Logo/Logo";
@@ -12,10 +13,26 @@ import useOffline from "hooks/useOffline";
 import "./_layout.scss";
 
 const Layout = ({ children }) => {
+  const [menuCollapsed, setMenuCollapsed] = useState(true);
+  const [sideNavCollapsed, setSideNavCollapsed] = useState(false);
+
   const [releaseNotification, setReleaseNotification] = useLocalStorage(
     "releaseNotification",
     false
   );
+
+  const location = useLocation();
+
+  // Check if pathname includes a model name - and then always collapse sidebar
+  const modelName = location.pathname.split("/models/")[1];
+  useEffect(() => {
+    if (modelName) {
+      setSideNavCollapsed(true);
+    }
+    return () => {
+      setSideNavCollapsed(false);
+    };
+  }, [modelName]);
 
   const isOffline = useOffline();
 
@@ -24,8 +41,6 @@ const Layout = ({ children }) => {
     useSelector(getWSControllerURL),
     store.getState()
   );
-
-  const [menuCollapsed, setMenuCollapsed] = useState(true);
 
   return (
     <>
@@ -59,7 +74,11 @@ const Layout = ({ children }) => {
             {menuCollapsed ? "Open menu" : "Close menu"}
           </button>
         </div>
-        <header className="l-navigation" data-collapsed={menuCollapsed}>
+        <header
+          className="l-navigation"
+          data-collapsed={menuCollapsed}
+          data-side-nav-collapsed={sideNavCollapsed}
+        >
           <div className="l-navigation__drawer">
             <PrimaryNav />
           </div>

--- a/src/components/Layout/Layout.test.js
+++ b/src/components/Layout/Layout.test.js
@@ -2,6 +2,9 @@ import { BrowserRouter as Router } from "react-router-dom";
 import { mount } from "enzyme";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router";
+import { QueryParamProvider } from "use-query-params";
+import TestRoute from "components/Routes/TestRoute";
 import dataDump from "testing/complete-redux-store-dump";
 import Layout from "./Layout";
 
@@ -31,5 +34,41 @@ describe("Layout", () => {
     expect(wrapper.find("[data-test='main-children']").html()).toStrictEqual(
       `<div data-test="main-children">content</div>`
     );
+  });
+
+  it("should collapse the sidebar on model details pages", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/pizza@external/hadoopspark?activeView=machines",
+          ]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <Layout />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("header").prop("data-side-nav-collapsed")).toBe(true);
+  });
+
+  it("should not collapse the sidebar when not on model details pages", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/"]}>
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/*">
+              <Layout />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("header").prop("data-side-nav-collapsed")).toBe(false);
   });
 });

--- a/src/components/Layout/_layout.scss
+++ b/src/components/Layout/_layout.scss
@@ -84,6 +84,42 @@
       transform: translateX(-100%);
     }
   }
+
+  // Override Vanilla to always collapse navigation sidebar
+  @media (min-width: $breakpoint-large - 1) {
+    &[data-side-nav-collapsed="true"] {
+      & ~ .l-main {
+        padding-left: 3rem;
+      }
+
+      height: 100vh;
+      left: 0;
+      max-width: 3rem;
+      position: fixed;
+      top: 0;
+
+      .logo__text,
+      .p-primary-nav__bottom,
+      .p-primary-nav__divider {
+        opacity: 0;
+      }
+
+      transition: all 0.25s;
+
+      &:hover {
+        max-width: 15rem;
+
+        .logo__text,
+        .p-primary-nav__bottom {
+          opacity: 1;
+        }
+
+        .p-primary-nav__divider {
+          opacity: 0.1;
+        }
+      }
+    }
+  }
 }
 
 .l-content {


### PR DESCRIPTION
## Done

Always collapse sidebar on model details pages

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Check sidebar on model details page always collapses regardless of breakpoint

## Details

Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/794
