### PR TITLE
Collapse user menu when active if side nav collapses

### DIFF
--- a/src/components/UserMenu/_user-menu.scss
+++ b/src/components/UserMenu/_user-menu.scss
@@ -15,12 +15,6 @@
     max-height: 120px;
   }
 
-  @at-root {
-    .has-collapsible-sidebar .is-collapsed .user-menu.is-active {
-      max-height: 2.5rem;
-    }
-  }
-
   &__header {
     cursor: pointer;
     display: flex;

--- a/src/components/UserMenu/_user-menu.scss
+++ b/src/components/UserMenu/_user-menu.scss
@@ -6,13 +6,13 @@
 
   bottom: 0;
   color: $color-light;
-  max-height: 2.5rem;
+  max-height: $user-menu-height--inactive;
   padding: 0;
   position: absolute;
   width: 100%;
 
   &.is-active {
-    max-height: 120px;
+    max-height: $user-menu-height--active;
   }
 
   &__header {

--- a/src/layout/BaseLayout/BaseLayout.test.tsx
+++ b/src/layout/BaseLayout/BaseLayout.test.tsx
@@ -70,7 +70,9 @@ describe("Base Layout", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("header").prop("data-side-nav-collapsed")).toBe(true);
+    expect(
+      wrapper.find("header").prop("data-sidenav-initially-collapsed")
+    ).toBe(true);
   });
 
   it("should not collapse the sidebar when not on entity details pages", () => {
@@ -88,6 +90,8 @@ describe("Base Layout", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("header").prop("data-side-nav-collapsed")).toBe(false);
+    expect(
+      wrapper.find("header").prop("data-sidenav-initially-collapsed")
+    ).toBe(false);
   });
 });

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -1,9 +1,8 @@
 import { TSFixMe } from "types";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 
-import Logo from "components/Logo/Logo";
 import Banner from "components/Banner/Banner";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 
@@ -23,7 +22,6 @@ type Props = {
 };
 
 const BaseLayout = ({ children }: Props) => {
-  const [menuCollapsed, setMenuCollapsed] = useState(true);
   const location = useLocation();
   const dispatch = useDispatch();
 
@@ -65,20 +63,8 @@ const BaseLayout = ({ children }: Props) => {
       <div id="confirmation-modal-container"></div>
 
       <div className="l-application">
-        <div className="l-navigation-bar">
-          <Logo />
-          <button
-            className="is-dense toggle-menu"
-            onClick={() => {
-              setMenuCollapsed(!menuCollapsed);
-            }}
-          >
-            {menuCollapsed ? "Open menu" : "Close menu"}
-          </button>
-        </div>
         <header
           className="l-navigation"
-          data-collapsed={menuCollapsed}
           data-side-nav-collapsed={collapseSidebar}
         >
           <div className="l-navigation__drawer">

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -65,7 +65,7 @@ const BaseLayout = ({ children }: Props) => {
       <div className="l-application">
         <header
           className="l-navigation"
-          data-side-nav-collapsed={collapseSidebar}
+          data-sidenav-initially-collapsed={collapseSidebar}
         >
           <div className="l-navigation__drawer">
             <PrimaryNav />

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -120,6 +120,20 @@
       }
     }
   }
+
+  // Close user menu when side nav collapses so it remains active but appears
+  // visually inactive until the user hovers the side nav again
+  &[data-sidenav-initially-collapsed="true"] {
+    .user-menu.is-active {
+      max-height: $user-menu-height--inactive;
+    }
+
+    &:hover {
+      .user-menu.is-active {
+        max-height: $user-menu-height--active;
+      }
+    }
+  }
 }
 
 .l-content {

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -87,7 +87,7 @@
 
   // Override Vanilla to always collapse navigation sidebar
   @media (min-width: $breakpoint-large - 1) {
-    &[data-side-nav-collapsed="true"] {
+    &[data-sidenav-initially-collapsed="true"] {
       & ~ .l-main {
         padding-left: 3rem;
       }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -8,3 +8,7 @@ $color-navigation-highlight: #004e68;
 $color-navigation-accent: #3fc8f2;
 $color-grey60: #999;
 $color-blue-highlight: #ddedfe;
+
+// User menu active/inactive heights
+$user-menu-height--inactive: 2.5rem;
+$user-menu-height--active: 7.5rem;


### PR DESCRIPTION
## Done

- Collapse user menu when active if side nav collapses
- Remove some redundant code related to old external menu in side nav which was removed months ago

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Open user menu
- Go to model details view
- See that menu has collapsed
- Hover side nav
- Menu should expand until closed or you hover away

## Details

Fixes #985
