### PR TITLE
Highlight changed fields

### DIFF
--- a/src/components/panels/ConfigPanel/BooleanConfig.tsx
+++ b/src/components/panels/ConfigPanel/BooleanConfig.tsx
@@ -12,6 +12,7 @@ export default function BooleanConfig({
   setNewValue,
 }: ConfigProps): ReactElement {
   const [inputFocused, setInputFocused] = useState(false);
+  const [inputChanged, setInputChanged] = useState(false);
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
@@ -35,26 +36,23 @@ export default function BooleanConfig({
   }, [selectedConfig, config]);
 
   useEffect(() => {
-    if (config.value === config.default) {
-      setShowUseDefault(false);
+    setShowUseDefault(localValue !== config.default);
+    if (isSet(localValue) && localValue !== config.value) {
+      setInputChanged(true);
+    } else if (!isSet(localValue) || localValue === config.value) {
+      setInputChanged(false);
     }
-  }, [config]);
+  }, [config, localValue]);
 
   function handleOptionChange(e: any) {
     const bool = e.target.value === "true" ? true : false;
     setNewValue(e.target.name, bool);
     setLocalValue(bool);
-    if (bool !== config.default) {
-      setShowUseDefault(true);
-    } else {
-      setShowUseDefault(false);
-    }
   }
 
   function resetToDefault() {
     setNewValue(config.name, config.default);
     setLocalValue(config.default);
-    setShowUseDefault(false);
   }
 
   return (
@@ -63,6 +61,7 @@ export default function BooleanConfig({
     <div
       className={classnames("config-input", {
         "config-input--focused": inputFocused,
+        "config-input--changed": inputChanged,
       })}
       onClick={() => setSelectedConfig(config)}
     >

--- a/src/components/panels/ConfigPanel/BooleanConfig.tsx
+++ b/src/components/panels/ConfigPanel/BooleanConfig.tsx
@@ -16,13 +16,12 @@ export default function BooleanConfig({
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
-  const [localValue, setLocalValue] = useState(config.value);
   const trueRef = useRef<HTMLInputElement>(null);
   const falseRef = useRef<HTMLInputElement>(null);
 
   let inputValue = config.default;
-  if (isSet(localValue) && isSet(config.newValue)) {
-    inputValue = localValue;
+  if (isSet(config.newValue)) {
+    inputValue = config.newValue;
   } else if (config.default !== config.value) {
     inputValue = config.value;
   }
@@ -36,23 +35,29 @@ export default function BooleanConfig({
   }, [selectedConfig, config]);
 
   useEffect(() => {
-    setShowUseDefault(localValue !== config.default);
-    if (isSet(localValue) && localValue !== config.value) {
+    if (
+      (isSet(config.newValue) && config.newValue !== config.default) ||
+      (!isSet(config.newValue) && config.value !== config.default)
+    ) {
+      setShowUseDefault(true);
+    } else {
+      setShowUseDefault(false);
+    }
+
+    if (isSet(config.newValue) && config.newValue !== config.value) {
       setInputChanged(true);
-    } else if (!isSet(localValue) || localValue === config.value) {
+    } else {
       setInputChanged(false);
     }
-  }, [config, localValue]);
+  }, [config]);
 
   function handleOptionChange(e: any) {
     const bool = e.target.value === "true" ? true : false;
     setNewValue(e.target.name, bool);
-    setLocalValue(bool);
   }
 
   function resetToDefault() {
     setNewValue(config.name, config.default);
-    setLocalValue(config.default);
   }
 
   return (

--- a/src/components/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/components/panels/ConfigPanel/ConfigPanel.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useEffect, useState } from "react";
 import { getApplicationConfig, setApplicationConfig } from "juju/index";
 import { useStore } from "react-redux";
+import type { Store } from "redux";
 import classnames from "classnames";
 import cloneDeep from "clone-deep";
 
@@ -64,36 +65,25 @@ export default function ConfigPanel({
 
   useEffect(() => {
     setIsLoading(true);
-    getApplicationConfig(modelUUID, appName, reduxStore.getState()).then(
-      (result) => {
-        // Add the key to the config object to make for easier use later.
-        const config: Config = {};
-        Object.keys(result.config).forEach((key) => {
-          config[key] = result.config[key];
-          config[key].name = key;
-        });
-        setIsLoading(false);
-        setConfig(config);
-        checkAllDefaults(config);
-      }
+    getConfig(
+      modelUUID,
+      appName,
+      reduxStore,
+      setIsLoading,
+      setConfig,
+      checkAllDefaults
     );
   }, [appName, modelUUID, reduxStore]);
 
   function setNewValue(name: string, value: any) {
-    config[name].newValue = value;
-    if (config[name].newValue === config[name].value) {
-      delete config[name].newValue;
+    const newConfig = cloneDeep(config);
+    newConfig[name].newValue = value;
+    if (newConfig[name].newValue === newConfig[name].value) {
+      delete newConfig[name].newValue;
     }
-    const fieldChanged = Object.keys(config).some((key) =>
-      isSet(config[key].newValue)
-    );
-    if (fieldChanged) {
-      setEnableSave(true);
-    } else if (!fieldChanged && enableSave) {
-      setEnableSave(false);
-    }
-    setConfig(config);
-    checkAllDefaults(config);
+    setConfig(newConfig);
+    checkEnableSave(newConfig);
+    checkAllDefaults(newConfig);
   }
 
   function checkAllDefaults(config: Config) {
@@ -116,12 +106,21 @@ export default function ConfigPanel({
   function allFieldsToDefault() {
     const newConfig = cloneDeep(config);
     Object.keys(newConfig).forEach((key) => {
-      newConfig[key].value = newConfig[key].default;
-      delete newConfig[key].newValue;
+      const cfg = newConfig[key];
+      if (cfg.value !== cfg.default) {
+        cfg.newValue = cfg.default;
+      }
     });
     setConfig(newConfig);
     checkAllDefaults(newConfig);
-    setEnableSave(false);
+    checkEnableSave(newConfig);
+  }
+
+  function checkEnableSave(newConfig: Config) {
+    const fieldChanged = Object.keys(newConfig).some((key) =>
+      isSet(newConfig[key].newValue)
+    );
+    setEnableSave(fieldChanged);
   }
 
   async function handleSubmit() {
@@ -137,6 +136,14 @@ export default function ConfigPanel({
       // XXX Surface this to the user.
       console.error("error setting config", error);
     }
+    await getConfig(
+      modelUUID,
+      appName,
+      reduxStore,
+      setIsLoading,
+      setConfig,
+      checkAllDefaults
+    );
     setSavingConfig(false);
     setEnableSave(false);
   }
@@ -238,6 +245,29 @@ export default function ConfigPanel({
         )}
       </div>
     </div>
+  );
+}
+
+function getConfig(
+  modelUUID: string,
+  appName: string,
+  reduxStore: Store,
+  setIsLoading: (value: boolean) => void,
+  setConfig: (value: Config) => void,
+  checkAllDefaults: (value: Config) => void
+) {
+  return getApplicationConfig(modelUUID, appName, reduxStore.getState()).then(
+    (result) => {
+      // Add the key to the config object to make for easier use later.
+      const config: Config = {};
+      Object.keys(result.config).forEach((key) => {
+        config[key] = result.config[key];
+        config[key].name = key;
+      });
+      setIsLoading(false);
+      setConfig(config);
+      checkAllDefaults(config);
+    }
   );
 }
 

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -16,12 +16,11 @@ export default function TextAreaConfig({
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
-  const [localNewValue, setLocalNewValue] = useState(config.value);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   let inputValue = config.default;
-  if (isSet(localNewValue) && isSet(config.newValue)) {
-    inputValue = localNewValue;
+  if (isSet(config.newValue)) {
+    inputValue = config.newValue;
   } else if (config.default !== config.value) {
     inputValue = config.value;
   }
@@ -31,24 +30,24 @@ export default function TextAreaConfig({
   }, [selectedConfig, config]);
 
   useEffect(() => {
-    if (localNewValue !== config.default) {
-      setShowUseDefault(true);
-    } else if (isSet(config.newValue) && config.newValue !== config.default) {
+    if (
+      (isSet(config.newValue) && config.newValue !== config.default) ||
+      (!isSet(config.newValue) && config.value !== config.default)
+    ) {
       setShowUseDefault(true);
     } else {
       setShowUseDefault(false);
     }
 
-    if (isSet(localNewValue) && localNewValue !== config.value) {
+    if (isSet(config.newValue) && config.newValue !== config.value) {
       setInputChanged(true);
-    } else if (!isSet(localNewValue) || localNewValue === config.value) {
+    } else {
       setInputChanged(false);
     }
-  }, [config, localNewValue]);
+  }, [config]);
 
   function resetToDefault() {
     setNewValue(config.name, config.default);
-    setLocalNewValue(config.default);
   }
 
   return (
@@ -76,7 +75,6 @@ export default function TextAreaConfig({
         onFocus={() => setSelectedConfig(config)}
         onChange={(e) => {
           setNewValue(config.name, e.target.value);
-          setLocalNewValue(e.target.value);
         }}
       ></textarea>
     </div>

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -12,10 +12,11 @@ export default function TextAreaConfig({
   setNewValue,
 }: ConfigProps): ReactElement {
   const [inputFocused, setInputFocused] = useState(false);
+  const [inputChanged, setInputChanged] = useState(false);
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
-  const [localNewValue, setLocalNewValue] = useState("");
+  const [localNewValue, setLocalNewValue] = useState(config.value);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   let inputValue = config.default;
@@ -30,15 +31,24 @@ export default function TextAreaConfig({
   }, [selectedConfig, config]);
 
   useEffect(() => {
-    if (config.value === config.default) {
+    if (localNewValue !== config.default) {
+      setShowUseDefault(true);
+    } else if (isSet(config.newValue) && config.newValue !== config.default) {
+      setShowUseDefault(true);
+    } else {
       setShowUseDefault(false);
     }
-  }, [config]);
+
+    if (isSet(localNewValue) && localNewValue !== config.value) {
+      setInputChanged(true);
+    } else if (!isSet(localNewValue) || localNewValue === config.value) {
+      setInputChanged(false);
+    }
+  }, [config, localNewValue]);
 
   function resetToDefault() {
-    setLocalNewValue(config.default);
     setNewValue(config.name, config.default);
-    setShowUseDefault(false);
+    setLocalNewValue(config.default);
   }
 
   return (
@@ -47,6 +57,7 @@ export default function TextAreaConfig({
     <div
       className={classnames("config-input", {
         "config-input--focused": inputFocused,
+        "config-input--changed": inputChanged,
       })}
       onClick={() => setSelectedConfig(config)}
     >
@@ -66,11 +77,6 @@ export default function TextAreaConfig({
         onChange={(e) => {
           setNewValue(config.name, e.target.value);
           setLocalNewValue(e.target.value);
-          if (e.target.value !== config.default) {
-            setShowUseDefault(true);
-          } else {
-            setShowUseDefault(false);
-          }
         }}
       ></textarea>
     </div>

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -104,7 +104,15 @@
   padding: 0 0.5rem;
 
   &--focused {
+    background-color: #ddedfe;
+  }
+
+  &--changed {
     background-color: $color-light;
+  }
+
+  &.config-input--focused.config-input--changed {
+    background-color: #ddedfe;
   }
 
   h5 {


### PR DESCRIPTION
## Done

When a field value has changed from the value Juju currently has it will be highlighted grey until it has been saved.
There were a lot of additional changes to clean up issues with state in this PR to enable the primary task.

## QA

- Run the demo
- Change a field value and then click to another field, it should highlight grey.
- Save that value and it'll go back to white.
- Play around setting and resetting values to ensure the state changes maintain functionality.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1584

## Screenshots

![Screen Shot 2021-01-20 at 1 17 04 PM](https://user-images.githubusercontent.com/532033/105223773-d4f7f380-5b21-11eb-9fe1-7e92fb0c7d20.png)

