### PR TITLE
Update webCLI documentation link.

### DIFF
--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -115,7 +115,7 @@ const WebCLI = ({
         content={output}
         showHelp={shouldShowHelp}
         setShouldShowHelp={setShouldShowHelp}
-        helpMessage={`Welcome to the Juju Web CLI - see the <a href="https://juju.is/docs/webcli" class="p-link--inverted" target="_blank">full documentation here</a>.`}
+        helpMessage={`Welcome to the Juju Web CLI - see the <a href="https://juju.is/docs/olm/using-the-juju-web-cli" class="p-link--inverted" target="_blank">full documentation here</a>.`}
       />
       <div className="webcli__input">
         <div className="webcli__input-prompt">$ juju</div>

--- a/src/components/WebCLI/WebCLI.test.js
+++ b/src/components/WebCLI/WebCLI.test.js
@@ -69,7 +69,7 @@ describe("WebCLI", () => {
           .find(".webcli__output-content code")
           .prop("dangerouslySetInnerHTML")["__html"]
       ).toBe(
-        `Welcome to the Juju Web CLI - see the <a href="https://juju.is/docs/webcli" class="p-link--inverted" target="_blank">full documentation here</a>.`
+        `Welcome to the Juju Web CLI - see the <a href="https://juju.is/docs/olm/using-the-juju-web-cli" class="p-link--inverted" target="_blank">full documentation here</a>.`
       );
     });
   });

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.js.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.js.snap
@@ -34,7 +34,7 @@ exports[`WebCLI renders correctly 1`] = `
   >
     <WebCLIOutput
       content=""
-      helpMessage="Welcome to the Juju Web CLI - see the <a href=\\"https://juju.is/docs/webcli\\" class=\\"p-link--inverted\\" target=\\"_blank\\">full documentation here</a>."
+      helpMessage="Welcome to the Juju Web CLI - see the <a href=\\"https://juju.is/docs/olm/using-the-juju-web-cli\\" class=\\"p-link--inverted\\" target=\\"_blank\\">full documentation here</a>."
       setShouldShowHelp={[Function]}
       showHelp={false}
     >


### PR DESCRIPTION
## Done

The URL paths changed in the Juju documentation so this updates the link to the new path.

## QA

#### Juju
- Bootstrap a new controller using Juju 2.9+ `juju bootstrap aws`
- Run `juju dashboard` and then view, in Firefox, the displayed link (accepting the ssl cert warning) 
- Follow these [instructions](https://github.com/canonical-web-and-design/jaas-dashboard#developing-while-connected-to-a-juju-controller) to configure the dashboard
- Check that the webCLI description link works as expected.

## Details

Fixes #1028 
