### PR TITLE
Add Sharing panel to model detail pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "classnames": "2.3.1",
     "clone-deep": "4.0.1",
     "d3": "6.7.0",
+    "date-fns": "^2.21.1",
     "formik": "2.2.6",
     "framer-motion": "4.1.9",
     "immer": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "classnames": "2.3.1",
     "clone-deep": "4.0.1",
     "d3": "6.7.0",
-    "date-fns": "^2.21.1",
+    "date-fns": "2.21.1",
     "formik": "2.2.6",
     "framer-motion": "4.1.9",
     "immer": "9.0.2",

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -141,7 +141,7 @@ const getDecodedMacaroons = (macaroons) => {
 const getModelUUIDByName = (name, modelData) => {
   let owner = null;
   let modelName = null;
-  if (name.includes("/")) {
+  if (name?.includes("/")) {
     [owner, modelName] = name.split("/");
   } else {
     modelName = name;

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,4 +1,3 @@
-import { URL } from "@canonical/jaaslib/lib/urls";
 import { parseISO, formatDistanceToNow } from "date-fns";
 import cloneDeep from "clone-deep";
 

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,3 +1,5 @@
+import { URL } from "@canonical/jaaslib/lib/urls";
+import { parseISO, formatDistanceToNow } from "date-fns";
 import cloneDeep from "clone-deep";
 
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
@@ -402,4 +404,8 @@ export const generateRelationIconImage = (applicationName, modelStatusData) => {
     return;
   }
   return generateIconImg(applicationName, application.charm);
+};
+
+export const formatFriendlyDateToNow = (date) => {
+  return formatDistanceToNow(parseISO(date), { addSuffix: true });
 };

--- a/src/app/utils/utils.test.js
+++ b/src/app/utils/utils.test.js
@@ -1,4 +1,4 @@
-import { pluralize } from "./utils";
+import { pluralize, formatFriendlyDateToNow } from "./utils";
 
 describe("pluralize", () => {
   it("should correctly handle a single item", () => {
@@ -15,5 +15,13 @@ describe("pluralize", () => {
     const multipleItems = 2;
     const label = pluralize(multipleItems, "allocating");
     expect(label).toBe("allocating");
+  });
+});
+
+describe("formatFriendlyDateToNow", () => {
+  it("should return a human friendly time string", () => {
+    const timeOneHourAgo = new Date(Date.now() - 3600000).toISOString();
+    const friendlyDate = formatFriendlyDateToNow(timeOneHourAgo);
+    expect(friendlyDate).toBe("about 1 hour ago");
   });
 });

--- a/src/components/Aside/Aside.tsx
+++ b/src/components/Aside/Aside.tsx
@@ -1,18 +1,22 @@
 import classnames from "classnames";
 import SlideInOut from "animations/SlideInOut";
 
+import Spinner from "@canonical/react-components/dist/components/Spinner/Spinner";
+
 import "./_aside.scss";
 
 type Props = {
   children: JSX.Element;
   width?: "wide" | "narrow";
   pinned?: boolean;
+  loading?: boolean;
 };
 
 export default function Aside({
   children,
   width,
   pinned = false,
+  loading = false,
 }: Props): JSX.Element {
   return (
     <SlideInOut
@@ -23,7 +27,13 @@ export default function Aside({
         "is-pinned": pinned === true,
       })}
     >
-      {children}
+      {!loading ? (
+        children
+      ) : (
+        <div className="loading">
+          <Spinner />
+        </div>
+      )}
     </SlideInOut>
   );
 }

--- a/src/components/Aside/_aside.scss
+++ b/src/components/Aside/_aside.scss
@@ -1,3 +1,5 @@
+@import "vanilla-framework/scss/vanilla";
+
 .l-aside {
   min-height: 100vh;
   overflow-y: scroll !important;
@@ -7,5 +9,14 @@
   .p-panel {
     min-height: 100vh;
     position: relative;
+  }
+
+  .loading {
+    align-items: center;
+    background-color: $color-x-light;
+    display: flex;
+    height: 100vh;
+    justify-content: center;
+    width: 100%;
   }
 }

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -1,6 +1,11 @@
 import { useMemo, useCallback } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
-import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import {
+  useQueryParams,
+  useQueryParam,
+  StringParam,
+  withDefault,
+} from "use-query-params";
 import { useHistory, useParams } from "react-router-dom";
 import { pluralize, extractCloudName } from "app/utils/utils";
 
@@ -240,10 +245,20 @@ const Model = () => {
     appOffersTableLength,
   ]);
 
+  const setPanelQs = useQueryParam("panel", StringParam)[1];
+
   return (
     <EntityDetails type="model">
       <div>
         <InfoPanel />
+        <div className="entity-details__actions">
+          <button
+            className="entity-details__action-button"
+            onClick={() => setPanelQs("share-model")}
+          >
+            <i className="p-icon--share"></i>Share model
+          </button>
+        </div>
         {modelStatusData && <EntityInfo data={ModelEntityData} />}
       </div>
       <div className="entity-details__main u-overflow--scroll">

--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -1,0 +1,32 @@
+import { mount } from "enzyme";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import { QueryParamProvider } from "use-query-params";
+import dataDump from "testing/complete-redux-store-dump";
+
+import TestRoute from "components/Routes/TestRoute";
+
+import ShareModel from "./ShareModel";
+
+const mockStore = configureStore([]);
+
+describe("Share Model Panel", () => {
+  it("should show users with which a model is shared", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
+        <Provider store={store}>
+          <TestRoute path="/models/:userName/:modelName?">
+            <QueryParamProvider ReactRouterRoute={Route}>
+              <ShareModel />
+            </QueryParamProvider>
+          </TestRoute>
+        </Provider>
+      </MemoryRouter>
+    );
+    const firstUserCard = wrapper.find(".share-model__card").first();
+    const firstUserName = firstUserCard.find(".share-model__card-title strong");
+    expect(firstUserName.text()).toBe("eggman@external");
+  });
+});

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -1,15 +1,98 @@
+import { useParams } from "react-router-dom";
+
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
+
+import type { EntityDetailsRoute } from "components/Routes/Routes";
 
 import "./share-model.scss";
 
 export default function ShareModel() {
+  const { modelName } = useParams<EntityDetailsRoute>();
   return (
     <Aside>
-      <div className="p-panel register-controller">
-        <PanelHeader title={<h4>Share</h4>} />
+      <div className="p-panel share-model">
+        <PanelHeader
+          title={
+            <div className="title-wrapper">
+              <i className="p-icon--share"></i>
+              <h4>Share {modelName}</h4>
+            </div>
+          }
+        />
         <div className="p-panel__content">
-          <p>WAT</p>
+          <div>
+            <h4>Sharing with</h4>
+            <div className="share-model__card">
+              <div className="share-model__card-title">
+                <strong>clara</strong>
+                <span className="secondary">owner</span>
+              </div>
+              <p className="supplementary">Last connection: 20 minutes ago</p>
+            </div>
+          </div>
+          <div>
+            <h4>Add new user</h4>
+            <form>
+              <label className="is-required" htmlFor="username">
+                Username
+              </label>
+              <input required type="text" placeholder="Username" />
+              <label className="is-required" htmlFor="accessLevel">
+                Access level
+              </label>
+              <div className="p-radio">
+                <input
+                  type="radio"
+                  className="p-radio__input"
+                  name="accessLevel"
+                  aria-labelledby="accessLevel1"
+                />
+                <span className="p-radio__label" id="accessLevel1">
+                  read
+                  <span className="help-text">
+                    A user can view the state of the model
+                  </span>
+                </span>
+              </div>
+
+              <div className="p-radio">
+                <input
+                  type="radio"
+                  className="p-radio__input"
+                  name="accessLevel"
+                  aria-labelledby="accessLevel2"
+                />
+                <span className="p-radio__label" id="accessLevel2">
+                  write
+                  <span className="help-text">
+                    In addition to 'read' abilities, a user can modify/configure
+                    models
+                  </span>
+                </span>
+              </div>
+
+              <div className="p-radio">
+                <input
+                  type="radio"
+                  className="p-radio__input"
+                  name="accessLevel"
+                  aria-labelledby="accessLevel3"
+                />
+                <span className="p-radio__label" id="accessLevel3">
+                  admin
+                  <span className="help-text">
+                    In addition to 'write' abilities, a user can perform model
+                    upgrades and connect to machines via juju ssh. Makes the
+                    user an effective model owner.
+                  </span>
+                </span>
+              </div>
+              <div className="action-wrapper">
+                <button className="p-button--positive">Add user</button>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </Aside>

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -18,7 +18,7 @@ export default function ShareModel() {
   const users = modelStatusData?.info?.users;
 
   const isOwner = (user: string) => {
-    return user === modelStatusData?.info["owner-tag"].split("-")[1];
+    return user === modelStatusData?.info["owner-tag"].replace("user-", "");
   };
 
   type User = {

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -1,16 +1,35 @@
 import { useParams } from "react-router-dom";
+import useModelStatus from "hooks/useModelStatus";
+import { formatFriendlyDateToNow } from "app/utils/utils";
 
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
+import type { TSFixMe } from "types";
 
 import "./share-model.scss";
 
 export default function ShareModel() {
   const { modelName } = useParams<EntityDetailsRoute>();
+
+  const modelStatusData: TSFixMe = useModelStatus() || null;
+
+  const users = modelStatusData?.info?.users;
+
+  const isOwner = (user: string) => {
+    return user === modelStatusData?.info["owner-tag"].split("-")[1];
+  };
+
+  type User = {
+    user: string;
+    "display-name": string;
+    "last-connection": string;
+    access: string;
+  };
+
   return (
-    <Aside>
+    <Aside loading={!modelStatusData}>
       <div className="p-panel share-model">
         <PanelHeader
           title={
@@ -22,76 +41,25 @@ export default function ShareModel() {
         />
         <div className="p-panel__content">
           <div>
-            <h4>Sharing with</h4>
-            <div className="share-model__card">
-              <div className="share-model__card-title">
-                <strong>clara</strong>
-                <span className="secondary">owner</span>
-              </div>
-              <p className="supplementary">Last connection: 20 minutes ago</p>
-            </div>
-          </div>
-          <div>
-            <h4>Add new user</h4>
-            <form>
-              <label className="is-required" htmlFor="username">
-                Username
-              </label>
-              <input required type="text" placeholder="Username" />
-              <label className="is-required" htmlFor="accessLevel">
-                Access level
-              </label>
-              <div className="p-radio">
-                <input
-                  type="radio"
-                  className="p-radio__input"
-                  name="accessLevel"
-                  aria-labelledby="accessLevel1"
-                />
-                <span className="p-radio__label" id="accessLevel1">
-                  read
-                  <span className="help-text">
-                    A user can view the state of the model
-                  </span>
-                </span>
-              </div>
-
-              <div className="p-radio">
-                <input
-                  type="radio"
-                  className="p-radio__input"
-                  name="accessLevel"
-                  aria-labelledby="accessLevel2"
-                />
-                <span className="p-radio__label" id="accessLevel2">
-                  write
-                  <span className="help-text">
-                    In addition to 'read' abilities, a user can modify/configure
-                    models
-                  </span>
-                </span>
-              </div>
-
-              <div className="p-radio">
-                <input
-                  type="radio"
-                  className="p-radio__input"
-                  name="accessLevel"
-                  aria-labelledby="accessLevel3"
-                />
-                <span className="p-radio__label" id="accessLevel3">
-                  admin
-                  <span className="help-text">
-                    In addition to 'write' abilities, a user can perform model
-                    upgrades and connect to machines via juju ssh. Makes the
-                    user an effective model owner.
-                  </span>
-                </span>
-              </div>
-              <div className="action-wrapper">
-                <button className="p-button--positive">Add user</button>
-              </div>
-            </form>
+            <h5>Sharing with:</h5>
+            {users?.map((userObj: User) => {
+              return (
+                <div className="share-model__card" key={userObj.user}>
+                  <div className="share-model__card-title">
+                    <strong>{userObj["user"]}</strong>
+                    <span className="secondary">
+                      {isOwner(userObj["user"]) && "Owner"}
+                    </span>
+                  </div>
+                  <p className="supplementary">
+                    Last connected:{" "}
+                    {userObj["last-connection"]
+                      ? formatFriendlyDateToNow(userObj["last-connection"])
+                      : `Never connected`}
+                  </p>
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -1,0 +1,17 @@
+import Aside from "components/Aside/Aside";
+import PanelHeader from "components/PanelHeader/PanelHeader";
+
+import "./share-model.scss";
+
+export default function ShareModel() {
+  return (
+    <Aside>
+      <div className="p-panel register-controller">
+        <PanelHeader title={<h4>Share</h4>} />
+        <div className="p-panel__content">
+          <p>WAT</p>
+        </div>
+      </div>
+    </Aside>
+  );
+}

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -13,12 +13,6 @@
 
   .p-panel__content {
     padding: 1rem;
-
-    > div:first-child {
-      border-bottom: 1px solid #ccc;
-      margin-bottom: 1.5rem;
-      padding-bottom: 1rem;
-    }
   }
 
   &__card {
@@ -28,7 +22,7 @@
     margin-bottom: 1rem;
     padding: 1rem 1rem 0;
 
-    .supplementary-text {
+    .supplementary {
       color: $color-mid-dark;
     }
 

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -1,0 +1,43 @@
+@import "vanilla-framework/scss/vanilla";
+
+.register-controller {
+  .row {
+    grid-gap: 0;
+    padding: 0;
+  }
+
+  .p-panel__content {
+    padding: 1.5rem;
+  }
+
+  .p-icon--warning {
+    margin-top: 7px;
+    position: absolute;
+  }
+
+  .p-form-help-text {
+    line-height: 1.25;
+    padding-right: 1rem;
+
+    code {
+      display: inline-block;
+      margin: 0.25rem 0.25rem;
+    }
+
+    &.identity-provider {
+      padding-left: 2rem;
+    }
+  }
+
+  .controller-link-message {
+    padding-left: 2rem;
+  }
+
+  .required-star {
+    color: $color-negative;
+  }
+
+  .p-button--positive {
+    width: 100%;
+  }
+}

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -1,43 +1,64 @@
 @import "vanilla-framework/scss/vanilla";
 
-.register-controller {
-  .row {
-    grid-gap: 0;
-    padding: 0;
+.share-model {
+  .title-wrapper {
+    display: flex;
+
+    i {
+      margin-right: 1rem;
+      position: relative;
+      top: 0.5rem;
+    }
   }
 
   .p-panel__content {
-    padding: 1.5rem;
+    padding: 1rem;
+
+    > div:first-child {
+      border-bottom: 1px solid #ccc;
+      margin-bottom: 1.5rem;
+      padding-bottom: 1rem;
+    }
   }
 
-  .p-icon--warning {
-    margin-top: 7px;
-    position: absolute;
-  }
+  &__card {
+    background-color: $color-light;
+    border: solid 1px $color-mid-x-light;
+    border-radius: 2px;
+    margin-bottom: 1rem;
+    padding: 1rem 1rem 0;
 
-  .p-form-help-text {
-    line-height: 1.25;
-    padding-right: 1rem;
-
-    code {
-      display: inline-block;
-      margin: 0.25rem 0.25rem;
+    .supplementary-text {
+      color: $color-mid-dark;
     }
 
-    &.identity-provider {
+    &-title {
+      display: flex;
+      margin-left: auto;
+      width: 100%;
+
+      .secondary {
+        margin-left: auto;
+      }
+    }
+  }
+
+  .p-radio {
+    margin-bottom: 1rem;
+
+    .help-text {
+      color: $color-mid-dark;
+      display: block;
       padding-left: 2rem;
     }
   }
 
-  .controller-link-message {
-    padding-left: 2rem;
-  }
+  .action-wrapper {
+    display: flex;
+    margin-top: 2rem;
 
-  .required-star {
-    color: $color-negative;
-  }
-
-  .p-button--positive {
-    width: 100%;
+    button {
+      margin-left: auto;
+    }
   }
 }

--- a/src/panels/panels.tsx
+++ b/src/panels/panels.tsx
@@ -4,6 +4,7 @@ import useEventListener from "hooks/useEventListener";
 
 import ActionsPanel from "panels/ActionsPanel/ActionsPanel";
 import RegisterController from "panels/RegisterController/RegisterController";
+import ShareModel from "panels/ShareModelPanel/ShareModel";
 
 import "./_panels.scss";
 
@@ -32,6 +33,8 @@ export default function Panels() {
         return <RegisterController />;
       case "execute-action":
         return <ActionsPanel />;
+      case "share-model":
+        return <ShareModel />;
       default:
         return null;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,7 +5180,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.21.1:
+date-fns@2.21.1:
   version "2.21.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.1.tgz#679a4ccaa584c0706ea70b3fa92262ac3009d2b0"
   integrity sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,6 +5180,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.21.1:
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.1.tgz#679a4ccaa584c0706ea70b3fa92262ac3009d2b0"
+  integrity sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Done

Add Sharing panel to model detail pages, showing who a model has already been shared with.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Click on a model 
- Click on 'Share model' under the topology
- Verify the share model panel opens and lists the users the model has been shared with

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1737,
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1739
