### PR TITLE
Fail gracefully when action logs includes missing applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juju-dashboard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A dashboard for Juju and JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"

--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
@@ -48,6 +48,10 @@ type ActionData = {
   name: string;
 };
 
+type ApplicationData = {
+  charm: string;
+};
+
 function generateLinkToApp(
   appName: string,
   userName: string,
@@ -58,6 +62,26 @@ function generateLinkToApp(
       {appName}
     </Link>
   );
+}
+
+function generateAppIcon(
+  application: ApplicationData | undefined,
+  appName: string,
+  userName: string,
+  modelName: string
+) {
+  // If the user has executed actions with an application and then removed
+  // that application it'll no longer be in the model data so in this
+  // case we need to fail gracefully.
+  if (application) {
+    return (
+      <>
+        {generateIconImg(appName, application.charm)}
+        {generateLinkToApp(appName, userName, modelName)}
+      </>
+    );
+  }
+  return <>{appName}</>;
 }
 
 export default function ActionLogs() {
@@ -133,13 +157,12 @@ export default function ActionLogs() {
               );
               return;
             }
-            const charm = modelStatusData.applications[appName].charm;
             newData = {
-              application: (
-                <>
-                  {generateIconImg(appName, charm)}
-                  {generateLinkToApp(appName, userName, modelName)}
-                </>
+              application: generateAppIcon(
+                modelStatusData.applications[appName],
+                appName,
+                userName,
+                modelName
               ),
               id: `${operationId}/${actionName}`,
               status: generateStatusElement(


### PR DESCRIPTION
## Done

If the action logs contains applications that are no longer in the model then fail gracefully by only rendering the application name.

## QA

- Contact me for access to a test model.... or...
- Create a new model and `juju deploy cs:ceph-mon`.
- Run a simple action like `get-health`.
- View the action logs page.
- `juju remove-application ceph-mon`
- View the action logs page.
- It shouldn't 💥 

## Details

Fixes #1020 

## Screenshots

Without application data:
<img width="1679" alt="Screen Shot 2021-05-31 at 11 33 36 AM" src="https://user-images.githubusercontent.com/532033/120227012-9c6dd200-c205-11eb-9a79-3baacf9bb5c0.png">

With application data:
<img width="1677" alt="Screen Shot 2021-05-31 at 11 36 09 AM" src="https://user-images.githubusercontent.com/532033/120227018-9d9eff00-c205-11eb-8e2b-4e9e5dd9037c.png">
