### PR TITLE
Populate actions list with real data

### DIFF
--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -10,7 +10,7 @@ export default function PanelHeader({ title }: Props): JSX.Element {
 
   return (
     <div className="p-panel__header">
-      <h4 className="p-panel__title">{title}</h4>
+      <div className="p-panel__title">{title}</div>
       <div className="p-panel__controls">
         <button
           onClick={() => panelQs && setPanelQs(undefined)}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,15 +1,20 @@
 import { useState } from "react";
 import classnames from "classnames";
+
+import type { ActionOptions } from "panels/ActionsPanel/ActionsPanel";
+
 import "./_radio-input-box.scss";
 
 type Props = {
   name: string;
   description: string;
+  options: ActionOptions;
 };
 
 export default function RadioInputBox({
   name,
   description,
+  options,
 }: Props): JSX.Element {
   const [opened, setOpened] = useState<boolean>(false);
 
@@ -18,6 +23,10 @@ export default function RadioInputBox({
     setOpened(bool);
   };
   const labelId = `actionRadio-${name}`;
+
+  const generateOptions = (options: ActionOptions): JSX.Element[] => {
+    return options.map((option) => <input key={option.name} type="text" />);
+  };
 
   return (
     <div className={classnames("radio-input-box", { opened })}>
@@ -34,7 +43,12 @@ export default function RadioInputBox({
           {name}
         </span>
       </label>
-      <div className="radio-input-box__content">{description}</div>
+      <div className="radio-input-box__content">
+        <div className="radio-input-box__description">{description}</div>
+        <div className="radio-input-box__options">
+          {generateOptions(options)}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -9,16 +9,17 @@ export default function RadioInputBox({
   name,
   description,
 }: Props): JSX.Element {
+  const labelId = `actionRadio-${name}`;
   return (
     <div className="radio-input-box">
       <label className="p-radio">
         <input
           type="radio"
           className="p-radio__input"
-          name="radioPattern"
-          aria-labelledby="radioExample1"
+          name="actionRadioSelector"
+          aria-labelledby={labelId}
         />
-        <span className="p-radio__label" id="radioExample1">
+        <span className="p-radio__label" id={labelId}>
           {name}
         </span>
       </label>

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import classnames from "classnames";
 import "./_radio-input-box.scss";
 
 type Props = {
@@ -9,15 +11,24 @@ export default function RadioInputBox({
   name,
   description,
 }: Props): JSX.Element {
+  const [opened, setOpened] = useState<boolean>(false);
+
+  const handleSelect = (e: any) => {
+    const bool = e.target.value === "on" ? true : false;
+    setOpened(bool);
+  };
   const labelId = `actionRadio-${name}`;
+
   return (
-    <div className="radio-input-box">
+    <div className={classnames("radio-input-box", { opened })}>
       <label className="p-radio">
         <input
           type="radio"
           className="p-radio__input"
           name="actionRadioSelector"
           aria-labelledby={labelId}
+          onClick={handleSelect}
+          onChange={handleSelect}
         />
         <span className="p-radio__label" id={labelId}>
           {name}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import classnames from "classnames";
 
 import type { ActionOptions } from "panels/ActionsPanel/ActionsPanel";
 
@@ -29,8 +28,8 @@ export default function RadioInputBox({
   };
 
   return (
-    <div className={classnames("radio-input-box", { opened })}>
-      <label className="p-radio">
+    <div className="radio-input-box" aria-expanded={opened}>
+      <label className="p-radio u-no-padding--top radio-input-box__label">
         <input
           type="radio"
           className="p-radio__input"

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,0 +1,28 @@
+import "./_radio-input-box.scss";
+
+type Props = {
+  name: string;
+  description: string;
+};
+
+export default function RadioInputBox({
+  name,
+  description,
+}: Props): JSX.Element {
+  return (
+    <div className="radio-input-box">
+      <label className="p-radio">
+        <input
+          type="radio"
+          className="p-radio__input"
+          name="radioPattern"
+          aria-labelledby="radioExample1"
+        />
+        <span className="p-radio__label" id="radioExample1">
+          {name}
+        </span>
+      </label>
+      <div className="radio-input-box__content">{description}</div>
+    </div>
+  );
+}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -29,7 +29,7 @@ export default function RadioInputBox({
 
   return (
     <div className="radio-input-box" aria-expanded={opened}>
-      <label className="p-radio u-no-padding--top radio-input-box__label">
+      <label className="p-radio radio-input-box__label">
         <input
           type="radio"
           className="p-radio__input"

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -5,22 +5,18 @@
   margin-bottom: 0.5rem;
   padding: 0.5rem;
 
-  label {
+  &__label {
     margin: 0;
     width: 100%;
   }
 
-  .p-radio {
-    padding: 0;
-  }
-
-  &__content {
+  .radio-input-box__content {
     display: none;
     font-size: 0.875rem;
     padding-left: 2rem;
   }
 
-  &.opened {
+  &[aria-expanded="true"] {
     background-color: rgba(0, 102, 204, 0.05);
     border-color: $color-information;
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -5,8 +5,9 @@
   margin-bottom: 0.5rem;
   padding: 0.5rem;
 
-  &__label {
+  .radio-input-box__label {
     margin: 0;
+    padding-top: 0;
     width: 100%;
   }
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -1,13 +1,13 @@
 @import "vanilla-framework/scss/vanilla";
 
 .radio-input-box {
-  border: 1px solid $color-mid-light;
   margin-bottom: 0.5rem;
-  padding-left: 0.5rem;
 
   label {
+    border: 1px solid $color-mid-light;
     margin: 0;
-    padding: 0.5rem 0;
+    padding: 0.5rem;
+    width: 100%;
   }
 
   &__content {

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -16,9 +16,8 @@
 
   &__content {
     display: none;
-    padding-left: 2rem;
-
     font-size: 0.875rem;
+    padding-left: 2rem;
   }
 
   &.opened {

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -1,0 +1,16 @@
+@import "vanilla-framework/scss/vanilla";
+
+.radio-input-box {
+  border: 1px solid $color-mid-light;
+  margin-bottom: 0.5rem;
+  padding-left: 0.5rem;
+
+  label {
+    margin: 0;
+    padding: 0.5rem 0;
+  }
+
+  &__content {
+    display: none;
+  }
+}

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -1,16 +1,32 @@
 @import "vanilla-framework/scss/vanilla";
 
 .radio-input-box {
+  border: 1px solid $color-mid-light;
   margin-bottom: 0.5rem;
+  padding: 0.5rem;
 
   label {
-    border: 1px solid $color-mid-light;
     margin: 0;
-    padding: 0.5rem;
     width: 100%;
+  }
+
+  .p-radio {
+    padding: 0;
   }
 
   &__content {
     display: none;
+    padding-left: 2rem;
+
+    font-size: 0.875rem;
+  }
+
+  &.opened {
+    background-color: rgba(0, 102, 204, 0.05);
+    border-color: $color-information;
+
+    .radio-input-box__content {
+      display: block;
+    }
   }
 }

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -1,6 +1,7 @@
 import Limiter from "async-limiter";
 import { connect, connectAndLogin } from "@canonical/jujulib";
 
+import actions from "@canonical/jujulib/dist/api/facades/action-v6";
 import annotations from "@canonical/jujulib/dist/api/facades/annotations-v2";
 import applications from "@canonical/jujulib/dist/api/facades/application-v12";
 import client from "@canonical/jujulib/dist/api/facades/client-v2";
@@ -37,6 +38,7 @@ import {
 function generateConnectionOptions(usePinger = false, bakery, onClose) {
   // The options used when connecting to a Juju controller or model.
   const facades = [
+    actions,
     annotations,
     applications,
     client,
@@ -415,4 +417,12 @@ export async function setApplicationConfig(
     options: setValues,
   });
   return resp;
+}
+
+export async function getActionsForApplication(appName, modelUUID, appState) {
+  const conn = await connectAndLoginToModel(modelUUID, appState);
+  const actionList = await conn.facades.action.applicationsCharmsActions({
+    entities: [{ tag: `application-${appName}` }],
+  });
+  return actionList;
 }

--- a/src/pages/EntityDetails/App/App.js
+++ b/src/pages/EntityDetails/App/App.js
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { useStore } from "react-redux";
 import { useParams } from "react-router-dom";
 import {
   useQueryParam,
@@ -24,8 +23,6 @@ import {
   generateStatusElement,
   filterModelStatusDataByApp,
 } from "app/utils/utils";
-
-import { getConfig } from "app/selectors";
 
 import { generateMachineRows, generateUnitRows } from "tables/tableRows";
 
@@ -87,7 +84,6 @@ export default function App() {
   const unitChips = renderCounts("units", modelStatusData);
   const machineChips = renderCounts("machines", modelStatusData);
 
-  const { showActionsPanel } = getConfig(useStore().getState());
   const setPanel = useQueryParam("panel", StringParam)[1];
   const showActions = () => {
     setPanel("execute-action");
@@ -105,14 +101,13 @@ export default function App() {
             >
               <i className="p-icon--settings"></i>Configure
             </button>
-            {showActionsPanel ? (
-              <button
-                className="entity-details__action-button"
-                onClick={showActions}
-              >
-                <i className="p-icon--settings"></i>Actions
-              </button>
-            ) : null}
+
+            <button
+              className="entity-details__action-button"
+              onClick={showActions}
+            >
+              <i className="p-icon--settings"></i>Actions
+            </button>
           </div>
           <EntityInfo data={AppEntityData} />
         </>

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -10,6 +10,8 @@ import type { EntityDetailsRoute } from "components/Routes/Routes";
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
 
+import "./_actions-panel.scss";
+
 export default function ActionsPanel(): JSX.Element {
   const appStore = useStore();
   const appState = appStore.getState();
@@ -21,6 +23,8 @@ export default function ActionsPanel(): JSX.Element {
     getModelUUIDMemo as (state: DefaultRootState) => unknown
   );
   const [actionData, setActionData] = useState();
+
+  console.log(actionData);
 
   useEffect(() => {
     getActionsForApplication(appName, modelUUID, appStore.getState()).then(
@@ -37,11 +41,19 @@ export default function ActionsPanel(): JSX.Element {
     appState.juju?.modelData?.[modelUUID as string]?.applications?.[appName]
       ?.charm;
 
-  const title = <h5>{generateIconImg(appName, namespace)} 3 units selected</h5>;
+  const generateSelectedUnitList = () => "1, 2, 3";
+
+  const generateTitle = () => (
+    <h5>{generateIconImg(appName, namespace)} 3 units selected</h5>
+  );
+
   return (
     <Aside width="narrow">
       <div className="p-panel actions-panel">
-        <PanelHeader title={title} />
+        <PanelHeader title={generateTitle()} />
+        <div className="actions-panel__unit-list">
+          Run action on {appName}: {generateSelectedUnitList()}
+        </div>
       </div>
     </Aside>
   );

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -9,8 +9,35 @@ import type { EntityDetailsRoute } from "components/Routes/Routes";
 
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
+import RadioInputBox from "components/RadioInputBox/RadioInputBox";
 
 import "./_actions-panel.scss";
+
+type ActionData = {
+  [key: string]: ActionItem;
+};
+
+type ActionItem = {
+  description: string;
+  params: ActionParams;
+};
+
+type ActionParams = {
+  description: string;
+  properties: ActionProps;
+  required: string[];
+  title: string;
+  type: string;
+};
+
+type ActionProps = {
+  [key: string]: ActionProp;
+};
+
+type ActionProp = {
+  description: string;
+  type: string;
+};
 
 export default function ActionsPanel(): JSX.Element {
   const appStore = useStore();
@@ -22,9 +49,7 @@ export default function ActionsPanel(): JSX.Element {
   const modelUUID = useSelector(
     getModelUUIDMemo as (state: DefaultRootState) => unknown
   );
-  const [actionData, setActionData] = useState();
-
-  console.log(actionData);
+  const [actionData, setActionData] = useState<ActionData>();
 
   useEffect(() => {
     getActionsForApplication(appName, modelUUID, appStore.getState()).then(
@@ -54,7 +79,21 @@ export default function ActionsPanel(): JSX.Element {
         <div className="actions-panel__unit-list">
           Run action on {appName}: {generateSelectedUnitList()}
         </div>
+        <div className="actions-panel__action-list">
+          {generateActionlist(actionData)}
+        </div>
       </div>
     </Aside>
   );
+}
+
+function generateActionlist(actionData: ActionData | undefined) {
+  if (!actionData) return null;
+  return Object.keys(actionData).map((actionName) => (
+    <RadioInputBox
+      name={actionName}
+      description={actionData[actionName].description}
+      key={actionName}
+    />
+  ));
 }

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -57,14 +57,18 @@ export default function ActionsPanel(): JSX.Element {
   const modelUUID = useSelector(
     getModelUUIDMemo as (state: DefaultRootState) => unknown
   );
+
   const [actionData, setActionData] = useState<ActionData>();
+  const [fetchingActionData, setFetchingActionData] = useState(false);
 
   useEffect(() => {
+    setFetchingActionData(true);
     getActionsForApplication(appName, modelUUID, appStore.getState()).then(
       (actions) => {
         if (actions?.results?.[0]?.actions) {
           setActionData(actions.results[0].actions);
         }
+        setFetchingActionData(false);
       }
     );
   }, [appName, appStore, modelUUID]);
@@ -88,15 +92,22 @@ export default function ActionsPanel(): JSX.Element {
           Run action on {appName}: {generateSelectedUnitList()}
         </div>
         <div className="actions-panel__action-list">
-          {generateActionlist(actionData)}
+          {generateActionlist(actionData, fetchingActionData)}
         </div>
       </div>
     </Aside>
   );
 }
 
-function generateActionlist(actionData: ActionData | undefined) {
+function generateActionlist(
+  actionData: ActionData | undefined,
+  fetchingActionData: boolean
+) {
+  if (!actionData && fetchingActionData) return null;
+  if (!actionData && !fetchingActionData)
+    return <div>This charm has not provided any actions</div>;
   if (!actionData) return null;
+
   return Object.keys(actionData).map((actionName) => {
     const action = actionData[actionName];
     const options: ActionOptions = [];

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -9,7 +9,6 @@ import type { EntityDetailsRoute } from "components/Routes/Routes";
 
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
-import RadioInputBox from "components/RadioInputBox/RadioInputBox";
 
 import "./_actions-panel.scss";
 
@@ -112,13 +111,6 @@ function generateActionlist(actionData: ActionData | undefined) {
       });
     });
 
-    return (
-      <RadioInputBox
-        name={actionName}
-        description={action.description}
-        options={options}
-        key={actionName}
-      />
-    );
+    return <div key={actionName}>{actionName}</div>;
   });
 }

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -39,6 +39,15 @@ type ActionProp = {
   type: string;
 };
 
+export type ActionOptions = ActionOptionDetails[];
+
+type ActionOptionDetails = {
+  name: string;
+  description: string;
+  type: string;
+  required: boolean;
+};
+
 export default function ActionsPanel(): JSX.Element {
   const appStore = useStore();
   const appState = appStore.getState();
@@ -89,11 +98,27 @@ export default function ActionsPanel(): JSX.Element {
 
 function generateActionlist(actionData: ActionData | undefined) {
   if (!actionData) return null;
-  return Object.keys(actionData).map((actionName) => (
-    <RadioInputBox
-      name={actionName}
-      description={actionData[actionName].description}
-      key={actionName}
-    />
-  ));
+  return Object.keys(actionData).map((actionName) => {
+    const action = actionData[actionName];
+    const options: ActionOptions = [];
+
+    Object.keys(action.params.properties).forEach((name) => {
+      const property = action.params.properties[name];
+      options.push({
+        name: name,
+        description: property.description,
+        type: property.type,
+        required: action.params.required.includes(name),
+      });
+    });
+
+    return (
+      <RadioInputBox
+        name={actionName}
+        description={action.description}
+        options={options}
+        key={actionName}
+      />
+    );
+  });
 }

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -3,6 +3,7 @@ import { DefaultRootState, useSelector, useStore } from "react-redux";
 import { useParams } from "react-router-dom";
 import { getActionsForApplication } from "juju";
 import { getModelUUID } from "app/selectors";
+import { generateIconImg } from "app/utils/utils";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 
@@ -11,7 +12,8 @@ import PanelHeader from "components/PanelHeader/PanelHeader";
 
 export default function ActionsPanel(): JSX.Element {
   const appStore = useStore();
-  const { modelName } = useParams<EntityDetailsRoute>();
+  const appState = appStore.getState();
+  const { appName, modelName } = useParams<EntityDetailsRoute>();
   const getModelUUIDMemo = useMemo(() => getModelUUID(modelName), [modelName]);
   // Selectors.js is not typescript yet and it complains about the return value
   // of getModelUUID. TSFixMe
@@ -21,16 +23,21 @@ export default function ActionsPanel(): JSX.Element {
   const [actionData, setActionData] = useState();
 
   useEffect(() => {
-    getActionsForApplication("ceph", modelUUID, appStore.getState()).then(
+    getActionsForApplication(appName, modelUUID, appStore.getState()).then(
       (actions) => {
         if (actions?.results?.[0]?.actions) {
           setActionData(actions.results[0].actions);
         }
       }
     );
-  }, [appStore, modelUUID]);
+  }, [appName, appStore, modelUUID]);
 
-  const title = <div>0 3 units selected</div>;
+  // See above note about selectors.js typings TSFixMe
+  const namespace =
+    appState.juju?.modelData?.[modelUUID as string]?.applications?.[appName]
+      ?.charm;
+
+  const title = <h5>{generateIconImg(appName, namespace)} 3 units selected</h5>;
   return (
     <Aside width="narrow">
       <div className="p-panel actions-panel">

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useSelector, useStore } from "react-redux";
+import { DefaultRootState, useSelector, useStore } from "react-redux";
 import { useParams } from "react-router-dom";
 import { getActionsForApplication } from "juju";
 import { getModelUUID } from "app/selectors";
@@ -10,20 +10,25 @@ import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
 
 export default function ActionsPanel(): JSX.Element {
-  const appState = useStore().getState();
+  const appStore = useStore();
   const { modelName } = useParams<EntityDetailsRoute>();
   const getModelUUIDMemo = useMemo(() => getModelUUID(modelName), [modelName]);
-  // @ts-ignore
-  const modelUUID = useSelector(getModelUUIDMemo);
+  // Selectors.js is not typescript yet and it complains about the return value
+  // of getModelUUID. TSFixMe
+  const modelUUID = useSelector(
+    getModelUUIDMemo as (state: DefaultRootState) => unknown
+  );
   const [actionData, setActionData] = useState();
 
   useEffect(() => {
-    getActionsForApplication("ceph", modelUUID, appState).then((actions) => {
-      if (actions?.results?.[0]?.actions) {
-        setActionData(actions.results[0].actions);
+    getActionsForApplication("ceph", modelUUID, appStore.getState()).then(
+      (actions) => {
+        if (actions?.results?.[0]?.actions) {
+          setActionData(actions.results[0].actions);
+        }
       }
-    });
-  }, [appState, modelUUID]);
+    );
+  }, [appStore, modelUUID]);
 
   const title = <div>0 3 units selected</div>;
   return (

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -75,10 +75,10 @@ export default function ActionsPanel(): JSX.Element {
     appState.juju?.modelData?.[modelUUID as string]?.applications?.[appName]
       ?.charm;
 
-  const generateSelectedUnitList = () => "1, 2, 3";
+  const generateSelectedUnitList = () => "...";
 
   const generateTitle = () => (
-    <h5>{generateIconImg(appName, namespace)} 3 units selected</h5>
+    <h5>{generateIconImg(appName, namespace)} 0 units selected</h5>
   );
 
   return (

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -1,7 +1,30 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSelector, useStore } from "react-redux";
+import { useParams } from "react-router-dom";
+import { getActionsForApplication } from "juju";
+import { getModelUUID } from "app/selectors";
+
+import type { EntityDetailsRoute } from "components/Routes/Routes";
+
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
 
 export default function ActionsPanel(): JSX.Element {
+  const appState = useStore().getState();
+  const { modelName } = useParams<EntityDetailsRoute>();
+  const getModelUUIDMemo = useMemo(() => getModelUUID(modelName), [modelName]);
+  // @ts-ignore
+  const modelUUID = useSelector(getModelUUIDMemo);
+  const [actionData, setActionData] = useState();
+
+  useEffect(() => {
+    getActionsForApplication("ceph", modelUUID, appState).then((actions) => {
+      if (actions?.results?.[0]?.actions) {
+        setActionData(actions.results[0].actions);
+      }
+    });
+  }, [appState, modelUUID]);
+
   const title = <div>0 3 units selected</div>;
   return (
     <Aside width="narrow">

--- a/src/panels/ActionsPanel/_actions-panel.scss
+++ b/src/panels/ActionsPanel/_actions-panel.scss
@@ -2,6 +2,10 @@
   padding: 0 1.5rem;
 
   .p-panel__header {
-    padding-left: 0;
+    padding: 0;
+  }
+
+  &__unit-list {
+    margin-bottom: 1.125rem;
   }
 }

--- a/src/panels/ActionsPanel/_actions-panel.scss
+++ b/src/panels/ActionsPanel/_actions-panel.scss
@@ -1,0 +1,7 @@
+.actions-panel {
+  padding: 0 1.5rem;
+
+  .p-panel__header {
+    padding-left: 0;
+  }
+}

--- a/src/panels/RegisterController/RegisterController.js
+++ b/src/panels/RegisterController/RegisterController.js
@@ -63,7 +63,7 @@ export default function RegisterController() {
   return (
     <Aside>
       <div className="p-panel register-controller">
-        <PanelHeader title="Register a controller" />
+        <PanelHeader title={<h4>Register a controller</h4>} />
         <div className="p-panel__content">
           <p className="p-form-help-text">
             Information can be retrieved using the{" "}


### PR DESCRIPTION
## Done

- Populate the action list with real action data.
- Clicking on the radio opens the description

## QA

- Pull code
- `yarn start`
- Open `config.js` and change `showActionsPanel` to `true`.
- View a charm with actions (I've been using `ceph`)
- Click one of them, the description will open (clicking others will just open more of them, this will be addressed in a follow-up)

## Details

Fixes: https://github.com/canonical-web-and-design/juju-squad/issues/1662

## Screenshots

![Screen Shot 2021-03-10 at 4 36 48 PM](https://user-images.githubusercontent.com/532033/110707394-d5764780-81be-11eb-8d98-035b9bf6fa91.png)
