### PR TITLE
Add support for relative controller api endpoint paths.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,17 @@ checkConfigExists();
 
 function bootstrap() {
   const config = window.jujuDashboardConfig;
+  // It's possible that the charm is generating a relative path for the
+  // websocket because it is providing the API on the same host as the
+  // application assets.
+  // If we were provided with a relative path for the endpoint then we need
+  // to build the full correct path for the websocket to connect to.
+  const controllerAPIEndpoint = config.controllerAPIEndpoint;
+  if (controllerAPIEndpoint.indexOf("://") === -1) {
+    const protocol =
+      window.location.protocol.indexOf("https") === -1 ? "ws" : "wss";
+    config.controllerAPIEndpoint = `${protocol}://${window.location.host}${controllerAPIEndpoint}`;
+  }
 
   if (process.env.NODE_ENV === "production") {
     Sentry.setTag("isJuju", config.isJuju);

--- a/src/index.js
+++ b/src/index.js
@@ -61,9 +61,8 @@ function bootstrap() {
   // If we were provided with a relative path for the endpoint then we need
   // to build the full correct path for the websocket to connect to.
   const controllerAPIEndpoint = config.controllerAPIEndpoint;
-  if (controllerAPIEndpoint.indexOf("://") === -1) {
-    const protocol =
-      window.location.protocol.indexOf("https") === -1 ? "ws" : "wss";
+  if (controllerAPIEndpoint.includes("://")) {
+    const protocol = window.location.protocol.includes("https") ? "ws" : "wss";
     config.controllerAPIEndpoint = `${protocol}://${window.location.host}${controllerAPIEndpoint}`;
   }
 


### PR DESCRIPTION
## Done

Added support for relative controller API endpoint paths. This is necessary because the charm can provide a relative path when it's proxying the connections to the same host. This allows the dashboard to connect to the correct endpoint even when we don't know the ultimate endpoint of the proxy.

## QA

- The app should continue to work as expected.

