### PR TITLE
Add interactivity to selecting an action in the Actions panel

### DIFF
--- a/src/components/RadioInputBox/DescriptionSummary.test.js
+++ b/src/components/RadioInputBox/DescriptionSummary.test.js
@@ -1,0 +1,18 @@
+import { mount } from "enzyme";
+
+import DescriptionSummary from "./DescriptionSummary";
+
+describe("DescriptionSummary", () => {
+  it("returns a details component if the description is longer than 30 characters", () => {
+    const description =
+      "The number of coding chunks, i.e. the number of additional chunks computed by the encoding functions. If there are 2 coding chunks, it means 2 OSDs can be out without losing data. ";
+    const wrapper = mount(<DescriptionSummary description={description} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("returns just the text if the description is shorter than 30 characters", () => {
+    const description = "The name of the profile";
+    const wrapper = mount(<DescriptionSummary description={description} />);
+    expect(wrapper.children().equals(<span>{description}</span>)).toBe(true);
+  });
+});

--- a/src/components/RadioInputBox/DescriptionSummary.tsx
+++ b/src/components/RadioInputBox/DescriptionSummary.tsx
@@ -1,0 +1,27 @@
+type Props = {
+  description: string;
+};
+
+export default function DescriptionSummary({
+  description,
+}: Props): JSX.Element {
+  // 30 is a magic number, the width of the available text area of the field
+  // If the width of the actions area increases then this number will need
+  // to be adjusted accordingly.
+  if (description.length > 30) {
+    return (
+      <details className="radio-input-box__details">
+        <summary className="radio-input-box__summary">
+          <span className="radio-input-box__summary-description">
+            {description}
+          </span>
+          &nbsp;
+        </summary>
+        <span className="radio-input-box__details-description">
+          {description}
+        </span>
+      </details>
+    );
+  }
+  return <span>{description}</span>;
+}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -62,7 +62,10 @@ export default function RadioInputBox({
         {options.map((option) => {
           const inputKey = `${option.name}Input`;
           return (
-            <div key={`${option.name}InputGroup`}>
+            <div
+              className="radio-input-box__input-group"
+              key={`${option.name}InputGroup`}
+            >
               <label
                 className={classnames("radio-input-box__label", {
                   "radio-input-box__label--required": option.required,

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -55,7 +55,10 @@ export default function RadioInputBox({
                 id={inputKey}
                 name={inputKey}
               ></input>
-              <span>{option.description}</span>
+              <details className="radio-input-box__details">
+                <summary>{option.description}</summary>
+                {option.description}
+              </details>
             </>
           );
         })}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, ReactNode } from "react";
+import { useEffect, useRef, useState, ReactNode } from "react";
 import classnames from "classnames";
 
 import type {
@@ -24,14 +24,64 @@ export default function RadioInputBox({
   onSelect,
 }: Props): JSX.Element {
   const [opened, setOpened] = useState<boolean>(false);
+  const inputBoxRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 40 is a magic number that aligns nicely with the height of 2.5rem;
+  const renderedHeight = 40;
 
   useEffect(() => {
     setOpened(selectedAction === name);
   }, [selectedAction, name]);
 
+  useEffect(() => {
+    const wrapper = inputBoxRef.current;
+    const container = containerRef.current;
+
+    if (wrapper === null || container === null) return;
+
+    let startHeight = 0;
+    let endHeight = 0;
+    let duration = 0;
+    if (opened) {
+      startHeight = wrapper.offsetHeight;
+      // To be used when we're closing so we know what the original value was.
+      endHeight = container.offsetHeight + 20; // 20 is magic
+      duration = endHeight;
+      // Set the height of the wrapper element to the end height to
+      // override the height set in css for the collapsed size.
+      wrapper.style.height = endHeight + "px";
+      // If the element hasn't been opened then we do not want to animate
+      // it closed again. This is to prevent the animation happening on the
+      // panel opening and the elements being initially rendered to the page.
+    } else if (wrapper.offsetHeight > 40) {
+      endHeight = renderedHeight;
+      startHeight = container.offsetHeight + 20; // 20 is magic
+      duration = startHeight;
+    }
+    const animation = wrapper.animate(
+      {
+        height: [startHeight + "px", endHeight + "px"],
+      },
+      {
+        // Set the duration to be the number of pixels that it has to animate
+        // so that it's a consistent animation regardless of the height.
+        duration,
+        easing: "ease-out",
+      }
+    );
+
+    animation.onfinish = () => {
+      if (opened === false) {
+        wrapper.style.height = renderedHeight + "px";
+      }
+    };
+  }, [opened, renderedHeight]);
+
   const handleSelect = () => {
     onSelect(name);
   };
+
   const labelId = `actionRadio-${name}`;
 
   const generateDescription = (description: string): ReactNode => {
@@ -89,24 +139,26 @@ export default function RadioInputBox({
   };
 
   return (
-    <div className="radio-input-box" aria-expanded={opened}>
-      <label className="p-radio radio-input-box__label">
-        <input
-          type="radio"
-          className="p-radio__input"
-          name="actionRadioSelector"
-          aria-labelledby={labelId}
-          onClick={handleSelect}
-          onChange={handleSelect}
-        />
-        <span className="p-radio__label" id={labelId}>
-          {name}
-        </span>
-      </label>
-      <div className="radio-input-box__content">
-        <div className="radio-input-box__description">{description}</div>
-        <div className="radio-input-box__options">
-          {generateOptions(options)}
+    <div className="radio-input-box" aria-expanded={opened} ref={inputBoxRef}>
+      <div className="radio-input-box__container" ref={containerRef}>
+        <label className="p-radio radio-input-box__label">
+          <input
+            type="radio"
+            className="p-radio__input"
+            name="actionRadioSelector"
+            aria-labelledby={labelId}
+            onClick={handleSelect}
+            onChange={handleSelect}
+          />
+          <span className="p-radio__label" id={labelId}>
+            {name}
+          </span>
+        </label>
+        <div className="radio-input-box__content">
+          <div className="radio-input-box__description">{description}</div>
+          <div className="radio-input-box__options">
+            {generateOptions(options)}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -42,7 +42,7 @@ export default function RadioInputBox({
           return (
             <>
               <label
-                className={classnames({
+                className={classnames("radio-input-box__label", {
                   "radio-input-box__label--required": option.required,
                 })}
                 htmlFor={inputKey}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -109,7 +109,7 @@ export default function RadioInputBox({
             >
               <label
                 className={classnames("radio-input-box__label", {
-                  "radio-input-box__label--required": option.required,
+                  "is-required": option.required,
                 })}
                 htmlFor={inputKey}
               >

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, ReactNode } from "react";
 import classnames from "classnames";
 
 import type {
@@ -34,6 +34,24 @@ export default function RadioInputBox({
   };
   const labelId = `actionRadio-${name}`;
 
+  const generateDescription = (description: string): ReactNode => {
+    // 30 is a magic number, the width of the available text area of the field
+    // If the width of the actions area increases then this number will need
+    // to be adjusted accordingly.
+    if (description.length > 30) {
+      return (
+        <details className="radio-input-box__details">
+          <summary>
+            <span>{description}</span>
+            &nbsp;
+          </summary>
+          <span>{description}</span>
+        </details>
+      );
+    }
+    return description;
+  };
+
   const generateOptions = (options: ActionOptions): JSX.Element => {
     return (
       <form>
@@ -55,13 +73,7 @@ export default function RadioInputBox({
                 id={inputKey}
                 name={inputKey}
               ></input>
-              <details className="radio-input-box__details">
-                <summary>
-                  <span>{option.description}</span>
-                  &nbsp;
-                </summary>
-                <span>{option.description}</span>
-              </details>
+              {generateDescription(option.description)}
             </>
           );
         })}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -41,11 +41,15 @@ export default function RadioInputBox({
     if (description.length > 30) {
       return (
         <details className="radio-input-box__details">
-          <summary>
-            <span>{description}</span>
+          <summary className="radio-input-box__summary">
+            <span className="radio-input-box__summary-description">
+              {description}
+            </span>
             &nbsp;
           </summary>
-          <span>{description}</span>
+          <span className="radio-input-box__details-description">
+            {description}
+          </span>
         </details>
       );
     }

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -60,7 +60,7 @@ export default function RadioInputBox({
                   <span>{option.description}</span>
                   &nbsp;
                 </summary>
-                {option.description}
+                <span>{option.description}</span>
               </details>
             </>
           );

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -56,7 +56,10 @@ export default function RadioInputBox({
                 name={inputKey}
               ></input>
               <details className="radio-input-box__details">
-                <summary>{option.description}</summary>
+                <summary>
+                  <span>{option.description}</span>
+                  &nbsp;
+                </summary>
                 {option.description}
               </details>
             </>

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -58,7 +58,7 @@ export default function RadioInputBox({
         {options.map((option) => {
           const inputKey = `${option.name}Input`;
           return (
-            <>
+            <div key={`${option.name}InputGroup`}>
               <label
                 className={classnames("radio-input-box__label", {
                   "radio-input-box__label--required": option.required,
@@ -74,7 +74,7 @@ export default function RadioInputBox({
                 name={inputKey}
               ></input>
               {generateDescription(option.description)}
-            </>
+            </div>
           );
         })}
       </form>

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 
 import type {
   ActionOptions,
   SetSelectedAction,
 } from "panels/ActionsPanel/ActionsPanel";
+
+import DescriptionSummary from "./DescriptionSummary";
 
 import "./_radio-input-box.scss";
 
@@ -95,28 +97,6 @@ export default function RadioInputBox({
 
   const labelId = `actionRadio-${name}`;
 
-  const generateDescription = (description: string): ReactNode => {
-    // 30 is a magic number, the width of the available text area of the field
-    // If the width of the actions area increases then this number will need
-    // to be adjusted accordingly.
-    if (description.length > 30) {
-      return (
-        <details className="radio-input-box__details">
-          <summary className="radio-input-box__summary">
-            <span className="radio-input-box__summary-description">
-              {description}
-            </span>
-            &nbsp;
-          </summary>
-          <span className="radio-input-box__details-description">
-            {description}
-          </span>
-        </details>
-      );
-    }
-    return description;
-  };
-
   const generateOptions = (options: ActionOptions): JSX.Element => {
     return (
       <form>
@@ -141,7 +121,7 @@ export default function RadioInputBox({
                 id={inputKey}
                 name={inputKey}
               ></input>
-              {generateDescription(option.description)}
+              <DescriptionSummary description={option.description} />
             </div>
           );
         })}

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -1,6 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import classnames from "classnames";
 
-import type { ActionOptions } from "panels/ActionsPanel/ActionsPanel";
+import type {
+  ActionOptions,
+  SetSelectedAction,
+} from "panels/ActionsPanel/ActionsPanel";
 
 import "./_radio-input-box.scss";
 
@@ -8,23 +12,55 @@ type Props = {
   name: string;
   description: string;
   options: ActionOptions;
+  selectedAction: string | undefined;
+  onSelect: SetSelectedAction;
 };
 
 export default function RadioInputBox({
   name,
   description,
   options,
+  selectedAction,
+  onSelect,
 }: Props): JSX.Element {
   const [opened, setOpened] = useState<boolean>(false);
 
-  const handleSelect = (e: any) => {
-    const bool = e.target.value === "on" ? true : false;
-    setOpened(bool);
+  useEffect(() => {
+    setOpened(selectedAction === name);
+  }, [selectedAction, name]);
+
+  const handleSelect = () => {
+    onSelect(name);
   };
   const labelId = `actionRadio-${name}`;
 
-  const generateOptions = (options: ActionOptions): JSX.Element[] => {
-    return options.map((option) => <input key={option.name} type="text" />);
+  const generateOptions = (options: ActionOptions): JSX.Element => {
+    return (
+      <form>
+        {options.map((option) => {
+          const inputKey = `${option.name}Input`;
+          return (
+            <>
+              <label
+                className={classnames({
+                  "radio-input-box__label--required": option.required,
+                })}
+                htmlFor={inputKey}
+              >
+                {option.name}
+              </label>
+              <input
+                className="radio-input-box__input"
+                type="text"
+                id={inputKey}
+                name={inputKey}
+              ></input>
+              <span>{option.description}</span>
+            </>
+          );
+        })}
+      </form>
+    );
   };
 
   return (

--- a/src/components/RadioInputBox/RadioInputBox.tsx
+++ b/src/components/RadioInputBox/RadioInputBox.tsx
@@ -27,8 +27,17 @@ export default function RadioInputBox({
   const inputBoxRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // 40 is a magic number that aligns nicely with the height of 2.5rem;
-  const renderedHeight = 40;
+  // 20, 40 are magic numbers that align nicely with the heights.
+  const initialHeight = 40;
+  const paddingNumber = 20;
+
+  useEffect(() => {
+    if (inputBoxRef.current !== null) {
+      // Due to the 'closed' hook animation running on initial load we cannot
+      // set the initial height in the css but have to do it on the first load.
+      inputBoxRef.current.style.height = initialHeight + "px";
+    }
+  }, [inputBoxRef]);
 
   useEffect(() => {
     setOpened(selectedAction === name);
@@ -43,20 +52,20 @@ export default function RadioInputBox({
     let startHeight = 0;
     let endHeight = 0;
     let duration = 0;
+
     if (opened) {
       startHeight = wrapper.offsetHeight;
       // To be used when we're closing so we know what the original value was.
-      endHeight = container.offsetHeight + 20; // 20 is magic
+      endHeight = container.offsetHeight + paddingNumber;
       duration = endHeight;
       // Set the height of the wrapper element to the end height to
       // override the height set in css for the collapsed size.
       wrapper.style.height = endHeight + "px";
-      // If the element hasn't been opened then we do not want to animate
-      // it closed again. This is to prevent the animation happening on the
-      // panel opening and the elements being initially rendered to the page.
-    } else if (wrapper.offsetHeight > 40) {
-      endHeight = renderedHeight;
-      startHeight = container.offsetHeight + 20; // 20 is magic
+    } else if (wrapper.offsetHeight !== initialHeight) {
+      // Do not animate if the wrapper height is already in the closed state
+      // and this hook runs for the closed state again.
+      endHeight = initialHeight;
+      startHeight = container.offsetHeight + paddingNumber;
       duration = startHeight;
     }
     const animation = wrapper.animate(
@@ -73,10 +82,12 @@ export default function RadioInputBox({
 
     animation.onfinish = () => {
       if (opened === false) {
-        wrapper.style.height = renderedHeight + "px";
+        wrapper.style.height = initialHeight + "px";
+      } else {
+        wrapper.style.height = "";
       }
     };
-  }, [opened, renderedHeight]);
+  }, [opened, initialHeight]);
 
   const handleSelect = () => {
     onSelect(name);

--- a/src/components/RadioInputBox/__snapshots__/DescriptionSummary.test.js.snap
+++ b/src/components/RadioInputBox/__snapshots__/DescriptionSummary.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DescriptionSummary returns a details component if the description is longer than 30 characters 1`] = `
+<DescriptionSummary
+  description="The number of coding chunks, i.e. the number of additional chunks computed by the encoding functions. If there are 2 coding chunks, it means 2 OSDs can be out without losing data. "
+>
+  <details
+    className="radio-input-box__details"
+  >
+    <summary
+      className="radio-input-box__summary"
+    >
+      <span
+        className="radio-input-box__summary-description"
+      >
+        The number of coding chunks, i.e. the number of additional chunks computed by the encoding functions. If there are 2 coding chunks, it means 2 OSDs can be out without losing data. 
+      </span>
+       
+    </summary>
+    <span
+      className="radio-input-box__details-description"
+    >
+      The number of coding chunks, i.e. the number of additional chunks computed by the encoding functions. If there are 2 coding chunks, it means 2 OSDs can be out without losing data. 
+    </span>
+  </details>
+</DescriptionSummary>
+`;

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -11,10 +11,22 @@
     width: 100%;
   }
 
+  .radio-input-box__description {
+    margin-bottom: 1.25rem;
+  }
+
   .radio-input-box__content {
     display: none;
     font-size: 0.875rem;
     padding-left: 2rem;
+
+    .radio-input-box__label--required::after {
+      content: "*";
+    }
+
+    .radio-input-box__input {
+      margin-bottom: 0.25rem;
+    }
   }
 
   &[aria-expanded="true"] {

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -40,6 +40,7 @@
     overflow: hidden;
 
     summary {
+      cursor: pointer;
       display: block;
       margin-bottom: 0;
       overflow: hidden;
@@ -67,8 +68,14 @@
       }
     }
 
-    &[open] > summary::before {
-      transform: rotate(90deg);
+    &[open] summary {
+      span {
+        display: none;
+      }
+
+      &::before {
+        transform: rotate(90deg);
+      }
     }
   }
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -3,12 +3,17 @@
 .radio-input-box {
   border: 1px solid $color-mid-light;
   margin-bottom: 0.5rem;
-  padding: 0.5rem;
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
 
   .radio-input-box__label {
-    margin: 0;
+    font-size: 1rem;
+    margin-bottom: 0;
     padding-top: 0;
     width: 100%;
+
+    &--required::after {
+      content: "*";
+    }
   }
 
   .radio-input-box__description {
@@ -18,14 +23,16 @@
   .radio-input-box__content {
     display: none;
     font-size: 0.875rem;
+    margin-top: 0.25rem;
     padding-left: 2rem;
-
-    .radio-input-box__label--required::after {
-      content: "*";
-    }
 
     .radio-input-box__input {
       margin-bottom: 0.25rem;
+    }
+
+    .radio-input-box__options .radio-input-box__label {
+      margin-bottom: 0.5rem;
+      margin-top: 1rem;
     }
   }
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -14,10 +14,6 @@
     margin-bottom: 0;
     padding-top: 0;
     width: 100%;
-
-    &--required::after {
-      content: "*";
-    }
   }
 
   .radio-input-box__content {

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -2,6 +2,7 @@
 
 .radio-input-box {
   border: 1px solid $color-mid-light;
+  border-radius: 2px;
   margin-bottom: 0.5rem;
   padding: 0.5rem 1rem 0.5rem 0.5rem;
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -25,14 +25,50 @@
     font-size: 0.875rem;
     margin-top: 0.25rem;
     padding-left: 2rem;
+  }
 
-    .radio-input-box__input {
-      margin-bottom: 0.25rem;
+  .radio-input-box__input {
+    margin-bottom: 0.25rem;
+  }
+
+  .radio-input-box__options .radio-input-box__label {
+    margin-bottom: 0.5rem;
+    margin-top: 1rem;
+  }
+
+  .radio-input-box__details {
+    overflow: hidden;
+
+    summary {
+      display: block;
+      margin-bottom: 0;
+      overflow: hidden;
+      padding: 0;
+      padding-left: 1.3rem;
+      position: relative;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      &::before {
+        border-color: transparent transparent transparent #111;
+        border-style: solid;
+        border-width: 0.3rem;
+        content: "";
+        left: 0.3rem;
+        position: absolute;
+        top: 0.5rem;
+        transform: rotate(0);
+        transform-origin: 0.1rem 50%;
+        transition: 0.25s transform ease;
+      }
+
+      &::marker {
+        display: none;
+      }
     }
 
-    .radio-input-box__options .radio-input-box__label {
-      margin-bottom: 0.5rem;
-      margin-top: 1rem;
+    &[open] > summary::before {
+      transform: rotate(90deg);
     }
   }
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -16,10 +16,6 @@
     }
   }
 
-  .radio-input-box__description {
-    margin-bottom: 1.25rem;
-  }
-
   .radio-input-box__content {
     display: none;
     font-size: 0.875rem;
@@ -31,9 +27,11 @@
     margin-bottom: 0.25rem;
   }
 
-  .radio-input-box__options .radio-input-box__label {
-    margin-bottom: 0.5rem;
-    margin-top: 1rem;
+  .radio-input-box__options {
+    .radio-input-box__label {
+      margin-bottom: 0.5rem;
+      margin-top: 1rem;
+    }
   }
 
   .radio-input-box__details {
@@ -83,6 +81,10 @@
         transform: rotate(90deg);
       }
     }
+  }
+
+  .radio-input-box__input-group:last-child .radio-input-box__details {
+    margin-bottom: 0;
   }
 
   &[aria-expanded="true"] {

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -39,7 +39,7 @@
   .radio-input-box__details {
     overflow: hidden;
 
-    summary {
+    .radio-input-box__summary {
       cursor: pointer;
       display: block;
       margin-bottom: 0;
@@ -68,14 +68,14 @@
       }
     }
 
-    &[open] span {
+    &[open] .radio-input-box__details-description {
       padding-left: 1.3rem;
     }
 
-    &[open] summary {
+    &[open] .radio-input-box__summary {
       margin-bottom: -1.5rem;
 
-      span {
+      &-description {
         display: none;
       }
 

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -3,8 +3,12 @@
 .radio-input-box {
   border: 1px solid $color-mid-light;
   border-radius: 2px;
+  height: 2.5rem;
   margin-bottom: 0.5rem;
+  overflow: hidden;
   padding: 0.5rem 1rem 0.5rem 0.5rem;
+
+  @include vf-animation(#{border, background-color}, sleepy, linear);
 
   .radio-input-box__label {
     font-size: 1rem;
@@ -18,7 +22,6 @@
   }
 
   .radio-input-box__content {
-    display: none;
     font-size: 0.875rem;
     margin-top: 0.25rem;
     padding-left: 2rem;

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -68,7 +68,13 @@
       }
     }
 
+    &[open] span {
+      padding-left: 1.3rem;
+    }
+
     &[open] summary {
+      margin-bottom: -1.5rem;
+
       span {
         display: none;
       }

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -3,7 +3,6 @@
 .radio-input-box {
   border: 1px solid $color-mid-light;
   border-radius: 2px;
-  height: 2.5rem;
   margin-bottom: 0.5rem;
   overflow: hidden;
   padding: 0.5rem 1rem 0.5rem 0.5rem;

--- a/src/components/RadioInputBox/_radio-input-box.scss
+++ b/src/components/RadioInputBox/_radio-input-box.scss
@@ -35,6 +35,13 @@
     }
   }
 
+  .radio-input-box__description {
+    // Required for Chrome as it does not break long running URLS on slashes
+    // like Firefox does. This doesn't appear to cause any negative side
+    // effects in Firefox.
+    word-wrap: break-word;
+  }
+
   .radio-input-box__details {
     overflow: hidden;
 

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -9,6 +9,7 @@ import type { EntityDetailsRoute } from "components/Routes/Routes";
 
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
+import RadioInputBox from "components/RadioInputBox/RadioInputBox";
 
 import "./_actions-panel.scss";
 
@@ -47,6 +48,8 @@ type ActionOptionDetails = {
   required: boolean;
 };
 
+export type SetSelectedAction = (actionName: string) => void;
+
 export default function ActionsPanel(): JSX.Element {
   const appStore = useStore();
   const appState = appStore.getState();
@@ -60,6 +63,10 @@ export default function ActionsPanel(): JSX.Element {
 
   const [actionData, setActionData] = useState<ActionData>();
   const [fetchingActionData, setFetchingActionData] = useState(false);
+  const [selectedAction, setSelectedAction]: [
+    string | undefined,
+    SetSelectedAction
+  ] = useState<string>();
 
   useEffect(() => {
     setFetchingActionData(true);
@@ -92,7 +99,12 @@ export default function ActionsPanel(): JSX.Element {
           Run action on {appName}: {generateSelectedUnitList()}
         </div>
         <div className="actions-panel__action-list">
-          {generateActionlist(actionData, fetchingActionData)}
+          {generateActionlist(
+            actionData,
+            fetchingActionData,
+            selectedAction,
+            setSelectedAction
+          )}
         </div>
       </div>
     </Aside>
@@ -101,7 +113,9 @@ export default function ActionsPanel(): JSX.Element {
 
 function generateActionlist(
   actionData: ActionData | undefined,
-  fetchingActionData: boolean
+  fetchingActionData: boolean,
+  selectedAction: string | undefined,
+  setSelectedAction: SetSelectedAction
 ) {
   if (!actionData && fetchingActionData) return null;
   if (!actionData && !fetchingActionData)
@@ -122,6 +136,15 @@ function generateActionlist(
       });
     });
 
-    return <div key={actionName}>{actionName}</div>;
+    return (
+      <RadioInputBox
+        name={actionName}
+        description={action.description}
+        options={options}
+        onSelect={setSelectedAction}
+        selectedAction={selectedAction}
+        key={actionName}
+      />
+    );
   });
 }


### PR DESCRIPTION
## Done

The actions list is now styled to match the designs.
- Selecting an action opens the actions option list (if one exists)
- If an option description is longer than 30 characters it'll be collapsed and allow for expansion.

Note:
It's still not functional - this is purely UI interactivity. Because of this the functionality tests are going to come in the follow-up branch which hooks this up to the API.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- View a charm with actions, select an action and see the available interactions

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1663

## Screenshots
![Screen Shot 2021-03-18 at 3 26 40 PM](https://user-images.githubusercontent.com/532033/111699999-71770300-87fe-11eb-8543-076b4955aed6.png)


![heightanim](https://user-images.githubusercontent.com/532033/111694264-49d06c80-87f7-11eb-8f1a-f4ea569ba25c.gif)

