### PR TITLE
Revert removal of mobile navigation bar

### DIFF
--- a/src/layout/BaseLayout/BaseLayout.test.tsx
+++ b/src/layout/BaseLayout/BaseLayout.test.tsx
@@ -94,4 +94,22 @@ describe("Base Layout", () => {
       wrapper.find("header").prop("data-sidenav-initially-collapsed")
     ).toBe(false);
   });
+
+  it("should include mobile navigation bar", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/models/"]}>
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models">
+              <BaseLayout>
+                <p>foo</p>
+              </BaseLayout>
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".l-navigation-bar").exists()).toBe(true);
+  });
 });

--- a/src/layout/BaseLayout/BaseLayout.tsx
+++ b/src/layout/BaseLayout/BaseLayout.tsx
@@ -1,8 +1,9 @@
 import { TSFixMe } from "types";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 
+import Logo from "components/Logo/Logo";
 import Banner from "components/Banner/Banner";
 import PrimaryNav from "components/PrimaryNav/PrimaryNav";
 
@@ -22,6 +23,7 @@ type Props = {
 };
 
 const BaseLayout = ({ children }: Props) => {
+  const [mobileMenuCollapsed, setMobileMenuCollapsed] = useState(true);
   const location = useLocation();
   const dispatch = useDispatch();
 
@@ -63,8 +65,20 @@ const BaseLayout = ({ children }: Props) => {
       <div id="confirmation-modal-container"></div>
 
       <div className="l-application">
+        <div className="l-navigation-bar">
+          <Logo />
+          <button
+            className="is-dense toggle-menu"
+            onClick={() => {
+              setMobileMenuCollapsed(!mobileMenuCollapsed);
+            }}
+          >
+            {mobileMenuCollapsed ? "Open menu" : "Close menu"}
+          </button>
+        </div>
         <header
           className="l-navigation"
+          data-collapsed={mobileMenuCollapsed}
           data-sidenav-initially-collapsed={collapseSidebar}
         >
           <div className="l-navigation__drawer">


### PR DESCRIPTION
## Done

Revert removal of mobile menu toggle and rename it to improve clarity of its purpose.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Ensure side nav collapses on small screens

## Details

Fixes #1041 
