### PR TITLE
Update button text from 'Share model' to 'Model access'

### DIFF
--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -254,6 +254,7 @@ const Model = () => {
         <div className="entity-details__actions">
           <button
             className="entity-details__action-button"
+            data-test="model-access-btn"
             onClick={() => setPanelQs("share-model")}
           >
             <i className="p-icon--share"></i>Model access

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -256,7 +256,7 @@ const Model = () => {
             className="entity-details__action-button"
             onClick={() => setPanelQs("share-model")}
           >
-            <i className="p-icon--share"></i>Share model
+            <i className="p-icon--share"></i>Model access
           </button>
         </div>
         {modelStatusData && <EntityInfo data={ModelEntityData} />}

--- a/src/pages/EntityDetails/Model/Model.test.js
+++ b/src/pages/EntityDetails/Model/Model.test.js
@@ -252,6 +252,24 @@ describe("Model", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Topology").length).toBe(1);
+    expect(wrapper.find("Topology").exists()).toBe(true);
+  });
+
+  it("should have a link for model access panel", () => {
+    const store = mockStore(dataDump);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={["/models/user-eggman@external/group-test"]}
+        >
+          <QueryParamProvider ReactRouterRoute={Route}>
+            <TestRoute path="/models/:userName/:modelName?">
+              <Model />
+            </TestRoute>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='model-access-btn']").exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Done

Update button text from 'Share model' to 'Model access'

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Go to a model
- Verify button text under info panel is updated

## Details

Fixes #1036
