### PR TITLE
Return to share list when adding new user on mobile

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -292,9 +292,10 @@ export default function ShareModel() {
                 access: "read",
               }}
               validate={(values) => handleValidateNewUser(values)}
-              onSubmit={(values, { resetForm }) =>
-                handleNewUserFormSubmit(values, resetForm)
-              }
+              onSubmit={(values, { resetForm }) => {
+                handleNewUserFormSubmit(values, resetForm);
+                setShowAddNewUser(false);
+              }}
             >
               <Form>
                 <label className="is-required" htmlFor="username">

--- a/src/panels/ShareModelPanel/share-model.scss
+++ b/src/panels/ShareModelPanel/share-model.scss
@@ -6,6 +6,7 @@
 
     .p-button--base.has-icon {
       display: flex;
+      margin-bottom: 0;
     }
 
     .p-icon--chevron-up {


### PR DESCRIPTION
## Done

Return to share list when adding new user on mobile

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models on a small screen
- Click into a model you have sharing permissions on
- Click 'model access'
- Click 'add new user'
- Add a user
- Verify you are returned to the share list

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1776