### PR TITLE
Fade descriptions in when selecting config inputs.

### DIFF
--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -223,6 +223,7 @@ export default function ConfigPanel({
           <div className="config-panel__description col-6">
             {selectedConfig ? (
               <FadeIn
+                key={selectedConfig.name}
                 isActive={true}
                 className="config-panel__description-wrapper"
               >

--- a/src/panels/LocalAppsPanel/LocalAppsPanel.js
+++ b/src/panels/LocalAppsPanel/LocalAppsPanel.js
@@ -12,8 +12,6 @@ import {
   filterModelStatusDataByApp,
 } from "app/utils";
 
-import ConfigPanel from "panels/ConfigPanel/ConfigPanel";
-
 import { generateMachineRows, generateUnitRows } from "tables/tableRows";
 
 import { machineTableHeaders, unitTableHeaders } from "tables/tableHeaders";


### PR DESCRIPTION
## Done

Fade descriptions in when selecting config inputs.

## QA

- Use the demo link
- View the configuration for an application and then switch focus between two fields.
- The descriptions should fade in when switching.
