### PR TITLE
Indicate the provider type throughout entity details

### DIFF
--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -125,6 +125,7 @@ export default function App(): JSX.Element {
     os: "Ubuntu",
     revision: (app && extractRevisionNumber(app.charm)) || "-",
     message: "-",
+    provider: modelStatusData?.info?.["provider-type"],
   };
 
   const unitChips = renderCounts("units", modelStatusData);

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -116,6 +116,7 @@ const Model = () => {
     "Cloud/Region": `${cloudProvider} / ${modelStatusData?.model.region}`,
     version: modelStatusData?.model.version,
     sla: modelStatusData?.model.sla,
+    provider: modelStatusData?.info?.["provider-type"],
   };
 
   const LocalAppChips = renderCounts("localApps", modelStatusData);

--- a/src/pages/EntityDetails/Unit/Unit.js
+++ b/src/pages/EntityDetails/Unit/Unit.js
@@ -88,6 +88,7 @@ export default function Unit() {
     revision: extractRevisionNumber(app.charm) || "-",
     version: app["workload-version"] || "-",
     info: app.status.info,
+    provider: modelStatusData?.info?.["provider-type"],
   };
 
   return (


### PR DESCRIPTION
## Done
Add the provider type of the model to all entity info panels. So it is clear which provider you are using at all depths.

## QA
- Open https://jaas-dashboard-951.demos.haus
- Go to a model details page and see the provider info in the info panel
- Go to a app details page and see the provider info in the info panel
- Go to a unit details page and see the provider info in the info panel

## Details
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1722

## Screenshots
Model details:
![image](https://user-images.githubusercontent.com/1413534/114545265-a9356700-9c53-11eb-9b23-929ca02bb7b5.png)

App details:
![image](https://user-images.githubusercontent.com/1413534/114545296-b2becf00-9c53-11eb-92d8-182a00df8b18.png)

Unit details:
![image](https://user-images.githubusercontent.com/1413534/114545329-bce0cd80-9c53-11eb-943e-b22d7cd35669.png)

