### PR TITLE
Mobile support for the config panel

### DIFF
--- a/src/components/panels/ConfigPanel/BooleanConfig.tsx
+++ b/src/components/panels/ConfigPanel/BooleanConfig.tsx
@@ -109,6 +109,12 @@ export default function BooleanConfig({
           <span className="p-radio__label">false</span>
         </label>
       </div>
+      <details>
+        <summary>
+          <span>{config.description}</span>
+        </summary>
+        <pre>{config.description}</pre>
+      </details>
     </div>
   );
 }

--- a/src/components/panels/ConfigPanel/BooleanConfig.tsx
+++ b/src/components/panels/ConfigPanel/BooleanConfig.tsx
@@ -13,6 +13,7 @@ export default function BooleanConfig({
 }: ConfigProps): ReactElement {
   const [inputFocused, setInputFocused] = useState(false);
   const [inputChanged, setInputChanged] = useState(false);
+  const [showDescription, setShowDescription] = useState(false);
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
@@ -70,7 +71,22 @@ export default function BooleanConfig({
       })}
       onClick={() => setSelectedConfig(config)}
     >
-      <h5 className="u-float-left">{config.name}</h5>
+      <h5
+        className="u-float-left"
+        onClick={() => setShowDescription(!showDescription)}
+        onKeyPress={() => setShowDescription(!showDescription)}
+        // eslint-disable-next-line
+        role="button"
+        tabIndex={0}
+      >
+        <i
+          className={classnames("config-input--view-description", {
+            "p-icon--plus": !showDescription,
+            "p-icon--minus": showDescription,
+          })}
+        />
+        {config.name}
+      </h5>
       <button
         className={classnames("u-float-right p-button--base", {
           "u-hide": !showUseDefault,
@@ -79,6 +95,13 @@ export default function BooleanConfig({
       >
         use default
       </button>
+      <div
+        className={classnames("config-input--description", {
+          "u-hide": !showDescription,
+        })}
+      >
+        {config.description}
+      </div>
       <div className="row">
         <label className=".p-radio--inline col-2">
           <input
@@ -109,12 +132,6 @@ export default function BooleanConfig({
           <span className="p-radio__label">false</span>
         </label>
       </div>
-      <details>
-        <summary>
-          <span>{config.description}</span>
-        </summary>
-        <pre>{config.description}</pre>
-      </details>
     </div>
   );
 }

--- a/src/components/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/components/panels/ConfigPanel/ConfigPanel.tsx
@@ -149,82 +149,80 @@ export default function ConfigPanel({
   }
 
   return (
-    <div className="config-panel">
-      <div className="row">
-        {isLoading ? (
-          <div className="full-size u-vertically-center">
-            <Spinner />
-          </div>
-        ) : !isLoading && (!config || Object.keys(config).length === 0) ? (
-          <div className="full-size u-align-center">
-            <NoConfigMessage />
-          </div>
-        ) : (
-          <>
-            <div className="config-panel__config-list col-6">
-              <div className="config-panel__list-header row">
-                <div className="col-3">{title}</div>
-                <div className="col-3 u-align-text--right">
-                  <button
-                    className={classnames("u-button-neutral col-2", {
-                      "u-hide": !showResetAll,
-                    })}
-                    onClick={allFieldsToDefault}
-                  >
-                    Reset all values
-                  </button>
-                </div>
-              </div>
-
-              <div className="config-panel__list">
-                {generateConfigElementList(
-                  config,
-                  selectedConfig,
-                  setSelectedConfig,
-                  setNewValue
-                )}
-              </div>
-              <div className="config-panel__drawer">
-                <button className="p-button--neutral" onClick={closePanel}>
-                  Cancel
-                </button>
+    <div className="config-panel row">
+      {isLoading ? (
+        <div className="full-size u-vertically-center">
+          <Spinner />
+        </div>
+      ) : !isLoading && (!config || Object.keys(config).length === 0) ? (
+        <div className="full-size u-align-center">
+          <NoConfigMessage />
+        </div>
+      ) : (
+        <>
+          <div className="config-panel__config-list col-6">
+            <div className="config-panel__list-header row">
+              <div className="col-3">{title}</div>
+              <div className="col-3 u-align-text--right">
                 <button
-                  className={classnames(
-                    "p-button--positive config-panel__save-button",
-                    {
-                      "is-active": savingConfig,
-                    }
-                  )}
-                  onClick={handleSubmit}
-                  disabled={!enableSave}
+                  className={classnames("u-button-neutral", {
+                    "u-hide": !showResetAll,
+                  })}
+                  onClick={allFieldsToDefault}
                 >
-                  {!savingConfig ? (
-                    "Save & apply"
-                  ) : (
-                    <>
-                      <i className="p-icon--spinner u-animation--spin is-light"></i>
-                      <span>Saving&hellip;</span>
-                    </>
-                  )}
+                  Reset all values
                 </button>
               </div>
             </div>
-            <div className="config-panel__description col-6">
-              {selectedConfig ? (
-                <div className="config-panel__description-wrapper">
-                  <h4>Configuration Description</h4>
-                  <h5>{selectedConfig.name}</h5>
-                  <pre>{selectedConfig.description}</pre>
-                </div>
-              ) : (
-                <div className="config-panel__no-description u-vertically-center">
-                  <NoDescriptionMessage />
-                </div>
+
+            <div className="config-panel__list">
+              {generateConfigElementList(
+                config,
+                selectedConfig,
+                setSelectedConfig,
+                setNewValue
               )}
             </div>
-          </>
-        )}
-      </div>
+            <div className="config-panel__drawer">
+              <button className="p-button--neutral" onClick={closePanel}>
+                Cancel
+              </button>
+              <button
+                className={classnames(
+                  "p-button--positive config-panel__save-button",
+                  {
+                    "is-active": savingConfig,
+                  }
+                )}
+                onClick={handleSubmit}
+                disabled={!enableSave}
+              >
+                {!savingConfig ? (
+                  "Save & apply"
+                ) : (
+                  <>
+                    <i className="p-icon--spinner u-animation--spin is-light"></i>
+                    <span>Saving&hellip;</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+          <div className="config-panel__description col-6">
+            {selectedConfig ? (
+              <div className="config-panel__description-wrapper">
+                <h4>Configuration Description</h4>
+                <h5>{selectedConfig.name}</h5>
+                <pre>{selectedConfig.description}</pre>
+              </div>
+            ) : (
+              <div className="config-panel__no-description u-vertically-center">
+                <NoDescriptionMessage />
+              </div>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/components/panels/ConfigPanel/ConfigPanel.tsx
@@ -161,9 +161,9 @@ export default function ConfigPanel({
       ) : (
         <>
           <div className="config-panel__config-list col-6">
-            <div className="config-panel__list-header row">
-              <div className="col-3">{title}</div>
-              <div className="col-3 u-align-text--right">
+            <div className="config-panel__list-header">
+              {title}
+              <div>
                 <button
                   className={classnames("u-button-neutral", {
                     "u-hide": !showResetAll,

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -82,7 +82,7 @@ export default function TextAreaConfig({
         <summary>
           <span>{config.description}</span>
         </summary>
-        {config.description}
+        <pre>{config.description}</pre>
       </details>
     </div>
   );

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -61,7 +61,10 @@ export default function TextAreaConfig({
       data-config-name={config.name}
       onClick={() => setSelectedConfig(config)}
     >
-      <h5 className="u-float-left">{config.name}</h5>
+      <h5 className="u-float-left">
+        <i className="p-icon--plus config-input--view-description"></i>
+        {config.name}
+      </h5>
       <button
         className={classnames("u-float-right p-button--base", {
           "u-hide": !showUseDefault,
@@ -70,6 +73,7 @@ export default function TextAreaConfig({
       >
         use default
       </button>
+      <div className="config-input--description">{config.description}</div>
       <textarea
         ref={inputRef}
         value={inputValue}
@@ -78,12 +82,6 @@ export default function TextAreaConfig({
           setNewValue(config.name, e.target.value);
         }}
       ></textarea>
-      <details>
-        <summary>
-          <span>{config.description}</span>
-        </summary>
-        <pre>{config.description}</pre>
-      </details>
     </div>
   );
 }

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -78,6 +78,12 @@ export default function TextAreaConfig({
           setNewValue(config.name, e.target.value);
         }}
       ></textarea>
+      <details>
+        <summary>
+          <span>{config.description}</span>
+        </summary>
+        {config.description}
+      </details>
     </div>
   );
 }

--- a/src/components/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/components/panels/ConfigPanel/TextAreaConfig.tsx
@@ -16,6 +16,7 @@ export default function TextAreaConfig({
   const [showUseDefault, setShowUseDefault] = useState(
     config.value !== config.default
   );
+  const [showDescription, setShowDescription] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   let inputValue = config.default;
@@ -61,8 +62,20 @@ export default function TextAreaConfig({
       data-config-name={config.name}
       onClick={() => setSelectedConfig(config)}
     >
-      <h5 className="u-float-left">
-        <i className="p-icon--plus config-input--view-description"></i>
+      <h5
+        className="u-float-left"
+        onClick={() => setShowDescription(!showDescription)}
+        onKeyPress={() => setShowDescription(!showDescription)}
+        // eslint-disable-next-line
+        role="button"
+        tabIndex={0}
+      >
+        <i
+          className={classnames("config-input--view-description", {
+            "p-icon--plus": !showDescription,
+            "p-icon--minus": showDescription,
+          })}
+        />
         {config.name}
       </h5>
       <button
@@ -73,7 +86,13 @@ export default function TextAreaConfig({
       >
         use default
       </button>
-      <div className="config-input--description">{config.description}</div>
+      <div
+        className={classnames("config-input--description", {
+          "u-hide": !showDescription,
+        })}
+      >
+        {config.description}
+      </div>
       <textarea
         ref={inputRef}
         value={inputValue}

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -83,10 +83,6 @@
 
   &__list {
     min-height: $magic-min-height;
-
-    @media screen and (max-width: $breakpoint-medium) {
-      margin-top: 3rem;
-    }
   }
 
   &__description {
@@ -119,6 +115,10 @@
     padding-top: 1rem;
     position: sticky;
     text-align: right;
+
+    @media screen and (max-width: $breakpoint-x-small) {
+      padding-right: 0;
+    }
   }
 
   &__save-button span {

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -8,6 +8,16 @@
     grid-template-columns: 1fr !important;
   }
 
+  pre {
+    // reset the vanilla pre styling
+    background-color: inherit;
+    border: none;
+    padding: 0;
+    // extra styles
+    white-space: pre-wrap;
+    word-break: keep-all;
+  }
+
   &.row {
     padding: 0;
   }
@@ -84,16 +94,6 @@
 
     @media screen and (max-width: $breakpoint-large) {
       display: none !important;
-    }
-
-    pre {
-      // reset the vanilla pre styling
-      background-color: inherit;
-      border: none;
-      padding: 0;
-      // extra styles
-      white-space: pre-wrap;
-      word-break: keep-all;
     }
 
     &-wrapper {

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -187,6 +187,12 @@
       display: block;
     }
 
+    &[open] summary {
+      // There is a bug in Chrome 87 where hiding the summary does
+      // not also hide the ellipsis.
+      text-overflow: inherit;
+    }
+
     &[open] summary span {
       visibility: hidden;
     }

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -143,7 +143,8 @@
     background-color: #ddedfe;
   }
 
-  .p-icon--plus.config-input--view-description {
+  .p-icon--plus.config-input--view-description,
+  .p-icon--minus.config-input--view-description {
     display: none;
     margin-right: 0.5rem;
     width: 0.875rem;

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -4,7 +4,11 @@
   $magic-height: 200px;
   $magic-min-height: calc(100vh - #{$magic-height});
 
-  .row {
+  @media (max-width: $breakpoint-large) {
+    grid-template-columns: 1fr !important;
+  }
+
+  &.row {
     padding: 0;
   }
 
@@ -35,28 +39,47 @@
     margin: 2rem 0 1rem;
     padding-left: 0.5rem;
 
+    @media screen and (max-width: $breakpoint-medium) {
+      margin-top: 4rem;
+    }
+
     button {
       margin-bottom: 0;
       padding-left: 0.5rem;
       padding-right: 0.5rem;
+      white-space: nowrap;
     }
 
     .entity-name {
       font-size: 1.3rem;
+      white-space: nowrap;
     }
   }
 
   &__config-list {
     border-right: 1px solid $color-mid-light;
+    padding-top: 1rem;
     padding-right: 1rem;
+
+    @media screen and (max-width: $breakpoint-large) {
+      border-right: none;
+    }
   }
 
   &__list {
     min-height: $magic-min-height;
+
+    @media screen and (max-width: $breakpoint-medium) {
+      margin-top: 3rem;
+    }
   }
 
   &__description {
     margin-top: 2rem;
+
+    @media screen and (max-width: $breakpoint-large) {
+      display: none !important;
+    }
 
     pre {
       // reset the vanilla pre styling
@@ -86,7 +109,7 @@
     background-color: white;
     border-top: 1px solid $color-mid-light;
     bottom: 0;
-    max-height: 100px;
+    max-height: 130px;
     padding-right: 1.5rem;
     padding-top: 1rem;
     position: sticky;
@@ -126,6 +149,12 @@
 
     &:hover {
       background-color: inherit;
+    }
+  }
+
+  @media screen and (max-width: $breakpoint-x-small) {
+    button {
+      width: auto;
     }
   }
 

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -35,7 +35,9 @@
   }
 
   &__list-header {
+    display: flex;
     height: 2rem;
+    justify-content: space-between;
     margin: 2rem 0 1rem;
     padding-left: 0.5rem;
 
@@ -45,6 +47,7 @@
 
     button {
       margin-bottom: 0;
+      margin-left: 1rem;
       padding-left: 0.5rem;
       padding-right: 0.5rem;
       white-space: nowrap;
@@ -52,6 +55,8 @@
 
     .entity-name {
       font-size: 1.3rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
       white-space: nowrap;
     }
   }

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -73,8 +73,11 @@
 
   &__config-list {
     border-right: 1px solid $color-mid-light;
-    padding-right: 1rem;
     padding-top: 1rem;
+
+    @media screen and (min-width: $breakpoint-large) {
+      padding-right: 1rem;
+    }
 
     @media screen and (max-width: $breakpoint-large) {
       border-right: none;
@@ -158,8 +161,8 @@
     clear: both;
     display: none;
     font-size: 0.875rem;
-    margin-left: 1.3rem;
     margin-bottom: 0.5rem;
+    margin-left: 1.3rem;
 
     @media screen and (max-width: $breakpoint-large) {
       display: block;

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -58,8 +58,8 @@
 
   &__config-list {
     border-right: 1px solid $color-mid-light;
-    padding-top: 1rem;
     padding-right: 1rem;
+    padding-top: 1rem;
 
     @media screen and (max-width: $breakpoint-large) {
       border-right: none;
@@ -158,11 +158,44 @@
     }
   }
 
+  @media screen and (min-width: $breakpoint-large) {
+    textarea {
+      margin-bottom: 1.2rem !important;
+    }
+  }
+
   textarea {
     border: 1px solid #999;
     border-radius: 2px;
     height: 2.3rem;
+    margin-bottom: 0;
     min-height: 2.3rem;
     resize: vertical;
+  }
+
+  details {
+    display: none;
+    font-size: 0.9rem;
+    margin-bottom: 0;
+
+    @media screen and (max-width: $breakpoint-large) {
+      display: block;
+    }
+
+    &[open] summary span {
+      visibility: hidden;
+    }
+
+    &[open] summary::marker {
+      visibility: visible;
+    }
+
+    summary {
+      height: 2rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      width: 350px;
+    }
   }
 }

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -143,8 +143,30 @@
     background-color: #ddedfe;
   }
 
-  h5 {
+  .p-icon--plus.config-input--view-description {
+    display: none;
+    margin-right: 0.5rem;
+    width: 0.875rem;
+
+    @media screen and (max-width: $breakpoint-large) {
+      display: inline-block;
+    }
+  }
+
+  &--description {
+    clear: both;
+    display: none;
+    font-size: 0.875rem;
+    margin-left: 1.3rem;
     margin-bottom: 0.5rem;
+
+    @media screen and (max-width: $breakpoint-large) {
+      display: block;
+    }
+  }
+
+  h5 {
+    margin-bottom: 0.2rem;
   }
 
   button {
@@ -173,40 +195,8 @@
     border: 1px solid #999;
     border-radius: 2px;
     height: 2.3rem;
-    margin-bottom: 0;
+    margin-bottom: 0.7rem;
     min-height: 2.3rem;
     resize: vertical;
-  }
-
-  details {
-    display: none;
-    font-size: 0.9rem;
-    margin-bottom: 0;
-
-    @media screen and (max-width: $breakpoint-large) {
-      display: block;
-    }
-
-    &[open] summary {
-      // There is a bug in Chrome 87 where hiding the summary does
-      // not also hide the ellipsis.
-      text-overflow: inherit;
-    }
-
-    &[open] summary span {
-      visibility: hidden;
-    }
-
-    &[open] summary::marker {
-      visibility: visible;
-    }
-
-    summary {
-      height: 2rem;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      width: 350px;
-    }
   }
 }

--- a/src/components/panels/ConfigPanel/_config-panel.scss
+++ b/src/components/panels/ConfigPanel/_config-panel.scss
@@ -45,6 +45,7 @@
   }
 
   &__list-header {
+    align-items: baseline;
     display: flex;
     height: 2rem;
     justify-content: space-between;
@@ -65,6 +66,7 @@
 
     .entity-name {
       font-size: 1.3rem;
+      margin-top: 0.3rem;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/components/panels/LocalAppsPanel/_local-apps-panel.scss
+++ b/src/components/panels/LocalAppsPanel/_local-apps-panel.scss
@@ -1,6 +1,7 @@
 .local-apps-panel {
   &__config-button {
     margin-top: 1rem;
+    white-space: nowrap;
 
     i {
       margin-right: 1rem;


### PR DESCRIPTION
## Done

- Ensure that the layout works at `all the widths`!
- Hide the description column for mobile views and show it under the inputs.

## QA

- Use the demo.
- View the `charmed-kubernetes` test model.
- View the config page for various apps and resize the browser to various widths.
- Check on your mobile device of choice.

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1574
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1582

## Screenshots

<details>
<summary>Mobile - short app name w/o reset - expanded description</summary>

![Screen Shot 2021-01-22 at 5 47 13 PM](https://user-images.githubusercontent.com/532033/105560670-17fcc700-5cda-11eb-85db-4c491d589333.png)

</details>

<details>
<summary>Tablet - long app name w/ reset</summary>

![Screen Shot 2021-01-22 at 5 44 39 PM](https://user-images.githubusercontent.com/532033/105560660-159a6d00-5cda-11eb-9d51-e0b594419b90.png)

</details>

<details>
<summary>Tablet - short app name w/ reset</summary>

![Screen Shot 2021-01-22 at 5 46 44 PM](https://user-images.githubusercontent.com/532033/105560667-17643080-5cda-11eb-82b5-d40eeac7514b.png)

</details>

<details>
<summary>Narrow Desktop - long app name w/ reset - expanded description</summary>

![Screen Shot 2021-01-22 at 5 44 53 PM](https://user-images.githubusercontent.com/532033/105560664-16cb9a00-5cda-11eb-8d1e-fcc08d273bcb.png)

</details>


<details>
<summary>Narrow Desktop - long app name w/o reset</summary>

![Screen Shot 2021-01-22 at 5 45 11 PM](https://user-images.githubusercontent.com/532033/105560665-16cb9a00-5cda-11eb-85d6-a96ace1539fd.png)

</details>

<details>
<summary>Narrow Desktop - short app name w/ reset</summary>

![Screen Shot 2021-01-22 at 5 46 17 PM](https://user-images.githubusercontent.com/532033/105560666-17643080-5cda-11eb-9bc5-c4cef8820de6.png)

</details>