### PR TITLE
Fix alignment button on mobile share button

### DIFF
--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -4,6 +4,10 @@
   .title-wrapper {
     display: flex;
 
+    .p-button--base.has-icon {
+      display: flex;
+    }
+
     .p-icon--chevron-up {
       display: block;
       padding-right: 1rem;


### PR DESCRIPTION
## Done

Before: 

<img width="521" alt="Screenshot 2021-06-22 at 15 40 05" src="https://user-images.githubusercontent.com/505570/122945180-4c9baa00-d370-11eb-956f-c5903029cfe2.png">

After:

<img width="521" alt="Screenshot 2021-06-22 at 15 40 36" src="https://user-images.githubusercontent.com/505570/122945219-53c2b800-d370-11eb-96a2-fb5e01c818b7.png">


## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Verify button fixed on mobile as above
