### PR TITLE
Implement the breadcrumb component in the header

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -11,6 +11,9 @@ export function generateEntityIdentifier(
   baseAppURL,
   disableLink = false
 ) {
+  if (!namespace) {
+    return [];
+  }
   let charmStorePath = "";
   try {
     charmStorePath = URL.fromAnyString(namespace).toString().replace("cs:", "");

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -12,7 +12,7 @@ export function generateEntityIdentifier(
   disableLink = false
 ) {
   if (!namespace) {
-    return [];
+    return null;
   }
   let charmStorePath = "";
   try {

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,54 @@
+import configureStore from "redux-mock-store";
+import TestRoute from "components/Routes/TestRoute";
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import dataDump from "testing/complete-redux-store-dump";
+
+import Breadcrumb from "./Breadcrumb";
+
+const mockStore = configureStore([]);
+
+describe("Breadcrumb", () => {
+  it("displays correctly on model details", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/eggman@external/group-test"]}>
+          <TestRoute path="/models/:userName/:modelName?">
+            <Breadcrumb />
+          </TestRoute>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='breadcrumb-application']").length).toBe(0);
+    expect(wrapper.find("[data-test='breadcrumb-model']").text()).toStrictEqual(
+      "group-test"
+    );
+  });
+
+  it("displays correctly on application details", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={["/models/eggman@external/group-test/app/easyrsa"]}
+        >
+          <TestRoute path="/models/:userName/:modelName?/app/:appName?">
+            <Breadcrumb />
+          </TestRoute>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='breadcrumb-model']").text()).toStrictEqual(
+      "group-test"
+    );
+    expect(
+      wrapper.find("[data-test='breadcrumb-section']").text()
+    ).toStrictEqual("Applications");
+    expect(
+      wrapper.find("[data-test='breadcrumb-application']").text()
+    ).toStrictEqual("easyrsa");
+  });
+});

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -41,6 +41,9 @@ describe("Breadcrumb", () => {
         </MemoryRouter>
       </Provider>
     );
+    expect(wrapper.find("[data-test='breadcrumb-items']").text()).toStrictEqual(
+      "group-testApplicationseasyrsa"
+    );
     expect(wrapper.find("[data-test='breadcrumb-model']").text()).toStrictEqual(
       "group-test"
     );

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,11 +1,7 @@
 import { Link } from "@canonical/react-components";
 import { useParams } from "react-router-dom";
 
-export type EntityDetailsRoute = {
-  userName: string;
-  modelName: string;
-  appName: string;
-};
+import type { EntityDetailsRoute } from "components/Routes/Routes";
 
 export default function Breadcrumb(): JSX.Element {
   const { userName, modelName, appName } = useParams<EntityDetailsRoute>();

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ const Breadcrumb = (): JSX.Element => {
 
   return (
     <nav className="p-breadcrumbs" aria-label="Breadcrumb navigation">
-      <ol className="p-breadcrumbs__items">
+      <ol className="p-breadcrumbs__items" data-test="breadcrumb-items">
         {appName ? (
           <>
             <li className="p-breadcrumbs__item" data-test="breadcrumb-model">

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,53 @@
+import { Link } from "@canonical/react-components";
+import { useParams } from "react-router-dom";
+
+export type EntityDetailsRoute = {
+  userName: string;
+  modelName: string;
+  appName: string;
+};
+
+const Breadcrumb = (): JSX.Element => {
+  const { userName, modelName, appName } = useParams<EntityDetailsRoute>();
+
+  return (
+    <nav className="p-breadcrumbs" aria-label="Breadcrumb navigation">
+      <ol className="p-breadcrumbs__items">
+        {appName ? (
+          <>
+            <li className="p-breadcrumbs__item" data-test="breadcrumb-model">
+              <Link
+                href={`/models/${
+                  userName ? `${userName}/${modelName}` : `${modelName}`
+                }`}
+              >
+                {modelName}
+              </Link>
+            </li>
+            <li className="p-breadcrumbs__item" data-test="breadcrumb-section">
+              <Link
+                href={`/models/${
+                  userName ? `${userName}/${modelName}` : `${modelName}`
+                }`}
+              >
+                Applications
+              </Link>
+            </li>
+            <li
+              className="p-breadcrumbs__item"
+              data-test="breadcrumb-application"
+            >
+              <strong>{appName}</strong>
+            </li>
+          </>
+        ) : (
+          <li className="p-breadcrumbs__item" data-test="breadcrumb-model">
+            <strong>{modelName}</strong>
+          </li>
+        )}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumb;

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
-import { Link } from "@canonical/react-components";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import React from "react";
 
 export default function Breadcrumb(): JSX.Element {
   const { userName, modelName, appName } = useParams<EntityDetailsRoute>();
@@ -20,10 +20,10 @@ export default function Breadcrumb(): JSX.Element {
         {appName ? (
           <>
             <li className="p-breadcrumbs__item" data-test="breadcrumb-model">
-              <Link href={generateModelURL()}>{modelName}</Link>
+              <Link to={generateModelURL()}>{modelName}</Link>
             </li>
             <li className="p-breadcrumbs__item" data-test="breadcrumb-section">
-              <Link href={generateModelURL()}>Applications</Link>
+              <Link to={generateModelURL()}>Applications</Link>
             </li>
             <li
               className="p-breadcrumbs__item"

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -7,7 +7,7 @@ export type EntityDetailsRoute = {
   appName: string;
 };
 
-const Breadcrumb = (): JSX.Element => {
+export default function Breadcrumb(): JSX.Element {
   const { userName, modelName, appName } = useParams<EntityDetailsRoute>();
 
   return (
@@ -48,6 +48,4 @@ const Breadcrumb = (): JSX.Element => {
       </ol>
     </nav>
   );
-};
-
-export default Breadcrumb;
+}

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -6,28 +6,24 @@ import type { EntityDetailsRoute } from "components/Routes/Routes";
 export default function Breadcrumb(): JSX.Element {
   const { userName, modelName, appName } = useParams<EntityDetailsRoute>();
 
+  const generateModelURL = function (): string {
+    if (userName) {
+      return `/models/${userName}/${modelName}`;
+    } else {
+      return `/models/${modelName}`;
+    }
+  };
+
   return (
     <nav className="p-breadcrumbs" aria-label="Breadcrumb navigation">
       <ol className="p-breadcrumbs__items" data-test="breadcrumb-items">
         {appName ? (
           <>
             <li className="p-breadcrumbs__item" data-test="breadcrumb-model">
-              <Link
-                href={`/models/${
-                  userName ? `${userName}/${modelName}` : `${modelName}`
-                }`}
-              >
-                {modelName}
-              </Link>
+              <Link href={generateModelURL()}>{modelName}</Link>
             </li>
             <li className="p-breadcrumbs__item" data-test="breadcrumb-section">
-              <Link
-                href={`/models/${
-                  userName ? `${userName}/${modelName}` : `${modelName}`
-                }`}
-              >
-                Applications
-              </Link>
+              <Link href={generateModelURL()}>Applications</Link>
             </li>
             <li
               className="p-breadcrumbs__item"

--- a/src/pages/EntityDetails/EntityDetails.js
+++ b/src/pages/EntityDetails/EntityDetails.js
@@ -6,6 +6,7 @@ import { useParams } from "react-router-dom";
 
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import Header from "components/Header/Header";
+import Breadcrumb from "components/Breadcrumb/Breadcrumb";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 
 import WebCLI from "components/WebCLI/WebCLI";
@@ -109,9 +110,7 @@ const EntityDetails = ({ activeView, setActiveView, type, children }) => {
     <BaseLayout>
       <Header>
         <div className="entity-details__header">
-          <strong className="entity-details__title">
-            {modelStatusData ? modelStatusData.model.name : "..."}
-          </strong>
+          <Breadcrumb />
           <div className="entity-details__view-selector">
             {modelStatusData && type === "model" && (
               <Tabs

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -101,6 +101,17 @@
       padding: 0 0.5rem;
     }
 
+    .p-breadcrumbs {
+      .p-breadcrumbs__items,
+      .p-breadcrumbs__item {
+        margin-bottom: 0;
+      }
+
+      .p-breadcrumbs__item:not(:first-of-type) {
+        text-indent: 1.25rem;
+      }
+    }
+
     // Modified styling of the Vanilla tabbed component. To remove the border
     // bottom as it sits on a border already.
     .p-tabs__list {


### PR DESCRIPTION
## Done
Implement the breadcrumb component in the header
Drive-by, fix error while awaiting modelStatusData to become available

## QA
- Load the demo and go to a model details
- See that the breadcrumb renders just the model name
- Go into an application and check the breadcrumb now matches [the design](https://zpl.io/aN63dv4)
- To test the drive-by, load the branch locally
- Go to an application details
- Refresh and see that the page loads without an error

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/891

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/109694988-4b592e00-7b83-11eb-9121-fe47db4ea423.png)

