### PR TITLE
Restrict model index visibility to Access button on row hover

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -411,3 +411,15 @@ export const formatFriendlyDateToNow = (date) => {
   });
   return formattedDate.concat(" ago");
 };
+
+export const canAdministerModelAccess = (userName, modelStatusData) => {
+  let hasPermission = false;
+  const modelUsers = modelStatusData?.info?.users;
+  const sharingAccess = ["admin", "write", "owner"];
+  modelUsers.forEach((userObj) => {
+    if (userObj.user === userName && sharingAccess.includes(userObj.access)) {
+      hasPermission = true;
+    }
+  });
+  return hasPermission;
+};

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -416,10 +416,11 @@ export const canAdministerModelAccess = (userName, modelStatusData) => {
   let hasPermission = false;
   const modelUsers = modelStatusData?.info?.users;
   const sharingAccess = ["admin", "write", "owner"];
-  modelUsers.forEach((userObj) => {
-    if (userObj.user === userName && sharingAccess.includes(userObj.access)) {
-      hasPermission = true;
-    }
-  });
+  modelUsers &&
+    modelUsers.forEach((userObj) => {
+      if (userObj.user === userName && sharingAccess.includes(userObj.access)) {
+        hasPermission = true;
+      }
+    });
   return hasPermission;
 };

--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -412,9 +412,8 @@ export const formatFriendlyDateToNow = (date) => {
   return formattedDate.concat(" ago");
 };
 
-export const canAdministerModelAccess = (userName, modelStatusData) => {
+export const canAdministerModelAccess = (userName, modelUsers) => {
   let hasPermission = false;
-  const modelUsers = modelStatusData?.info?.users;
   const sharingAccess = ["admin", "write", "owner"];
   modelUsers &&
     modelUsers.forEach((userObj) => {

--- a/src/app/utils/utils.test.js
+++ b/src/app/utils/utils.test.js
@@ -1,4 +1,8 @@
-import { pluralize, formatFriendlyDateToNow } from "./utils";
+import {
+  pluralize,
+  formatFriendlyDateToNow,
+  canAdministerModelAccess,
+} from "./utils";
 
 describe("pluralize", () => {
   it("should correctly handle a single item", () => {
@@ -23,5 +27,37 @@ describe("formatFriendlyDateToNow", () => {
     const timeOneHourAgo = new Date(Date.now() - 3600000).toISOString();
     const friendlyDate = formatFriendlyDateToNow(timeOneHourAgo);
     expect(friendlyDate).toBe("about 1 hour ago");
+  });
+});
+
+describe("canAdministerModelAccess", () => {
+  it("should return true when user has admin access", () => {
+    const userName = "john-smith@external";
+    const modelData = {
+      info: {
+        users: [
+          {
+            user: "john-smith@external",
+            access: "admin",
+          },
+        ],
+      },
+    };
+    expect(canAdministerModelAccess(userName, modelData)).toBe(true);
+  });
+
+  it("should return false when user has read access", () => {
+    const userName = "joan-smith@external";
+    const modelData = {
+      info: {
+        users: [
+          {
+            user: "joan-smith@external",
+            access: "read",
+          },
+        ],
+      },
+    };
+    expect(canAdministerModelAccess(userName, modelData)).toBe(false);
   });
 });

--- a/src/app/utils/utils.test.js
+++ b/src/app/utils/utils.test.js
@@ -43,7 +43,7 @@ describe("canAdministerModelAccess", () => {
         ],
       },
     };
-    expect(canAdministerModelAccess(userName, modelData)).toBe(true);
+    expect(canAdministerModelAccess(userName, modelData.info.users)).toBe(true);
   });
 
   it("should return false when user has read access", () => {
@@ -58,6 +58,8 @@ describe("canAdministerModelAccess", () => {
         ],
       },
     };
-    expect(canAdministerModelAccess(userName, modelData)).toBe(false);
+    expect(canAdministerModelAccess(userName, modelData.info.users)).toBe(
+      false
+    );
   });
 });

--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -132,13 +132,13 @@ export default function CloudGroup({ filters }) {
               "data-test-column": "updated",
               content: (
                 <>
-                  {canAdministerModelAccess(activeUser, model) &&
+                  {canAdministerModelAccess(activeUser, model.info.users) &&
                     generateAccessButton(setPanelQs, model.info.name)}
                   <span className="model-access-alt">{lastUpdated}</span>
                 </>
               ),
               className: `u-align--right lrg-screen-access-cell ${
-                canAdministerModelAccess(activeUser, model)
+                canAdministerModelAccess(activeUser, model.info.users)
                   ? "has-permission"
                   : ""
               }`,
@@ -146,7 +146,7 @@ export default function CloudGroup({ filters }) {
             {
               content: (
                 <>
-                  {canAdministerModelAccess(activeUser, model) &&
+                  {canAdministerModelAccess(activeUser, model.info.users) &&
                     generateAccessButton(setPanelQs, model.info.name)}
                 </>
               ),

--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -1,12 +1,17 @@
 import { useSelector } from "react-redux";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import useActiveUser from "hooks/useActiveUser";
+
 import {
   generateStatusElement,
   getModelStatusGroupData,
   extractOwnerName,
+  canAdministerModelAccess,
 } from "app/utils/utils";
+
 import { getGroupedByCloudAndFilteredModelData } from "app/selectors";
+
 import {
   generateModelDetailsLink,
   getStatusValue,
@@ -59,6 +64,8 @@ function generateCloudTableHeaders(cloud, count) {
 }
 
 export default function CloudGroup({ filters }) {
+  const activeUser = useActiveUser();
+
   const groupedAndFilteredData = useSelector(
     getGroupedByCloudAndFilteredModelData(filters)
   );
@@ -125,14 +132,24 @@ export default function CloudGroup({ filters }) {
               "data-test-column": "updated",
               content: (
                 <>
-                  {generateAccessButton(setPanelQs, model.info.name)}
+                  {canAdministerModelAccess(activeUser, model) &&
+                    generateAccessButton(setPanelQs, model.info.name)}
                   <span className="model-access-alt">{lastUpdated}</span>
                 </>
               ),
-              className: "u-align--right lrg-screen-access-cell",
+              className: `u-align--right lrg-screen-access-cell ${
+                canAdministerModelAccess(activeUser, model)
+                  ? "has-permission"
+                  : ""
+              }`,
             },
             {
-              content: generateAccessButton(setPanelQs, model.info.name),
+              content: (
+                <>
+                  {canAdministerModelAccess(activeUser, model) &&
+                    generateAccessButton(setPanelQs, model.info.name)}
+                </>
+              ),
               className: "sm-screen-access-cell",
             },
           ],

--- a/src/components/ModelTableList/CloudGroup.test.js
+++ b/src/components/ModelTableList/CloudGroup.test.js
@@ -13,7 +13,11 @@ const mockStore = configureStore([]);
 describe("CloudGroup", () => {
   it("by default, renders no tables with no data", () => {
     const store = mockStore({
-      root: {},
+      root: {
+        config: {
+          baseControllerURL: "jimm.jujucharms.com",
+        },
+      },
       juju: {
         models: {},
         modelData: {},

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -1,11 +1,16 @@
 import { useSelector } from "react-redux";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import useActiveUser from "hooks/useActiveUser";
+
 import {
   generateStatusElement,
   getModelStatusGroupData,
+  canAdministerModelAccess,
 } from "app/utils/utils";
+
 import { getGroupedByOwnerAndFilteredModelData } from "app/selectors";
+
 import {
   generateModelDetailsLink,
   getStatusValue,
@@ -67,6 +72,8 @@ export default function OwnerGroup({ filters }) {
     model: StringParam,
     panel: withDefault(StringParam, "share-model"),
   })[1];
+  const activeUser = useActiveUser();
+
   let ownerTables = [];
   let ownerModels = {};
   for (const owner in ownerRows) {
@@ -119,14 +126,24 @@ export default function OwnerGroup({ filters }) {
               "data-test-column": "updated",
               content: (
                 <>
-                  {generateAccessButton(setPanelQs, model.info.name)}
+                  {canAdministerModelAccess(activeUser, model) &&
+                    generateAccessButton(setPanelQs, model.info.name)}
                   <span className="model-access-alt">{lastUpdated}</span>
                 </>
               ),
-              className: "u-align--right lrg-screen-access-cell",
+              className: `u-align--right lrg-screen-access-cell ${
+                canAdministerModelAccess(activeUser, model)
+                  ? "has-permission"
+                  : ""
+              }`,
             },
             {
-              content: generateAccessButton(setPanelQs, model.info.name),
+              content: (
+                <>
+                  {canAdministerModelAccess(activeUser, model) &&
+                    generateAccessButton(setPanelQs, model.info.name)}
+                </>
+              ),
               className: "sm-screen-access-cell",
             },
           ],

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -126,13 +126,13 @@ export default function OwnerGroup({ filters }) {
               "data-test-column": "updated",
               content: (
                 <>
-                  {canAdministerModelAccess(activeUser, model) &&
+                  {canAdministerModelAccess(activeUser, model.info.users) &&
                     generateAccessButton(setPanelQs, model.info.name)}
                   <span className="model-access-alt">{lastUpdated}</span>
                 </>
               ),
               className: `u-align--right lrg-screen-access-cell ${
-                canAdministerModelAccess(activeUser, model)
+                canAdministerModelAccess(activeUser, model.info.users)
                   ? "has-permission"
                   : ""
               }`,
@@ -140,7 +140,7 @@ export default function OwnerGroup({ filters }) {
             {
               content: (
                 <>
-                  {canAdministerModelAccess(activeUser, model) &&
+                  {canAdministerModelAccess(activeUser, model.info.users) &&
                     generateAccessButton(setPanelQs, model.info.name)}
                 </>
               ),

--- a/src/components/ModelTableList/OwnerGroup.test.js
+++ b/src/components/ModelTableList/OwnerGroup.test.js
@@ -13,7 +13,11 @@ const mockStore = configureStore([]);
 describe("OwnerGroup", () => {
   it("by default, renders no tables with no data", () => {
     const store = mockStore({
-      root: {},
+      root: {
+        config: {
+          baseControllerURL: "jimm.jujucharms.com",
+        },
+      },
       juju: {
         models: {},
         modelData: {},

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -152,13 +152,13 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
             "data-test-column": "updated",
             content: (
               <>
-                {canAdministerModelAccess(activeUser, model) &&
+                {canAdministerModelAccess(activeUser, model.info.users) &&
                   generateAccessButton(setPanelQs, model.model.name)}
                 <span className="model-access-alt">{lastUpdated}</span>
               </>
             ),
             className: `u-align--right lrg-screen-access-cell ${
-              canAdministerModelAccess(activeUser, model)
+              canAdministerModelAccess(activeUser, model.info.users)
                 ? "has-permission"
                 : ""
             }`,
@@ -166,7 +166,7 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
           {
             content: (
               <>
-                {canAdministerModelAccess(activeUser, model) &&
+                {canAdministerModelAccess(activeUser, model.info.users) &&
                   generateAccessButton(setPanelQs, model.model.name)}
               </>
             ),

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -1,11 +1,13 @@
 import { useSelector } from "react-redux";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import useActiveUser from "hooks/useActiveUser";
 
 import {
   generateStatusElement,
   getModelStatusGroupData,
   extractOwnerName,
+  canAdministerModelAccess,
 } from "app/utils/utils";
 
 import { getGroupedByStatusAndFilteredModelData } from "app/selectors";
@@ -94,7 +96,7 @@ const generateModelNameCell = (model, groupLabel) => {
   @param {Object} groupedModels The models grouped by state
   @returns {Object} The formatted table data.
 */
-function generateModelTableDataByStatus(groupedModels, setPanelQs) {
+function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
   const modelData = {
     blockedRows: [],
     alertRows: [],
@@ -103,6 +105,7 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs) {
 
   Object.keys(groupedModels).forEach((groupLabel) => {
     const models = groupedModels[groupLabel];
+
     models.forEach((model) => {
       let owner = "";
       if (model.info) {
@@ -149,14 +152,24 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs) {
             "data-test-column": "updated",
             content: (
               <>
-                {generateAccessButton(setPanelQs, model.model.name)}
+                {canAdministerModelAccess(activeUser, model) &&
+                  generateAccessButton(setPanelQs, model.model.name)}
                 <span className="model-access-alt">{lastUpdated}</span>
               </>
             ),
-            className: "u-align--right lrg-screen-access-cell",
+            className: `u-align--right lrg-screen-access-cell ${
+              canAdministerModelAccess(activeUser, model)
+                ? "has-permission"
+                : ""
+            }`,
           },
           {
-            content: generateAccessButton(setPanelQs, model.model.name),
+            content: (
+              <>
+                {canAdministerModelAccess(activeUser, model) &&
+                  generateAccessButton(setPanelQs, model.model.name)}
+              </>
+            ),
             className: "sm-screen-access-cell",
           },
         ],
@@ -183,9 +196,14 @@ export default function StatusGroup({ filters }) {
     model: StringParam,
     panel: withDefault(StringParam, "share-model"),
   })[1];
+  const activeUser = useActiveUser();
 
   const { blockedRows, alertRows, runningRows } =
-    generateModelTableDataByStatus(groupedAndFilteredData, setPanelQs);
+    generateModelTableDataByStatus(
+      groupedAndFilteredData,
+      setPanelQs,
+      activeUser
+    );
 
   const emptyStateMsg = "There are no models with this status";
 

--- a/src/components/ModelTableList/StatusGroup.test.js
+++ b/src/components/ModelTableList/StatusGroup.test.js
@@ -13,7 +13,11 @@ const mockStore = configureStore([]);
 describe("StatusGroup", () => {
   it("by default, renders no tables when there is no data", () => {
     const store = mockStore({
-      root: {},
+      root: {
+        config: {
+          baseControllerURL: "jimm.jujucharms.com",
+        },
+      },
       juju: {
         models: {},
         modelData: {},

--- a/src/components/ModelTableList/_model-table-list.scss
+++ b/src/components/ModelTableList/_model-table-list.scss
@@ -65,7 +65,7 @@
         width: 100%;
       }
 
-      .model-access-alt {
+      .has-permission .model-access-alt {
         display: none;
       }
     }

--- a/src/hooks/useActiveUser.tsx
+++ b/src/hooks/useActiveUser.tsx
@@ -4,7 +4,7 @@ import { getActiveUserTag, getWSControllerURL } from "app/selectors";
 export default function useActiveUser() {
   const store = useStore();
   const getState = store.getState;
-  return getActiveUserTag(useSelector(getWSControllerURL), getState()).replace(
+  return getActiveUserTag(useSelector(getWSControllerURL), getState())?.replace(
     "user-",
     ""
   );

--- a/src/hooks/useActiveUser.tsx
+++ b/src/hooks/useActiveUser.tsx
@@ -1,0 +1,11 @@
+import { useSelector, useStore } from "react-redux";
+import { getActiveUserTag, getWSControllerURL } from "app/selectors";
+
+export default function useActiveUser() {
+  const store = useStore();
+  const getState = store.getState;
+  return getActiveUserTag(useSelector(getWSControllerURL), getState()).replace(
+    "user-",
+    ""
+  );
+}

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -258,7 +258,7 @@ const Model = () => {
       <div>
         <InfoPanel />
         <div className="entity-details__actions">
-          {canAdministerModelAccess(activeUser, modelStatusData) && (
+          {canAdministerModelAccess(activeUser, modelStatusData.info.users) && (
             <button
               className="entity-details__action-button"
               data-test="model-access-btn"

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -1,7 +1,5 @@
 import { useMemo, useCallback } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
-import { useSelector, useStore } from "react-redux";
-import { getActiveUserTag, getWSControllerURL } from "app/selectors";
 import {
   useQueryParams,
   useQueryParam,
@@ -9,7 +7,11 @@ import {
   withDefault,
 } from "use-query-params";
 import { useHistory, useParams } from "react-router-dom";
-import { pluralize, extractCloudName } from "app/utils/utils";
+import {
+  pluralize,
+  extractCloudName,
+  canAdministerModelAccess,
+} from "app/utils/utils";
 
 import {
   appsOffersTableHeaders,
@@ -40,6 +42,7 @@ import ActionLogs from "pages/EntityDetails/Model/ActionLogs/ActionLogs";
 
 import useModelStatus from "hooks/useModelStatus";
 import useTableRowClick from "hooks/useTableRowClick";
+import useActiveUser from "hooks/useActiveUser";
 
 import ChipGroup from "components/ChipGroup/ChipGroup";
 
@@ -63,20 +66,9 @@ const shouldShow = (segment, activeView) => {
   }
 };
 
-const canAdministerAccess = (userName, modelStatusData) => {
-  let hasPermission = false;
-  const modelUsers = modelStatusData?.info?.users;
-  const sharingAccess = ["admin", "write", "owner"];
-  modelUsers.forEach((userObj) => {
-    if (userObj.user === userName && sharingAccess.includes(userObj.access)) {
-      hasPermission = true;
-    }
-  });
-  return hasPermission;
-};
-
 const Model = () => {
   const modelStatusData = useModelStatus();
+  const activeUser = useActiveUser();
   const history = useHistory();
   const { userName, modelName } = useParams();
 
@@ -261,20 +253,12 @@ const Model = () => {
 
   const setPanelQs = useQueryParam("panel", StringParam)[1];
 
-  // check user permission to administer model access
-  const store = useStore();
-  const getState = store.getState;
-  const activeUser = getActiveUserTag(
-    useSelector(getWSControllerURL),
-    getState()
-  ).replace("user-", "");
-
   return (
     <EntityDetails type="model">
       <div>
         <InfoPanel />
         <div className="entity-details__actions">
-          {canAdministerAccess(activeUser, modelStatusData) && (
+          {canAdministerModelAccess(activeUser, modelStatusData) && (
             <button
               className="entity-details__action-button"
               data-test="model-access-btn"


### PR DESCRIPTION
## Done

Restrict model index visibility to Access button on row hover

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Verify you can only open the access panel for those models you have the correct permissions for

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1779
