### PR TITLE
Fetch charm icon from charmhub for charms deployed from there

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juju-dashboard",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A dashboard for Juju and JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -251,6 +251,11 @@ export const generateIconPath = (charmId) => {
     charmId = charmId.replace("cs:", "");
     return `https://api.jujucharms.com/charmstore/v5/${charmId}/icon.svg`;
   }
+  if (charmId.indexOf("ch:") === 0) {
+    // XXX This is a temporary fix until charmhub.io can provide us with an
+    // icon endpoint.
+    return defaultCharmIcon;
+  }
   return "";
 };
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,42 +1,17 @@
-import { URL } from "@canonical/jaaslib/lib/urls";
-
 import cloneDeep from "clone-deep";
 
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 
-export function generateEntityIdentifier(
-  charmId,
-  name,
-  subordinate,
-  disableLink = false
-) {
+export function generateEntityIdentifier(charmId, name, subordinate) {
   if (!charmId) {
     return null;
-  }
-  let charmStorePath = "";
-  try {
-    charmStorePath = URL.fromAnyString(charmId).toString().replace("cs:", "");
-  } catch (e) {
-    console.error("unable to parse charmstore path", e);
   }
 
   return (
     <div className="entity-name">
       {subordinate && <span className="subordinate"></span>}
       {charmId && generateIconImg(name, charmId)}
-      {/* Ensure app is not a local charm or disable link is true */}
-      {charmId.includes("cs:") && !disableLink ? (
-        <a
-          data-test="app-link"
-          target="_blank"
-          rel="noopener noreferrer"
-          href={`https://www.jaas.ai/${charmStorePath}`}
-        >
-          {name}
-        </a>
-      ) : (
-        name
-      )}
+      {name}
     </div>
   );
 }

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -252,9 +252,11 @@ export const generateIconPath = (charmId) => {
     return `https://api.jujucharms.com/charmstore/v5/${charmId}/icon.svg`;
   }
   if (charmId.indexOf("ch:") === 0) {
-    // XXX This is a temporary fix until charmhub.io can provide us with an
-    // icon endpoint.
-    return defaultCharmIcon;
+    // Regex explanation:
+    // "ch:amd64/xenial/content-cache-425".match(/\/(.+)\/(.+)-\d+/)
+    // Array(3) [ "/xenial/content-cache-425", "xenial", "content-cache" ]
+    const charmName = charmId.match(/\/(.+)\/(.+)-\d+/)[2];
+    return `https://charmhub.io/${charmName}/icon`;
   }
   return "";
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -5,17 +5,17 @@ import cloneDeep from "clone-deep";
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 
 export function generateEntityIdentifier(
-  namespace,
+  charmId,
   name,
   subordinate,
   disableLink = false
 ) {
-  if (!namespace) {
+  if (!charmId) {
     return null;
   }
   let charmStorePath = "";
   try {
-    charmStorePath = URL.fromAnyString(namespace).toString().replace("cs:", "");
+    charmStorePath = URL.fromAnyString(charmId).toString().replace("cs:", "");
   } catch (e) {
     console.error("unable to parse charmstore path", e);
   }
@@ -23,9 +23,9 @@ export function generateEntityIdentifier(
   return (
     <div className="entity-name">
       {subordinate && <span className="subordinate"></span>}
-      {namespace && generateIconImg(name, namespace)}
+      {charmId && generateIconImg(name, charmId)}
       {/* Ensure app is not a local charm or disable link is true */}
-      {namespace.includes("cs:") && !disableLink ? (
+      {charmId.includes("cs:") && !disableLink ? (
         <a
           data-test="app-link"
           target="_blank"
@@ -265,16 +265,16 @@ export const extractRevisionNumber = (charmName) => charmName.split("-").pop();
 
 /**
   Returns a link to the charm icon for the provided charm name.
-  @param {String} namespace The fully qualified charm name.
+  @param {String} charmId The fully qualified charm name.
   @returns {String} The link to the charm icon.
 */
-export const generateIconPath = (namespace) => {
-  if (namespace.indexOf("local:") === 0) {
+export const generateIconPath = (charmId) => {
+  if (charmId.indexOf("local:") === 0) {
     return defaultCharmIcon;
   }
-  if (namespace.indexOf("cs:") === 0) {
-    namespace = namespace.replace("cs:", "");
-    return `https://api.jujucharms.com/charmstore/v5/${namespace}/icon.svg`;
+  if (charmId.indexOf("cs:") === 0) {
+    charmId = charmId.replace("cs:", "");
+    return `https://api.jujucharms.com/charmstore/v5/${charmId}/icon.svg`;
   }
   return "";
 };
@@ -396,10 +396,10 @@ export const extractRelationEndpoints = (relation) => {
   return endpoints;
 };
 
-export const generateIconImg = (name, namespace) => {
+export const generateIconImg = (name, charmId) => {
   let iconSrc = defaultCharmIcon;
-  if (namespace.indexOf("local:") !== 0) {
-    iconSrc = generateIconPath(namespace);
+  if (charmId.indexOf("local:") !== 0) {
+    iconSrc = generateIconPath(charmId);
   }
   return (
     <img

--- a/src/tables/tableRows.js
+++ b/src/tables/tableRows.js
@@ -39,7 +39,7 @@ export function generateLocalApplicationRows(
       columns: [
         {
           "data-test-column": "name",
-          content: generateEntityIdentifier(app.charm || "", key, false, true),
+          content: generateEntityIdentifier(app.charm || "", key, false),
           className: "u-truncate",
         },
         {
@@ -180,16 +180,10 @@ export function generateUnitRows(
       const publicAddress = unit["public-address"] || "-";
       const port = unit?.["opened-ports"]?.join(" ") || "-";
       const message = unit["workload-status"].info || "-";
+      const charm = applications[applicationName].charm;
       let columns = [
         {
-          content: generateEntityIdentifier(
-            applications[applicationName].charm
-              ? applications[applicationName].charm
-              : "",
-            unitId,
-            false,
-            true // disable link
-          ),
+          content: generateEntityIdentifier(charm ? charm : "", unitId, false),
           className: "u-truncate",
         },
         {
@@ -257,12 +251,7 @@ export function generateUnitRows(
           unitRows.push({
             columns: [
               {
-                content: generateEntityIdentifier(
-                  subordinate.charm,
-                  key,
-                  true,
-                  true // disable link
-                ),
+                content: generateEntityIdentifier(subordinate.charm, key, true),
                 className: "u-truncate",
               },
               {


### PR DESCRIPTION
## Done

Fetch charm icon from charmhub for charms deployed from there.

## QA

- In the demo icons should be rendered as expected.
- Bootstrap your own controller with Juju 2.9 
- Point the dashboard to it using [these instructions](https://github.com/canonical-web-and-design/jaas-dashboard#developing-while-connected-to-a-juju-controller)

## Details

Fixes #972 

## Screenshots

<img width="1003" alt="Screen Shot 2021-04-27 at 2 11 00 PM" src="https://user-images.githubusercontent.com/532033/116308022-3bfdf780-a764-11eb-83d5-01f636ce759b.png">

