### PR TITLE
Improve share error handling

### DIFF
--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -497,17 +497,23 @@ export async function setModelSharingPermissions(
 
   let response = Promise.resolve({ results: [{}] });
 
-  if (permissionFrom) {
-    response = await modifyAccess(permissionFrom, "revoke");
-  }
+  if (conn) {
+    if (permissionFrom) {
+      response = await modifyAccess(permissionFrom, "revoke");
+    }
 
-  if (action === "grant") {
-    response = await modifyAccess(permissionTo, "grant");
-  }
+    if (action === "grant") {
+      response = await modifyAccess(permissionTo, "grant");
+    }
 
-  const modelInfo = await fetchModelInfo(conn, modelUUID);
-  modelInfo &&
-    dispatch(updateModelInfo(modelInfo), { wsControllerURL: controllerURL });
+    const modelInfo = await fetchModelInfo(conn, modelUUID);
+    modelInfo &&
+      dispatch(updateModelInfo(modelInfo), { wsControllerURL: controllerURL });
+  } else {
+    response = Promise.resolve({
+      results: [{ error: true }],
+    });
+  }
 
   return response;
 }

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -113,8 +113,14 @@ export default function ShareModel() {
       action,
       dispatch
     );
-
-    return response;
+    if (response?.error) {
+      toast.custom((t) => (
+        <ToastCard toastInstance={t} type="negative" text={response.error} />
+      ));
+      return false;
+    } else {
+      return response;
+    }
   };
 
   const handleAccessSelectChange = async (


### PR DESCRIPTION
## Done

Improve share error handling

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/
- Register a dud controller
- Try to add/remove/amend users in model share menu
- Verify that error toast appears

