### PR TITLE
Fix aside styling and animations

### DIFF
--- a/src/animations/SlideInOut.tsx
+++ b/src/animations/SlideInOut.tsx
@@ -3,16 +3,19 @@ import { motion } from "framer-motion";
 type Props = {
   isActive: boolean;
   children: JSX.Element;
+  className: string;
 };
 
 export default function SlideInOut({
   isActive = true,
   children,
+  className,
 }: Props): JSX.Element {
   return (
     <>
       {isActive && (
         <motion.div
+          className={className}
           initial={{ x: "100%" }}
           animate={{ x: 0 }}
           exit={{ x: "100%" }}

--- a/src/components/Aside/Aside.tsx
+++ b/src/components/Aside/Aside.tsx
@@ -15,14 +15,15 @@ export default function Aside({
   pinned = false,
 }: Props): JSX.Element {
   return (
-    <div
+    <SlideInOut
+      isActive={true}
       className={classnames("l-aside", {
         "is-narrow": width === "narrow",
         "is-wide": width === "wide",
         "is-pinned": pinned === true,
       })}
     >
-      <SlideInOut isActive={true}>{children}</SlideInOut>
-    </div>
+      {children}
+    </SlideInOut>
   );
 }

--- a/src/components/Aside/_aside.scss
+++ b/src/components/Aside/_aside.scss
@@ -1,16 +1,11 @@
 .l-aside {
-  // Must override Vanilla box shadow and overflow to move shadow to inner panels of aside as
-  // animating content leaves a hanging shadow if not attached to animating page element
-  box-shadow: none !important;
   min-height: 100vh;
   overflow-y: scroll !important;
   padding: 0;
   position: relative;
 
   .p-panel {
-    box-shadow: 0 0 2rem 0 rgb(0 0 0 / 20%);
     min-height: 100vh;
     position: relative;
-    right: -2px;
   }
 }

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -125,3 +125,7 @@
 .l-content {
   margin: 0.5rem 1rem;
 }
+
+.l-application {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
## Done

- Horizontal scroll bars no longer appear when aside panels animate in.
- Removed fudge values to position panel content in aside panels.
- Fixed animation so that it animated the aside and not the panel.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Click to open the register controller panel, it should animate in smoothly with a drop shadow and no scrollbar appearing for the app.
- You can also use the Actions panel if you have a model with actions.

## Details

Fixes: https://github.com/canonical-web-and-design/jaas-dashboard/issues/880
