### PR TITLE
Update breadcrumbs to support unit details

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -61,10 +61,10 @@ describe("Breadcrumb", () => {
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
-            "/models/eggman@external/group-test/unit/logstash-0",
+            "/models/eggman@external/group-test/app/logstash/unit/logstash-0",
           ]}
         >
-          <TestRoute path="/models/:userName/:modelName?/unit/:unitId?">
+          <TestRoute path="/models/:userName/:modelName?/app/:appName/unit/:unitId?">
             <Breadcrumb />
           </TestRoute>
         </MemoryRouter>

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -71,14 +71,14 @@ describe("Breadcrumb", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='breadcrumb-items']").text()).toStrictEqual(
-      "group-testUnitslogstash-0"
+      "group-testApplicationslogstashlogstash-0"
     );
     expect(wrapper.find("[data-test='breadcrumb-model']").text()).toStrictEqual(
       "group-test"
     );
     expect(
       wrapper.find("[data-test='breadcrumb-section']").text()
-    ).toStrictEqual("Units");
+    ).toStrictEqual("Applications");
     expect(wrapper.find("[data-test='breadcrumb-units']").text()).toStrictEqual(
       "logstash-0"
     );

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -14,17 +14,69 @@ export default function Breadcrumb(): JSX.Element {
     machineId,
   } = useParams<EntityDetailsRoute>();
 
-  const generateModelURL = function (): string {
-    if (userName && machineId) {
-      return `/models/${userName}/${modelName}?activeView=machines`;
-    } else if (userName) {
-      return `/models/${modelName}/${modelName}?activeView=apps`;
-    } else {
-      return `/models/${modelName}`;
+  const generateBreadcrumbs = function (): JSX.Element {
+    const view = machineId ? "machines" : "apps";
+    const isNestedEntityPage = !!appName || !!unitId || !!machineId;
+    if (isNestedEntityPage) {
+      return (
+        <>
+          <li
+            className="p-breadcrumbs__item u-no-padding--top"
+            data-test="breadcrumb-model"
+          >
+            <Link to={`/models/${userName}/${modelName}`}>{modelName}</Link>
+          </li>
+          {!unitId && (
+            <li
+              className="p-breadcrumbs__item u-no-padding--top"
+              data-test="breadcrumb-section"
+            >
+              <Link to={`/models/${userName}/${modelName}?activeView=${view}`}>
+                {entityType.title}
+              </Link>
+            </li>
+          )}
+          {unitId && (
+            <>
+              <li
+                className="p-breadcrumbs__item u-no-padding--top"
+                data-test="breadcrumb-section"
+              >
+                <Link to={`/models/${userName}/${modelName}?activeView=apps`}>
+                  Applications
+                </Link>
+              </li>
+              <li
+                className="p-breadcrumbs__item u-no-padding--top"
+                data-test="breadcrumb-app"
+              >
+                <Link to={`/models/${userName}/${modelName}/${appName}`}>
+                  {appName}
+                </Link>
+              </li>
+            </>
+          )}
+          <li
+            className="p-breadcrumbs__item u-no-padding--top"
+            data-test={`breadcrumb-${entityType.title?.toLowerCase()}`}
+          >
+            <strong>{entityType.id}</strong>
+          </li>
+        </>
+      );
     }
+    return (
+      <li
+        className="p-breadcrumbs__item p-breadcrumbs__item--restricted"
+        data-test="breadcrumb-model"
+        title={modelName}
+      >
+        <Link to={`/models/${userName}/${modelName}`} className="p-link--soft">
+          <strong>{modelName}</strong>
+        </Link>
+      </li>
+    );
   };
-
-  let isNestedEntityPage = !!appName || !!unitId || !!machineId;
 
   type EntityType = {
     id: string | undefined;
@@ -54,38 +106,7 @@ export default function Breadcrumb(): JSX.Element {
   return (
     <nav className="p-breadcrumbs" aria-label="Breadcrumb navigation">
       <ol className="p-breadcrumbs__items" data-test="breadcrumb-items">
-        {isNestedEntityPage ? (
-          <>
-            <li
-              className="p-breadcrumbs__item u-no-padding--top"
-              data-test="breadcrumb-model"
-            >
-              <Link to={generateModelURL()}>{modelName}</Link>
-            </li>
-            <li
-              className="p-breadcrumbs__item u-no-padding--top"
-              data-test="breadcrumb-section"
-            >
-              <Link to={generateModelURL()}>{entityType.title}</Link>
-            </li>
-            <li
-              className="p-breadcrumbs__item u-no-padding--top"
-              data-test={`breadcrumb-${entityType.title?.toLowerCase()}`}
-            >
-              <strong>{entityType.id}</strong>
-            </li>
-          </>
-        ) : (
-          <li
-            className="p-breadcrumbs__item p-breadcrumbs__item--restricted"
-            data-test="breadcrumb-model"
-            title={modelName}
-          >
-            <Link to={generateModelURL()} className="p-link--soft">
-              <strong>{modelName}</strong>
-            </Link>
-          </li>
-        )}
+        {generateBreadcrumbs()}
       </ol>
     </nav>
   );

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -50,7 +50,7 @@ export default function Breadcrumb(): JSX.Element {
                 className="p-breadcrumbs__item u-no-padding--top"
                 data-test="breadcrumb-app"
               >
-                <Link to={`/models/${userName}/${modelName}/${appName}`}>
+                <Link to={`/models/${userName}/${modelName}/app/${appName}`}>
                   {appName}
                 </Link>
               </li>

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -39,7 +39,9 @@ export const paths: Paths = {
   "/models": { component: ModelsIndex },
   "/models/:userName/:modelName?": { component: Model },
   "/models/:userName/:modelName?/app/:appName?": { component: App },
-  "/models/:userName/:modelName?/unit/:unitId?": { component: Unit },
+  "/models/:userName/:modelName?/app/:appName/unit/:unitId?": {
+    component: Unit,
+  },
   "/models/:userName/:modelName?/machine/:machineId?": { component: Machine },
   "/controllers": { component: ControllersIndex },
   "/settings": { component: Settings },

--- a/src/hooks/useTableRowClick.tsx
+++ b/src/hooks/useTableRowClick.tsx
@@ -4,6 +4,7 @@ import { useParams, useHistory } from "react-router-dom";
 type Params = {
   userName: string;
   modelName: string;
+  appName: string;
 };
 
 type Entity = {
@@ -14,17 +15,27 @@ type Entity = {
 export default function useTableRowClick() {
   const history = useHistory();
   const [entity, setEntity] = useState<Entity | null>(null);
-  const { userName, modelName } = useParams<Params>();
+  const { userName, modelName, appName } = useParams<Params>();
 
   useEffect(() => {
     const entityId = entity && entity.id.replace("/", "-");
-    userName &&
-      modelName &&
-      entity &&
-      history.push(
-        `/models/${userName}/${modelName}/${entity.type}/${entityId}`
-      );
-  }, [entity, history, modelName, userName]);
+    if (entity?.type === "unit") {
+      userName &&
+        modelName &&
+        entity &&
+        appName &&
+        history.push(
+          `/models/${userName}/${modelName}/app/${appName}/${entity.type}/${entityId}/`
+        );
+    } else {
+      userName &&
+        modelName &&
+        entity &&
+        history.push(
+          `/models/${userName}/${modelName}/${entity.type}/${entityId}`
+        );
+    }
+  }, [entity, history, modelName, userName, appName]);
 
   return (entityType: string, entityId: string) => {
     setEntity({ type: entityType, id: entityId });


### PR DESCRIPTION
## Done
- Persist the app name in the unit details URL path
- Update breadcrumbs display correctly on unit details 

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to model details and see you get the name and the tabbed options
- Go to an application details and see you get "modelName > Applications > applicationName"
- Go to a unit details and check you get "modelName > Applications > applicationName > unitName"
- Go to a machine details and see you get "modelName > Machines > machineName"  
- [Designs here](https://app.zeplin.io/project/600ef2ab1717a62fd46c0b79/screen/6033c4f2c7763f1716d269c8)

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/911

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/110645366-cf2b9f80-81ad-11eb-8272-2d269bcab4dc.png)

