### PR TITLE
Connect to the all model watcher when viewing a model details page 

### DIFF
--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -464,7 +464,6 @@ export async function startModelWatcher(modelUUID, appState) {
   const conn = await connectAndLoginToModel(modelUUID, appState);
   const watcherHandle = await conn.facades.client.watchAll();
   const callback = (data) => {
-    console.log(data);
     conn.facades.allWatcher._transport.write(
       {
         type: "AllWatcher",
@@ -476,6 +475,17 @@ export async function startModelWatcher(modelUUID, appState) {
     );
   };
   callback();
+  return { conn, watcherHandle };
+}
+
+export async function stopModelWatcher(conn, watcherHandleId) {
+  conn.facades.allWatcher._transport.write({
+    type: "AllWatcher",
+    request: "Stop",
+    version: 1,
+    id: watcherHandleId,
+  });
+  conn.transport.close();
 }
 
 /**

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -47,7 +47,7 @@ import useActiveUser from "hooks/useActiveUser";
 
 import ChipGroup from "components/ChipGroup/ChipGroup";
 
-import { startModelWatcher } from "juju/index";
+import { startModelWatcher, stopModelWatcher } from "juju/index";
 
 import { renderCounts } from "../counts";
 
@@ -85,10 +85,21 @@ const Model = () => {
   const uuid = modelStatusData?.info?.uuid;
 
   useEffect(() => {
-    if (uuid) {
-      console.log("starting watcher");
-      startModelWatcher(uuid, appState);
+    let watcherHandle = null;
+    let conn = null;
+    async function startWatcher() {
+      ({ conn, watcherHandle } = await startModelWatcher(uuid, appState));
     }
+    if (uuid) {
+      startWatcher();
+    }
+    return () => {
+      stopModelWatcher(conn, watcherHandle["watcher-id"]);
+    };
+    // Skipped as we need appState due to the call to `connectAndLoginToModel`
+    // this method will need to be updated to take specific values instead of
+    // the entire state.
+    // eslint-disable-next-line
   }, [uuid]);
 
   const tableRowClick = useTableRowClick();

--- a/src/pages/EntityDetails/Model/Model.js
+++ b/src/pages/EntityDetails/Model/Model.js
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect } from "react";
 import MainTable from "@canonical/react-components/dist/components/MainTable";
 import {
   useQueryParams,
@@ -12,6 +12,7 @@ import {
   extractCloudName,
   canAdministerModelAccess,
 } from "app/utils/utils";
+import { useStore } from "react-redux";
 
 import {
   appsOffersTableHeaders,
@@ -46,6 +47,8 @@ import useActiveUser from "hooks/useActiveUser";
 
 import ChipGroup from "components/ChipGroup/ChipGroup";
 
+import { startModelWatcher } from "juju/index";
+
 import { renderCounts } from "../counts";
 
 const shouldShow = (segment, activeView) => {
@@ -67,6 +70,7 @@ const shouldShow = (segment, activeView) => {
 };
 
 const Model = () => {
+  const appState = useStore().getState();
   const modelStatusData = useModelStatus();
   const activeUser = useActiveUser();
   const history = useHistory();
@@ -77,6 +81,15 @@ const Model = () => {
     entity: StringParam,
     activeView: withDefault(StringParam, "apps"),
   });
+
+  const uuid = modelStatusData?.info?.uuid;
+
+  useEffect(() => {
+    if (uuid) {
+      console.log("starting watcher");
+      startModelWatcher(uuid, appState);
+    }
+  }, [uuid]);
 
   const tableRowClick = useTableRowClick();
 


### PR DESCRIPTION
## Done

When viewing a model details page connect to the all model watcher.
When leaving the model details page, stop and disconnect from the all model watcher.

This is step 1 of many to convert this page from using the timer based poller to the watcher for displaying model data.

## QA

- View a model details page and then inspect the network tab, it should connect to the watcher and disconnect upon leaving.

## Details

Fixes: https://github.com/canonical-web-and-design/juju-squad/issues/1542