### PR TITLE
Generate the app status from an aggregate of the unit statuses

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -17,7 +17,7 @@ export function generateEntityIdentifier(charmId, name, subordinate) {
 }
 
 export const generateStatusElement = (
-  status,
+  status = "unknown",
   count,
   useIcon = true,
   actionsLogs = false

--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -16,7 +16,6 @@ const WebCLI = ({
   credentials,
   modelUUID,
   protocol = "wss",
-  refreshModel,
 }) => {
   const [connection, setConnection] = useState(null);
   const [shouldShowHelp, setShouldShowHelp] = useState(false);
@@ -98,11 +97,6 @@ const WebCLI = ({
       action: "WebCLI command sent",
     });
     inputRef.current.value = ""; // Clear the input after sending the message.
-    setTimeout(() => {
-      // Delay the refresh long enough so that the Juju controller has time to
-      // respond before we request the updated status.
-      refreshModel();
-    }, 500);
   };
 
   const showHelp = () => {

--- a/src/components/WebCLI/WebCLI.test.js
+++ b/src/components/WebCLI/WebCLI.test.js
@@ -2,7 +2,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import WS from "jest-websocket-mock";
+import { WS } from "jest-websocket-mock";
 import cloneDeep from "clone-deep";
 
 import { waitForComponentToPaint } from "testing/utils";
@@ -71,34 +71,6 @@ describe("WebCLI", () => {
       ).toBe(
         `Welcome to the Juju Web CLI - see the <a href="https://juju.is/docs/olm/using-the-juju-web-cli" class="p-link--inverted" target="_blank">full documentation here</a>.`
       );
-    });
-  });
-
-  it("calls to refresh the model on command submission", async () => {
-    const mockRefreshModel = jest.fn();
-    new WS("ws://localhost:1234/model/abc123/commands", {
-      jsonProtocol: true,
-    });
-    const wrapper = await generateComponent({
-      protocol: "ws",
-      controllerWSHost: "localhost:1234",
-      modelUUID: "abc123",
-      credentials: {
-        user: "spaceman",
-        password: "somelongpassword",
-      },
-      refreshModel: mockRefreshModel,
-    });
-    wrapper.find(".webcli__input-input").instance().value = "status --color";
-    wrapper.find("form").simulate("submit", { preventDefault: () => {} });
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        expect(mockRefreshModel).toHaveBeenCalled();
-        act(() => {
-          WS.clean();
-        });
-        resolve();
-      }, 600); // the timeout is 500ms in the app
     });
   });
 

--- a/src/juju/model-selectors.ts
+++ b/src/juju/model-selectors.ts
@@ -96,3 +96,73 @@ export function getModelMachines(modelUUID: string) {
     }
   );
 }
+
+// The order of this enum is important. It needs to be organized in order of
+// best to worst status.
+enum Statuses {
+  running,
+  alert,
+  blocked,
+}
+
+interface StatusData {
+  // keyof typeof returns the list of string keys in the Statuses enum
+  // not the numeric indexes generated at compile time.
+  [applicationName: string]: keyof typeof Statuses;
+}
+
+/**
+  Returns an object of key value pairs indicating an
+  applications aggregate unit status.
+*/
+export function getAllModelApplicationStatus(modelUUID: string) {
+  return createSelector(
+    getModelUnits(modelUUID),
+    (units): StatusData | null => {
+      if (!units) {
+        return null;
+      }
+
+      const applicationStatuses: StatusData = {};
+      // Convert the various unit statuses into our three current
+      // status types "blocked", "alert", "running".
+      Object.entries(units).forEach(([unitId, unitData]) => {
+        let workloadStatus = Statuses.running;
+        switch (unitData["workload-status"].current) {
+          case "maintenance":
+          case "waiting":
+            workloadStatus = Statuses.alert;
+            break;
+          case "blocked":
+            workloadStatus = Statuses.blocked;
+            break;
+        }
+
+        let agentStatus = Statuses.running;
+        switch (unitData["agent-status"].current) {
+          case "allocating":
+          case "executing":
+          case "rebooting":
+            agentStatus = Statuses.alert;
+            break;
+          case "failed":
+          case "lost":
+            agentStatus = Statuses.blocked;
+            break;
+        }
+        // Use the enum index to determine the worst status value.
+        const worstStatusIndex = Math.max(
+          workloadStatus,
+          agentStatus,
+          Statuses.running
+        );
+
+        applicationStatuses[unitData.application] = Statuses[
+          worstStatusIndex
+        ] as keyof typeof Statuses;
+      });
+
+      return applicationStatuses;
+    }
+  );
+}

--- a/src/juju/reducer.js
+++ b/src/juju/reducer.js
@@ -86,6 +86,9 @@ export default function jujuReducer(state = defaultState, action) {
         break;
       case actionsList.populateMissingAllWatcherData:
         if (!draftState.modelWatcherData?.[payload.uuid]?.model) {
+          if (!draftState.modelWatcherData?.[payload.uuid]) {
+            draftState.modelWatcherData[payload.uuid] = {};
+          }
           draftState.modelWatcherData[payload.uuid].model = {};
         }
         mergeWith(draftState.modelWatcherData[payload.uuid].model, {

--- a/src/pages/EntityDetails/EntityDetails.js
+++ b/src/pages/EntityDetails/EntityDetails.js
@@ -29,7 +29,6 @@ import useWindowTitle from "hooks/useWindowTitle";
 
 import FadeIn from "animations/FadeIn";
 
-import { fetchAndStoreModelStatus } from "juju";
 import { fetchModelStatus } from "juju/actions";
 
 import "./_entity-details.scss";
@@ -93,18 +92,6 @@ const EntityDetails = ({ type, children, className = "" }) => {
   }
 
   const showWebCLIConfig = useSelector(getConfig).showWebCLI;
-
-  // Until we switch to the new lib and watcher model we want to trigger a
-  // refresh of the model data when a user submits a cli command so that it
-  // doesn't look like it did nothing.
-  const refreshModel = () => {
-    fetchAndStoreModelStatus(
-      modelUUID,
-      primaryControllerData[0],
-      dispatch,
-      store.getState
-    );
-  };
 
   const handleNavClick = (e, section) => {
     e.preventDefault();
@@ -249,7 +236,6 @@ const EntityDetails = ({ type, children, className = "" }) => {
           controllerWSHost={controllerWSHost}
           credentials={credentials}
           modelUUID={modelUUID}
-          refreshModel={refreshModel}
         />
       )}
     </BaseLayout>

--- a/src/pages/EntityDetails/Machine/Machine.tsx
+++ b/src/pages/EntityDetails/Machine/Machine.tsx
@@ -7,6 +7,7 @@ import useTableRowClick from "hooks/useTableRowClick";
 
 import {
   getModelApplications,
+  getAllModelApplicationStatus,
   getModelMachines,
   getModelUnits,
   getModelUUID,
@@ -39,6 +40,10 @@ export default function Machine() {
   const machines = useSelector(getModelMachines(modelUUID));
   const machine = machines?.[machineId];
 
+  const applicationStatuses = useSelector(
+    getAllModelApplicationStatus(modelUUID)
+  );
+
   const filteredApplicationList = useMemo(() => {
     if (!applications || !units) {
       return null;
@@ -70,8 +75,13 @@ export default function Machine() {
   }, [units, machineId]);
 
   const applicationRows = useMemo(
-    () => generateLocalApplicationRows(filteredApplicationList, tableRowClick),
-    [filteredApplicationList, tableRowClick]
+    () =>
+      generateLocalApplicationRows(
+        filteredApplicationList,
+        applicationStatuses,
+        tableRowClick
+      ),
+    [filteredApplicationList, applicationStatuses, tableRowClick]
   );
 
   const unitRows = useMemo(

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -48,6 +48,7 @@ import useActiveUser from "hooks/useActiveUser";
 import ChipGroup from "components/ChipGroup/ChipGroup";
 
 import {
+  getAllModelApplicationStatus,
   getModelApplications,
   getModelInfo,
   getModelMachines,
@@ -120,9 +121,18 @@ const Model = () => {
   const machines = useSelector(getModelMachines(modelUUID));
   const units = useSelector(getModelUnits(modelUUID));
 
+  const applicationStatuses = useSelector(
+    getAllModelApplicationStatus(modelUUID)
+  );
+
   const localApplicationTableRows = useMemo(() => {
-    return generateLocalApplicationRows(applications, tableRowClick, query);
-  }, [applications, tableRowClick, query]);
+    return generateLocalApplicationRows(
+      applications,
+      applicationStatuses,
+      tableRowClick,
+      query
+    );
+  }, [applications, applicationStatuses, tableRowClick, query]);
 
   const remoteApplicationTableRows = useMemo(() => {
     return generateRemoteApplicationRows(modelStatusData, panelRowClick, query);

--- a/src/pages/EntityDetails/Unit/Unit.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.tsx
@@ -23,6 +23,7 @@ import EntityInfo from "components/EntityInfo/EntityInfo";
 
 import {
   getModelApplications,
+  getAllModelApplicationStatus,
   getModelInfo,
   getModelMachines,
   getModelUnits,
@@ -63,14 +64,23 @@ export default function Unit() {
     return filteredApps;
   }, [applications, units, unitIdentifier]);
 
+  const applicationStatuses = useSelector(
+    getAllModelApplicationStatus(modelUUID)
+  );
+
   const machineRows = useMemo(
     () => generateMachineRows(filteredMachineList, units, tableRowClick),
     [filteredMachineList, units, tableRowClick]
   );
 
   const applicationRows = useMemo(
-    () => generateLocalApplicationRows(filteredApplicationList, tableRowClick),
-    [filteredApplicationList, tableRowClick]
+    () =>
+      generateLocalApplicationRows(
+        filteredApplicationList,
+        applicationStatuses,
+        tableRowClick
+      ),
+    [filteredApplicationList, applicationStatuses, tableRowClick]
   );
 
   const unit = units?.[unitIdentifier];

--- a/src/tables/tableRows.js
+++ b/src/tables/tableRows.js
@@ -12,6 +12,7 @@ import {
 
 export function generateLocalApplicationRows(
   applications,
+  applicationStatuses,
   tableRowClick,
   query
 ) {
@@ -41,7 +42,9 @@ export function generateLocalApplicationRows(
         },
         {
           "data-test-column": "status",
-          content: app.status ? generateStatusElement(app.status.current) : "-",
+          content: app.status
+            ? generateStatusElement(applicationStatuses[app.name])
+            : "-",
           className: "u-capitalise u-truncate",
         },
         {


### PR DESCRIPTION
## Done

- The all watcher doesn't contain an app status so we have to generate an aggregate app status from parsing the units.
- Remove the `refreshModel` call as a driveby from the webCLI as it's no longer needed now that the model details page uses the watcher data.

## QA

- Contact me for access to a model to QA this with.
- It should show the application status on the Application list, Machine details page, Unit details page.

## Screenshot

![Screen Shot 2021-09-01 at 11 36 08 AM](https://user-images.githubusercontent.com/532033/131717690-b49f33b9-d90a-4dbe-9830-6ba293d842db.png)
