### PR TITLE
Switch button group with tabs in model details

### DIFF
--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -3,11 +3,12 @@
 @import "../../scss/functions/z-index";
 
 .header {
+  align-items: center;
   background-color: $color-x-light;
-  box-shadow: 0 1px 5px 1px rgba(51, 51, 51, 0.2);
+  border-bottom: 1px solid $color-mid-light;
   display: grid;
-  min-height: 3rem;
-  padding: 0.5rem;
+  min-height: 4rem;
+  padding: 0 1.5rem;
   position: sticky;
   top: 0;
   z-index: z("gamma");

--- a/src/components/SlidePanel/_slide-panel.scss
+++ b/src/components/SlidePanel/_slide-panel.scss
@@ -3,7 +3,7 @@
 
 .slide-panel {
   @include vf-animation(transform, brisk, out);
-  $top-header-height: 40px;
+  $top-header-height: 64px;
 
   background-color: $color-x-light;
   height: calc(100% - #{$top-header-height});

--- a/src/pages/ControllersIndex/ControllersIndex.js
+++ b/src/pages/ControllersIndex/ControllersIndex.js
@@ -177,10 +177,10 @@ export default function ControllersIndex() {
   return (
     <BaseLayout>
       <Header>
-        <div className="controllers--count">
+        <strong className="controllers--count">
           {controllerCount} controllers,{" "}
           <Link to="/models">{modelCount} models</Link>
-        </div>
+        </strong>
       </Header>
       <div className="l-content controllers">
         <FadeIn isActive={true}>

--- a/src/pages/ControllersIndex/_controllers.scss
+++ b/src/pages/ControllersIndex/_controllers.scss
@@ -14,11 +14,6 @@
     }
   }
 
-  &--count {
-    font-size: 0.875rem;
-    padding: 0.25rem 0.5rem;
-  }
-
   &--header {
     border-bottom: 1px solid $colors--light-theme--border-default;
     color: $color-mid-dark;

--- a/src/pages/EntityDetails/EntityDetails.js
+++ b/src/pages/EntityDetails/EntityDetails.js
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 
-import Spinner from "@canonical/react-components/dist/components/Spinner";
+import { Spinner, Tabs } from "@canonical/react-components";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { useParams } from "react-router-dom";
-
-import ButtonGroup from "components/ButtonGroup/ButtonGroup";
 
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import Header from "components/Header/Header";
@@ -116,11 +114,33 @@ const EntityDetails = ({ activeView, setActiveView, type, children }) => {
           </strong>
           <div className="entity-details__view-selector">
             {modelStatusData && type === "model" && (
-              <ButtonGroup
-                buttons={["apps", "integrations", "machines"]}
-                label="View:"
-                activeButton={activeView}
-                setActiveButton={setActiveView}
+              <Tabs
+                links={[
+                  {
+                    active: activeView === "apps",
+                    label: "Applications",
+                    onClick: (e) => {
+                      e.preventDefault();
+                      setActiveView("apps");
+                    },
+                  },
+                  {
+                    active: activeView === "integrations",
+                    label: "Integrations",
+                    onClick: (e) => {
+                      e.preventDefault();
+                      setActiveView("integrations");
+                    },
+                  },
+                  {
+                    active: activeView === "machines",
+                    label: "Machines",
+                    onClick: (e) => {
+                      e.preventDefault();
+                      setActiveView("machines");
+                    },
+                  },
+                ]}
               />
             )}
           </div>

--- a/src/pages/EntityDetails/Model/Model.test.js
+++ b/src/pages/EntityDetails/Model/Model.test.js
@@ -50,15 +50,21 @@ describe("Model", () => {
     expect(
       wrapper.find(".entity-details__main > .entity-details__apps").length
     ).toBe(1);
-    wrapper.find("ButtonGroup button[value='machines']").simulate("click");
+    wrapper
+      .find(".p-tabs__link[data-test='tab-link-Machines']")
+      .simulate("click");
     expect(
       wrapper.find(".entity-details__main > .entity-details__machines").length
     ).toBe(1);
-    wrapper.find("ButtonGroup button[value='integrations']").simulate("click");
+    wrapper
+      .find(".p-tabs__link[data-test='tab-link-Integrations']")
+      .simulate("click");
     expect(
       wrapper.find(".entity-details__main > .entity-details__relations").length
     ).toBe(1);
-    wrapper.find("ButtonGroup button[value='apps']").simulate("click");
+    wrapper
+      .find(".p-tabs__link[data-test='tab-link-Applications']")
+      .simulate("click");
     expect(
       wrapper.find(".entity-details__main > .entity-details__apps").length
     ).toBe(1);

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -101,16 +101,18 @@
       padding: 0 0.5rem;
     }
 
-    @media (min-width: $breakpoint-m-large) {
-      grid-template-columns: 360px 1fr;
-    }
-
+    // Modified styling of the Vanilla tabbed component. To remove the border
+    // bottom as it sits on a border already.
     .p-tabs__list {
       margin-bottom: 0;
 
       &::after {
-        background-color: none;
+        background-color: transparent;
       }
+    }
+
+    .p-tabs__link::before {
+      background-color: transparent;
     }
 
     .p-tabs__link {

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -96,13 +96,26 @@
     grid-template-columns: 1fr;
 
     @media (min-width: $breakpoint-medium) {
-      gap: 1rem;
-      grid-template-columns: 240px 1fr;
+      gap: 2rem;
+      grid-template-columns: auto 1fr;
       padding: 0 0.5rem;
     }
 
     @media (min-width: $breakpoint-m-large) {
       grid-template-columns: 360px 1fr;
+    }
+
+    .p-tabs__list {
+      margin-bottom: 0;
+
+      &::after {
+        background-color: none;
+      }
+    }
+
+    .p-tabs__link {
+      padding-bottom: 1.25rem;
+      padding-top: 1.25rem;
     }
   }
 

--- a/src/pages/ModelsIndex/ModelsIndex.js
+++ b/src/pages/ModelsIndex/ModelsIndex.js
@@ -80,9 +80,9 @@ export default function Models() {
     <BaseLayout>
       <Header>
         <div className="models__header" data-disabled={modelCount === 0}>
-          <div className="models__count">
+          <strong className="models__count">
             {modelCount} {pluralize(modelCount, "model")}
-          </div>
+          </strong>
           <ButtonGroup
             activeButton={groupModelsBy}
             buttons={["status", "cloud", "owner"]}

--- a/src/pages/ModelsIndex/_models.scss
+++ b/src/pages/ModelsIndex/_models.scss
@@ -31,7 +31,6 @@
 
       .models__count {
         display: block;
-        margin-left: 1rem;
       }
 
       .p-button-group__inner {
@@ -45,7 +44,7 @@
         max-width: 270px;
         position: absolute;
         right: 0.75rem;
-        top: 0.3rem;
+        top: 0.7rem;
         width: 100%;
       }
 


### PR DESCRIPTION
## Done
- Increase the header height to `64px`
- Replaced the button group on model details with the [Tabs component](https://canonical-web-and-design.github.io/react-components/?path=/story/tabs--default-story) __Some styling tweaks required__
- Updated panel offset to match the new header height
- Aligned the header titles styling

## QA
- Open the demo
- See that the header is now 64px tall
- Go to the controller's list and see the header is aligned and the count is strong
- Go to models list and check the header matches controllers **button group updates to come**
- Go to model details and check the header matches [the design](https://zpl.io/2yKRxDq)
- Click on an application and check the header matches other views
- Click a unit and check the panel is correctly positioned

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/888

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/109573350-ccaeb300-7ae6-11eb-87df-1f87728b61ad.png)

