### PR TITLE
Add focus state and simple animations to sharing cards

### DIFF
--- a/src/animations/SlideDownFadeOut.tsx
+++ b/src/animations/SlideDownFadeOut.tsx
@@ -1,0 +1,25 @@
+import { motion, AnimatePresence } from "framer-motion";
+
+type Props = {
+  children: JSX.Element;
+  className?: string;
+  isAnimating: boolean;
+};
+
+export default function SlideDownFadeOut({
+  children,
+  className,
+  isAnimating,
+}: Props): JSX.Element {
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 1, y: 0 }}
+        animate={isAnimating && { opacity: 0, y: 50 }}
+        className={className}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/components/ShareCard/ShareCard.test.tsx
+++ b/src/components/ShareCard/ShareCard.test.tsx
@@ -1,0 +1,77 @@
+import { mount } from "enzyme";
+
+import ShareCard from "./ShareCard";
+
+describe("Share Card", () => {
+  it("should display appropriate text", () => {
+    const wrapper = mount(
+      <ShareCard
+        userName="janedoe"
+        lastConnected="2021-06-03T16:03:15Z"
+        access="read"
+        isOwner={false}
+        removeUser={jest.fn()}
+        accessSelectChange={jest.fn()}
+      />
+    );
+    expect(wrapper.find(".share-card__username").text()).toStrictEqual(
+      "janedoe"
+    );
+    expect(wrapper.find(".share-card__secondary").text()).toStrictEqual(
+      "Remove user"
+    );
+  });
+
+  it("should not allow owners to change access", () => {
+    const wrapper = mount(
+      <ShareCard
+        userName="janedoe"
+        lastConnected="2021-06-03T16:03:15Z"
+        access="read"
+        isOwner={true}
+        removeUser={jest.fn()}
+        accessSelectChange={jest.fn()}
+      />
+    );
+    expect(wrapper.find(".share-card__secondary").text()).toStrictEqual(
+      "Owner"
+    );
+    expect(wrapper.find(".share__card-access").length).toBe(0);
+  });
+
+  it("should call remove function when icon clicked", () => {
+    const removeUserFn = jest.fn();
+    const accessSelectChangeFn = jest.fn();
+    const wrapper = mount(
+      <ShareCard
+        userName="janedoe"
+        lastConnected="2021-06-03T16:03:15Z"
+        access="read"
+        isOwner={false}
+        removeUser={removeUserFn}
+        accessSelectChange={accessSelectChangeFn}
+      />
+    );
+    const removeIcon = wrapper.find(".p-icon--delete");
+    removeIcon.simulate("click");
+    expect(removeUserFn).toBeCalled();
+  });
+
+  it("should call access change function when select value clicked", () => {
+    const removeUserFn = jest.fn();
+    const accessSelectChangeFn = jest.fn();
+    const wrapper = mount(
+      <ShareCard
+        userName="janedoe"
+        lastConnected="2021-06-03T16:03:15Z"
+        access="read"
+        isOwner={false}
+        removeUser={removeUserFn}
+        accessSelectChange={accessSelectChangeFn}
+      />
+    );
+    const accessLevelSelect = wrapper.find("select.share__card-access");
+    accessLevelSelect.simulate("change");
+    expect(accessSelectChangeFn).toBeCalled();
+  });
+});

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -31,10 +31,10 @@ export default function ShareCard({
   return (
     <div>
       <SlideDownFadeOut isAnimating={hasBeenRemoved}>
-        <div className="share__card" data-active={inFocus}>
-          <div className="share__card-title">
-            <strong className="share__card-username">{userName}</strong>
-            <span className="secondary">
+        <div className="share-card" data-active={inFocus}>
+          <div className="share-card__title">
+            <strong className="share-card__username">{userName}</strong>
+            <span className="share-card__secondary">
               {isOwner ? (
                 "Owner"
               ) : (
@@ -53,7 +53,7 @@ export default function ShareCard({
               )}
             </span>
           </div>
-          <div className="supplementary">
+          <div className="share-card__supplementary">
             Last connected:{" "}
             {lastConnected
               ? formatFriendlyDateToNow(lastConnected)

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -1,0 +1,70 @@
+import { Formik, Field, Form } from "formik";
+import { formatFriendlyDateToNow } from "app/utils/utils";
+
+type Props = {
+  userName: string;
+  lastConnected: string | null;
+  access: string;
+  isOwner: boolean;
+  removeUser: (userName: string) => void;
+  accessSelectChange: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    userName: string
+  ) => void;
+};
+
+export default function ShareCard({
+  userName,
+  lastConnected,
+  access,
+  isOwner,
+  removeUser,
+  accessSelectChange,
+}: Props) {
+  return (
+    <div className="share-model__card" key={userName}>
+      <div className="share-model__card-title">
+        <strong>{userName}</strong>
+        <span className="secondary">
+          {isOwner ? (
+            "Owner"
+          ) : (
+            <i
+              className="p-icon--delete"
+              onClick={() => removeUser(userName)}
+              onKeyPress={() => removeUser(userName)}
+              role="button"
+              tabIndex={0}
+            >
+              Remove user
+            </i>
+          )}
+        </span>
+      </div>
+      <div className="supplementary">
+        Last connected:{" "}
+        {lastConnected
+          ? formatFriendlyDateToNow(lastConnected)
+          : `Never connected`}
+        {!isOwner && (
+          <Formik initialValues={{}} onSubmit={() => {}}>
+            <Form>
+              <Field
+                as="select"
+                name="access"
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  accessSelectChange(e, userName)
+                }
+                value={access}
+              >
+                <option value="read">Read</option>
+                <option value="write">Write</option>
+                <option value="admin">Admin</option>
+              </Field>
+            </Form>
+          </Formik>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -33,7 +33,7 @@ export default function ShareCard({
       <SlideDownFadeOut isAnimating={hasBeenRemoved}>
         <div className="share__card" data-active={inFocus}>
           <div className="share__card-title">
-            <strong>{userName}</strong>
+            <strong className="share__card-username">{userName}</strong>
             <span className="secondary">
               {isOwner ? (
                 "Owner"
@@ -71,6 +71,7 @@ export default function ShareCard({
                       setInFocus(false);
                     }}
                     value={access}
+                    className="share__card-access"
                   >
                     <option value="read">Read</option>
                     <option value="write">Write</option>

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Formik, Field, Form } from "formik";
 import { formatFriendlyDateToNow } from "app/utils/utils";
 
+import SlideDownFadeOut from "animations/SlideDownFadeOut";
+
 import "./_share-card.scss";
 
 type Props = {
@@ -25,53 +27,61 @@ export default function ShareCard({
   accessSelectChange,
 }: Props) {
   const [inFocus, setInFocus] = useState(false);
+  const [hasBeenRemoved, setHasBeenRemoved] = useState(false);
   return (
-    <div className="share__card" key={userName} data-active={inFocus}>
-      <div className="share__card-title">
-        <strong>{userName}</strong>
-        <span className="secondary">
-          {isOwner ? (
-            "Owner"
-          ) : (
-            <i
-              className="p-icon--delete"
-              onClick={() => removeUser(userName)}
-              onKeyPress={() => removeUser(userName)}
-              role="button"
-              tabIndex={0}
-            >
-              Remove user
-            </i>
-          )}
-        </span>
-      </div>
-      <div className="supplementary">
-        Last connected:{" "}
-        {lastConnected
-          ? formatFriendlyDateToNow(lastConnected)
-          : `Never connected`}
-        {!isOwner && (
-          <Formik initialValues={{}} onSubmit={() => {}}>
-            <Form>
-              <Field
-                as="select"
-                name="access"
-                onFocus={() => setInFocus(true)}
-                onBlur={() => setInFocus(false)}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  accessSelectChange(e, userName);
-                  setInFocus(false);
-                }}
-                value={access}
-              >
-                <option value="read">Read</option>
-                <option value="write">Write</option>
-                <option value="admin">Admin</option>
-              </Field>
-            </Form>
-          </Formik>
-        )}
-      </div>
+    <div>
+      <SlideDownFadeOut isAnimating={hasBeenRemoved}>
+        <div className="share__card" data-active={inFocus}>
+          <div className="share__card-title">
+            <strong>{userName}</strong>
+            <span className="secondary">
+              {isOwner ? (
+                "Owner"
+              ) : (
+                <i
+                  className="p-icon--delete"
+                  onClick={() => {
+                    removeUser(userName);
+                    setHasBeenRemoved(true);
+                  }}
+                  onKeyPress={() => removeUser(userName)}
+                  role="button"
+                  tabIndex={0}
+                >
+                  Remove user
+                </i>
+              )}
+            </span>
+          </div>
+          <div className="supplementary">
+            Last connected:{" "}
+            {lastConnected
+              ? formatFriendlyDateToNow(lastConnected)
+              : `Never connected`}
+            {!isOwner && (
+              <Formik initialValues={{}} onSubmit={() => {}}>
+                <Form>
+                  <Field
+                    as="select"
+                    name="access"
+                    onFocus={() => setInFocus(true)}
+                    onBlur={() => setInFocus(false)}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      accessSelectChange(e, userName);
+                      setInFocus(false);
+                    }}
+                    value={access}
+                  >
+                    <option value="read">Read</option>
+                    <option value="write">Write</option>
+                    <option value="admin">Admin</option>
+                  </Field>
+                </Form>
+              </Formik>
+            )}
+          </div>
+        </div>
+      </SlideDownFadeOut>
     </div>
   );
 }

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 import { Formik, Field, Form } from "formik";
 import { formatFriendlyDateToNow } from "app/utils/utils";
+
+import "./_share-card.scss";
 
 type Props = {
   userName: string;
@@ -21,9 +24,10 @@ export default function ShareCard({
   removeUser,
   accessSelectChange,
 }: Props) {
+  const [inFocus, setInFocus] = useState(false);
   return (
-    <div className="share-model__card" key={userName}>
-      <div className="share-model__card-title">
+    <div className="share__card" key={userName} data-active={inFocus}>
+      <div className="share__card-title">
         <strong>{userName}</strong>
         <span className="secondary">
           {isOwner ? (
@@ -52,9 +56,12 @@ export default function ShareCard({
               <Field
                 as="select"
                 name="access"
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  accessSelectChange(e, userName)
-                }
+                onFocus={() => setInFocus(true)}
+                onBlur={() => setInFocus(false)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  accessSelectChange(e, userName);
+                  setInFocus(false);
+                }}
                 value={access}
               >
                 <option value="read">Read</option>

--- a/src/components/ShareCard/_share-card.scss
+++ b/src/components/ShareCard/_share-card.scss
@@ -1,6 +1,6 @@
 @import "vanilla-framework/scss/vanilla";
 
-.share__card {
+.share-card {
   background-color: $color-light;
   border: solid 1px $color-mid-x-light;
   border-radius: 2px;
@@ -11,7 +11,7 @@
     margin-bottom: 0;
   }
 
-  .supplementary {
+  &__supplementary {
     color: $color-mid-dark;
     max-width: 80%;
 
@@ -21,14 +21,14 @@
     }
   }
 
-  &-title {
+  &__title {
     display: flex;
     margin-left: auto;
     width: 100%;
+  }
 
-    .secondary {
-      margin-left: auto;
-    }
+  &__secondary {
+    margin-left: auto;
   }
 
   .p-icon--delete {

--- a/src/components/ShareCard/_share-card.scss
+++ b/src/components/ShareCard/_share-card.scss
@@ -1,0 +1,43 @@
+@import "vanilla-framework/scss/vanilla";
+
+.share__card {
+  background-color: $color-light;
+  border: solid 1px $color-mid-x-light;
+  border-radius: 2px;
+  margin-bottom: 1rem;
+  padding: 1rem;
+
+  select {
+    margin-bottom: 0;
+  }
+
+  .supplementary {
+    color: $color-mid-dark;
+    max-width: 80%;
+
+    form {
+      margin-top: 1rem;
+      max-width: 50%;
+    }
+  }
+
+  &-title {
+    display: flex;
+    margin-left: auto;
+    width: 100%;
+
+    .secondary {
+      margin-left: auto;
+    }
+  }
+
+  .p-icon--delete {
+    cursor: pointer;
+  }
+
+  &[data-active="true"] {
+    background-color: rgba(0, 102, 204, 0.05);
+    border: 1px solid $color-link;
+    transition: background-color 0.5s;
+  }
+}

--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -12,7 +12,7 @@ import ShareModel from "./ShareModel";
 const mockStore = configureStore([]);
 
 describe("Share Model Panel", () => {
-  it("should show users with which a model is shared", () => {
+  it("should show panel", () => {
     const store = mockStore(dataDump);
     const wrapper = mount(
       <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
@@ -25,8 +25,7 @@ describe("Share Model Panel", () => {
         </Provider>
       </MemoryRouter>
     );
-    const firstUserCard = wrapper.find(".share-model__card").first();
-    const firstUserName = firstUserCard.find(".share-model__card-title strong");
-    expect(firstUserName.text()).toBe("eggman@external");
+    const panelHeader = wrapper.find(".aside-split-col h5");
+    expect(panelHeader.text()).toEqual("Sharing with:");
   });
 });

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -5,6 +5,7 @@ import { Formik, Field, Form } from "formik";
 import cloneDeep from "clone-deep";
 import useModelStatus from "hooks/useModelStatus";
 import { setModelSharingPermissions } from "juju";
+import { motion } from "framer-motion";
 
 import { getModelControllerDataByUUID } from "app/selectors";
 
@@ -170,7 +171,7 @@ export default function ShareModel() {
 
   return (
     <Aside loading={!modelStatusData} isSplit={true}>
-      <div className="p-panel share-model">
+      <motion.div layout className="p-panel share-model">
         <PanelHeader
           title={
             <div className="title-wrapper">
@@ -205,6 +206,7 @@ export default function ShareModel() {
               const lastConnected = userObj["last-connection"];
               return (
                 <ShareCard
+                  key={userName}
                   userName={userName}
                   lastConnected={lastConnected}
                   access={usersAccess?.[userName]}
@@ -312,7 +314,7 @@ export default function ShareModel() {
             </Formik>
           </div>
         </div>
-      </div>
+      </motion.div>
     </Aside>
   );
 }

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -4,13 +4,13 @@ import { useParams } from "react-router-dom";
 import { Formik, Field, Form } from "formik";
 import cloneDeep from "clone-deep";
 import useModelStatus from "hooks/useModelStatus";
-import { formatFriendlyDateToNow } from "app/utils/utils";
 import { setModelSharingPermissions } from "juju";
 
 import { getModelControllerDataByUUID } from "app/selectors";
 
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
+import ShareCard from "components/ShareCard/ShareCard";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 import type { TSFixMe } from "types";
@@ -203,52 +203,15 @@ export default function ShareModel() {
             {users?.map((userObj: User) => {
               const userName = userObj["user"];
               const lastConnected = userObj["last-connection"];
-
               return (
-                <div className="share-model__card" key={userObj.user}>
-                  <div className="share-model__card-title">
-                    <strong>{userName}</strong>
-                    <span className="secondary">
-                      {isOwner(userName) ? (
-                        "Owner"
-                      ) : (
-                        <i
-                          className="p-icon--delete"
-                          onClick={() => handleRemoveUser(userName)}
-                          onKeyPress={() => handleRemoveUser(userName)}
-                          role="button"
-                          tabIndex={0}
-                        >
-                          Remove user
-                        </i>
-                      )}
-                    </span>
-                  </div>
-                  <div className="supplementary">
-                    Last connected:{" "}
-                    {lastConnected
-                      ? formatFriendlyDateToNow(lastConnected)
-                      : `Never connected`}
-                    {!isOwner(userName) && (
-                      <Formik initialValues={{}} onSubmit={() => {}}>
-                        <Form>
-                          <Field
-                            as="select"
-                            name="access"
-                            onChange={(
-                              e: React.ChangeEvent<HTMLInputElement>
-                            ) => handleAccessSelectChange(e, userName)}
-                            value={usersAccess?.[userName]}
-                          >
-                            <option value="read">Read</option>
-                            <option value="write">Write</option>
-                            <option value="admin">Admin</option>
-                          </Field>
-                        </Form>
-                      </Formik>
-                    )}
-                  </div>
-                </div>
+                <ShareCard
+                  userName={userName}
+                  lastConnected={lastConnected}
+                  access={usersAccess?.[userName]}
+                  isOwner={isOwner(userName)}
+                  removeUser={handleRemoveUser}
+                  accessSelectChange={handleAccessSelectChange}
+                />
               );
             })}
           </div>

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -53,6 +53,10 @@
     .p-icon--delete {
       cursor: pointer;
     }
+
+    &.is-focussed {
+      border: 1px solid hotpink;
+    }
   }
 
   .p-radio {

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -19,46 +19,6 @@
     margin: 0 1rem;
   }
 
-  &__card {
-    background-color: $color-light;
-    border: solid 1px $color-mid-x-light;
-    border-radius: 2px;
-    margin-bottom: 1rem;
-    padding: 1rem;
-
-    select {
-      margin-bottom: 0;
-    }
-
-    .supplementary {
-      color: $color-mid-dark;
-      max-width: 80%;
-
-      form {
-        margin-top: 1rem;
-        max-width: 50%;
-      }
-    }
-
-    &-title {
-      display: flex;
-      margin-left: auto;
-      width: 100%;
-
-      .secondary {
-        margin-left: auto;
-      }
-    }
-
-    .p-icon--delete {
-      cursor: pointer;
-    }
-
-    &.is-focussed {
-      border: 1px solid hotpink;
-    }
-  }
-
   .p-radio {
     margin-bottom: 1rem;
 


### PR DESCRIPTION
## Done

Add focus state and simple animations to sharing cards

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Add and remove sharing access to users of a model
- Click the select box to change their access to see focus states

## Details

Related: https://github.com/canonical-web-and-design/juju-squad/issues/1746
