### PR TITLE
Add undo action to remove share user toasts

### DIFF
--- a/src/components/ToastCard/ToastCard.test.tsx
+++ b/src/components/ToastCard/ToastCard.test.tsx
@@ -76,4 +76,33 @@ describe("Toast Card", () => {
     );
     expect(wrapper.find(".p-icon--close").exists()).toBe(true);
   });
+
+  it("should not display an undo button if an undo function is not passed", () => {
+    const t = cloneDeep(toastInstanceExample);
+    const wrapper = mount(
+      <ToastCard
+        type="negative"
+        text="I am a toast message"
+        toastInstance={t}
+      />
+    );
+    expect(wrapper.find(".toast-card__undo").exists()).toBe(false);
+  });
+
+  it("should display a clickable undo button if an undo function is passed", () => {
+    const undoFn = jest.fn();
+    const t = cloneDeep(toastInstanceExample);
+    const wrapper = mount(
+      <ToastCard
+        type="negative"
+        text="I am a toast message"
+        toastInstance={t}
+        undo={undoFn}
+      />
+    );
+    const undoButton = wrapper.find(".toast-card__undo button");
+    expect(undoButton.exists()).toBe(true);
+    undoButton.simulate("click");
+    expect(undoFn).toBeCalled();
+  });
 });

--- a/src/components/ToastCard/ToastCard.tsx
+++ b/src/components/ToastCard/ToastCard.tsx
@@ -16,9 +16,10 @@ type Props = {
   toastInstance: ToastInstance;
   type: "positive" | "caution" | "negative";
   text: string;
+  undo?: () => void;
 };
 
-export default function ToastCard({ toastInstance, type, text }: Props) {
+export default function ToastCard({ toastInstance, type, text, undo }: Props) {
   let iconName;
   switch (type) {
     case "positive":
@@ -45,20 +46,35 @@ export default function ToastCard({ toastInstance, type, text }: Props) {
       role="status"
       aria-live="polite"
     >
-      {iconName && <i className={`p-icon--${iconName}`}>Success</i>}
-      <div
-        className="toast-card__message"
-        dangerouslySetInnerHTML={{ __html: text }}
-      ></div>
-      <i
-        className="p-icon--close"
-        onClick={() => handleClose(toastInstance.id)}
-        onKeyPress={() => handleClose(toastInstance.id)}
-        role="button"
-        tabIndex={0}
-      >
-        Close
-      </i>
+      <div className="toast-card__body">
+        {iconName && <i className={`p-icon--${iconName}`}>Success</i>}
+        <div
+          className="toast-card__message"
+          dangerouslySetInnerHTML={{ __html: text }}
+        ></div>
+        <i
+          className="p-icon--close"
+          onClick={() => handleClose(toastInstance.id)}
+          onKeyPress={() => handleClose(toastInstance.id)}
+          role="button"
+          tabIndex={0}
+        >
+          Close
+        </i>
+      </div>
+      {undo && (
+        <footer className="toast-card__undo">
+          <button
+            onClick={() => {
+              undo();
+              handleClose(toastInstance.id);
+            }}
+            className="p-button--base"
+          >
+            Undo
+          </button>
+        </footer>
+      )}
     </div>
   );
 }

--- a/src/components/ToastCard/_toast-card.scss
+++ b/src/components/ToastCard/_toast-card.scss
@@ -6,10 +6,19 @@
   border-radius: 5px;
   box-shadow: $box-shadow;
   color: $color-dark;
-  display: grid;
-  gap: 0.5rem;
-  grid-template-columns: 1rem 1fr 1rem;
+  max-width: 350px;
   padding: 1rem 0.75rem;
+  width: 100%;
+
+  &__body {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: 1rem 1fr 1rem;
+  }
+
+  &__message {
+    margin-bottom: 2rem;
+  }
 
   i {
     display: inline-block;
@@ -31,5 +40,17 @@
 
   &[data-type="negative"] {
     border-left: 3px solid $color-negative;
+  }
+
+  &__undo {
+    display: flex;
+    width: 100%;
+
+    [class~="p-button"] {
+      color: $color-link;
+      margin-bottom: 0;
+      margin-left: auto;
+      width: auto;
+    }
   }
 }

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -474,12 +474,12 @@ export async function setModelSharingPermissions(
   modelUUID,
   getState,
   user,
+  updatedAccess,
   previousAccess,
   action,
   dispatch
 ) {
   const conn = await getControllerConnection(controllerURL, getState());
-  const updatedAccess = user?.access;
 
   const modifyAccess = async (access, action) => {
     return await conn.facades.modelManager.modifyModelAccess({
@@ -488,7 +488,7 @@ export async function setModelSharingPermissions(
           access,
           action,
           "model-tag": `model-${modelUUID}`,
-          "user-tag": `user-${user.name}`,
+          "user-tag": `user-${user}`,
         },
       ],
     });

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -464,7 +464,8 @@ export async function queryOperationsList(queryArgs, modelUUID, appState) {
   @param {String} modelUUID
   @param {Function} getState Function to get current store state
   @param {Object} user The user obj with name and access info
-  @param {String | undefined} previousAccess The level of access a user previously had (read|write|admin)
+  @param {String | undefined} permissionTo
+  @param {String | undefined} permissionFrom The level of access a user previously had (read|write|admin)
   @param {String} action grant|revoke
   @param {Function} dispatch Redux dispatch method
   @returns {Promise} The application set config response
@@ -474,8 +475,8 @@ export async function setModelSharingPermissions(
   modelUUID,
   getState,
   user,
-  updatedAccess,
-  previousAccess,
+  permissionTo,
+  permissionFrom,
   action,
   dispatch
 ) {
@@ -494,12 +495,12 @@ export async function setModelSharingPermissions(
     });
   };
 
-  if (previousAccess) {
-    await modifyAccess(previousAccess, "revoke");
+  if (permissionFrom) {
+    await modifyAccess(permissionFrom, "revoke");
   }
 
   if (action === "grant") {
-    await modifyAccess(updatedAccess, "grant");
+    await modifyAccess(permissionTo, "grant");
   }
 
   const modelInfo = await fetchModelInfo(conn, modelUUID);


### PR DESCRIPTION
## Done

Add undo action to remove share user toasts

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Click through to a model
- Click the share link in the info panel
- Delete an existing user
- Verify their card disappears and confirmation toast appears with an 'Undo' link
- Click the 'Undo' link
- Their card should reinstate

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1743
