### PR TITLE
Fix the unit row click from machines

### DIFF
--- a/src/hooks/useTableRowClick.tsx
+++ b/src/hooks/useTableRowClick.tsx
@@ -4,7 +4,6 @@ import { useParams, useHistory } from "react-router-dom";
 type Params = {
   userName: string;
   modelName: string;
-  appName: string;
 };
 
 type Entity = {
@@ -15,11 +14,12 @@ type Entity = {
 export default function useTableRowClick() {
   const history = useHistory();
   const [entity, setEntity] = useState<Entity | null>(null);
-  const { userName, modelName, appName } = useParams<Params>();
+  const { userName, modelName } = useParams<Params>();
 
   useEffect(() => {
     const entityId = entity && entity.id.replace("/", "-");
     if (entity?.type === "unit") {
+      const appName = entityId?.split("-").slice(0, -1).join("-");
       userName &&
         modelName &&
         entity &&
@@ -35,7 +35,7 @@ export default function useTableRowClick() {
           `/models/${userName}/${modelName}/${entity.type}/${entityId}`
         );
     }
-  }, [entity, history, modelName, userName, appName]);
+  }, [entity, history, modelName, userName]);
 
   return (entityType: string, entityId: string) => {
     setEntity({ type: entityType, id: entityId });

--- a/src/pages/EntityDetails/Machine/Machine.js
+++ b/src/pages/EntityDetails/Machine/Machine.js
@@ -130,14 +130,14 @@ export default function Machine() {
               rows={unitRows}
               className="entity-details__units p-main-table"
               sortable
-              emptyStateMsg={"There are no units in this model"}
+              emptyStateMsg={"There are no units in this machine"}
             />
             <MainTable
               headers={localApplicationTableHeaders}
               rows={applicationRows}
               className="entity-details__apps p-main-table"
               sortable
-              emptyStateMsg={"There are no apps in this model"}
+              emptyStateMsg={"There are no apps in this machine"}
             />
           </div>
         </div>


### PR DESCRIPTION
## Done
Fix the unit row click from machines
**Driveby**, update the empty table message in the machines view

## QA
- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Click into an model -> app -> unit -> machine -> unit
- Check at all stages the breadcrumb and URL is correct.

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/917
