### PR TITLE
Wrap content in the entity panel if info is too long

### DIFF
--- a/src/components/EntityInfo/_entity-info.scss
+++ b/src/components/EntityInfo/_entity-info.scss
@@ -6,4 +6,8 @@
       grid-template-columns: repeat(2, 1fr);
     }
   }
+
+  &__grid-item {
+    overflow-wrap: anywhere;
+  }
 }


### PR DESCRIPTION
## Done
Wrap content in the entity panel if info is too long

## QA
- Open the demo
- Go to a unit details
- Check the version to a very long string such as the screenshot and see the word wraps

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/952

## Screenshots
| Before | After |
| --- | --- |
| ![Image Pasted at 2021-4-13 13-45](https://user-images.githubusercontent.com/1413534/114575547-2ff93c80-9c72-11eb-9b09-0766dc04a5b3.png) | ![Image Pasted at 2021-4-13 13-48](https://user-images.githubusercontent.com/1413534/114575627-456e6680-9c72-11eb-98e8-fdd90b52bb01.png) |


