### PR TITLE
Add an empty column to a subordinate unit table

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -9,7 +9,7 @@ export function generateEntityIdentifier(charmId, name, subordinate) {
   }
 
   return (
-    <div className="entity-name">
+    <div className="entity-name u-truncate" title={name}>
       {subordinate && <span className="subordinate"></span>}
       {charmId && generateIconImg(name, charmId)}
       {name}

--- a/src/pages/EntityDetails/App/App.test.js
+++ b/src/pages/EntityDetails/App/App.test.js
@@ -207,7 +207,7 @@ describe("Entity Details App", () => {
     ].applications.etcd.units = null;
     const wrapper = await generateComponent(tweakedData);
     expect(wrapper.find("MainTable caption").text()).toBe(
-      "There are no units in this model"
+      "There are no units in this application"
     );
   });
 });

--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -284,7 +284,7 @@ export default function App(): JSX.Element {
                     rows={unitPanelRows}
                     className="entity-details__units p-main-table panel__table has-checkbox"
                     sortable
-                    emptyStateMsg={"There are no units in this model"}
+                    emptyStateMsg={"There are no units in this application"}
                     data-test="units-table"
                   />
                 </FormikFormData>

--- a/src/tables/tableRows.js
+++ b/src/tables/tableRows.js
@@ -251,6 +251,9 @@ export function generateUnitRows(
           unitRows.push({
             columns: [
               {
+                content: "",
+              },
+              {
                 content: generateEntityIdentifier(subordinate.charm, key, true),
                 className: "u-truncate",
               },


### PR DESCRIPTION
## Done
Add an empty column to a subordinate unit table
Also drive by, to update the empty unit table message to be application now model.

## QA
- Open the demo
- Go to a model with a subordinate (hadoopspark(gomboli) > slave)
- Check the subordinate columns now align correctly

## Details
Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1765

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/118973532-aec85000-b969-11eb-8bcf-6d6fc2e8f3ab.png)
