### PR TITLE
Improve specificity of button to show sharing close panel

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -256,7 +256,7 @@ export default function ShareModel() {
             <div className="share-cards__heading">
               <h5>Sharing with:</h5>
               <button
-                className="p-button--base has-icon"
+                className="add-user-btn p-button--base has-icon"
                 onClick={() => setShowAddNewUser(true)}
               >
                 <i className="p-icon--plus"></i>

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  .p-button--base {
+  .add-user-btn {
     display: flex;
     margin-bottom: 0;
     padding-left: 0.5rem;


### PR DESCRIPTION
## Done

Improve specificity of button to show sharing close panel

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- See sharing panel close button is working again

## Details

Fixes https://app.zenhub.com/workspaces/-app-squad-60910956c649200013c0a571/issues/canonical-web-and-design/juju-squad/1777
