### PR TITLE
Ensure owner share card always appears first

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -220,6 +220,13 @@ export default function ShareModel() {
     }
   };
 
+  // Ensure user with 'owner' status is always the first card
+  const sortedUsers = cloneDeep(users || null);
+  sortedUsers?.some(
+    (item: User, i: Number) =>
+      isOwner(item.user) && sortedUsers.unshift(sortedUsers.splice(i, 1)[0])
+  );
+
   return (
     <Aside loading={!modelStatusData} isSplit={true}>
       <motion.div layout className="p-panel share-model">
@@ -261,7 +268,7 @@ export default function ShareModel() {
                 <span>Add new user</span>
               </button>
             </div>
-            {users?.map((userObj: User) => {
+            {sortedUsers?.map((userObj: User) => {
               const userName = userObj["user"];
               const lastConnected = userObj["last-connection"];
               return (


### PR DESCRIPTION
## Done

Ensure owner share card always appears first

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8036/models
- Open share panel
- Add a new user which becomes alphabetically before the owner username
- Ensure owner card stays at the top of the list

## Details

Fixes https://github.com/canonical-web-and-design/juju-squad/issues/1775
