### PR TITLE
Update to Node v16.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal
 WORKDIR /srv
 RUN apt update && \
     apt install curl --yes && \
-    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt update && \
     apt install nodejs --yes
 RUN npm install -g yarn


### PR DESCRIPTION
## Done

It appears that Vanilla now required Node v16 to build successfully. This updates the docker image from 14 to 16 in hopes of resolving the build issue in the Vanilla upgrade.

## QA

- The app should continue to build and work as expected.
