### PR TITLE
Split out NotFound component

### DIFF
--- a/src/components/NotFound/NotFound.test.tsx
+++ b/src/components/NotFound/NotFound.test.tsx
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import NotFound from "./NotFound";
 
 describe("NotFound", () => {
-  it("should display corrent text", () => {
+  it("should display correct text", () => {
     const wrapper = mount(
       <NotFound message="Wut?">
         <p>This thing cannot be found</p>

--- a/src/components/NotFound/NotFound.test.tsx
+++ b/src/components/NotFound/NotFound.test.tsx
@@ -1,0 +1,18 @@
+import { mount } from "enzyme";
+
+import NotFound from "./NotFound";
+
+describe("NotFound", () => {
+  it("should display corrent text", () => {
+    const wrapper = mount(
+      <NotFound message="Wut?">
+        <p>This thing cannot be found</p>
+      </NotFound>
+    );
+    expect(wrapper.find("h1").length).toBe(1);
+    expect(wrapper.find("h2").text()).toEqual("Wut?");
+    expect(wrapper.find(".not-found__content p").text()).toEqual(
+      "This thing cannot be found"
+    );
+  });
+});

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  message: string;
+  children: JSX.Element;
+};
+
+export default function NotFound({ message, children }: Props) {
+  return (
+    <>
+      <h2>¯\_(ツ)_/¯</h2>
+      <h3>{message}</h3>
+      {children}
+    </>
+  );
+}

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -6,9 +6,13 @@ type Props = {
 export default function NotFound({ message, children }: Props) {
   return (
     <>
-      <h2>¯\_(ツ)_/¯</h2>
-      <h3>{message}</h3>
-      {children}
+      <h1>
+        <span role="img" aria-label="Shrug">
+          ¯\_(ツ)_/¯
+        </span>
+      </h1>
+      <h2>{message}</h2>
+      <div className="not-found__content">{children}</div>
     </>
   );
 }

--- a/src/components/Routes/Routes.tsx
+++ b/src/components/Routes/Routes.tsx
@@ -13,7 +13,9 @@ import Unit from "pages/EntityDetails/Unit/Unit";
 import Machine from "pages/EntityDetails/Machine/Machine";
 
 import Settings from "pages/Settings/Settings";
-import NotFound from "pages/NotFound/NotFound";
+
+// Error pages
+import PageNotFound from "pages/PageNotFound/PageNotFound";
 
 import useAnalytics from "hooks/useAnalytics";
 
@@ -78,7 +80,7 @@ export function Routes() {
     <Switch>
       {routes}
       <Route>
-        <NotFound />
+        <PageNotFound />
       </Route>
     </Switch>
   );

--- a/src/pages/PageNotFound/PageNotFound.js
+++ b/src/pages/PageNotFound/PageNotFound.js
@@ -2,10 +2,11 @@ import { Link } from "react-router-dom";
 
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import Header from "components/Header/Header";
+import NotFound from "components/NotFound/NotFound";
 
 import useWindowTitle from "hooks/useWindowTitle";
 
-export default function NotFound() {
+export default function PageNotFound() {
   useWindowTitle("Page not found");
   return (
     <BaseLayout>

--- a/src/pages/PageNotFound/PageNotFound.js
+++ b/src/pages/PageNotFound/PageNotFound.js
@@ -1,34 +1,30 @@
 import { Link } from "react-router-dom";
 
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-import Header from "components/Header/Header";
 import NotFound from "components/NotFound/NotFound";
 
 import useWindowTitle from "hooks/useWindowTitle";
 
 export default function PageNotFound() {
-  useWindowTitle("Page not found");
+  useWindowTitle("404 - Page not found");
   return (
     <BaseLayout>
-      <Header>
-        <span style={{ marginLeft: "1rem" }}>404: Page not found</span>
-      </Header>
       <div className="p-strip">
         <div className="row">
-          <h2>¯\_(ツ)_/¯</h2>
-          <h3>Hmm, we can't seem to find that page...</h3>
-          <p>Are you looking for any of the pages below?</p>
-          <ul>
-            <li>
-              <Link to="/models">Models</Link>
-            </li>
-            <li>
-              <Link to="/controllers">Controllers</Link>
-            </li>
-            <li>
-              <Link to="/settings">Settings</Link>
-            </li>
-          </ul>
+          <NotFound message="Hmm, we can't seem to find that page...">
+            <p>Are you looking for any of the pages below?</p>
+            <ul>
+              <li>
+                <Link to="/models">Models</Link>
+              </li>
+              <li>
+                <Link to="/controllers">Controllers</Link>
+              </li>
+              <li>
+                <Link to="/settings">Settings</Link>
+              </li>
+            </ul>
+          </NotFound>
         </div>
       </div>
     </BaseLayout>

--- a/src/pages/PageNotFound/PageNotFound.test.js
+++ b/src/pages/PageNotFound/PageNotFound.test.js
@@ -9,7 +9,7 @@ import { Routes } from "components/Routes/Routes";
 
 const mockStore = configureStore([]);
 
-describe("NotFound page", () => {
+describe("PageNotFound page", () => {
   it("should display when unknown route is accessed", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(
@@ -21,7 +21,7 @@ describe("NotFound page", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("NotFound").length).toBe(1);
+    expect(wrapper.find("PageNotFound").length).toBe(1);
     // Ensure only one route is rendered
     expect(wrapper.find("main").length).toBe(1);
   });


### PR DESCRIPTION
## Done

Split out NotFound component to enable this component to be reused in the EntityDetails template if a model cannot be found  

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Sanity check code
- Verify nothing breaks

## Details

Related #906 
