### PR TITLE
gracefully fail if the web cli is not passed the necessary data to construct the websocket address.

### DIFF
--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -39,6 +39,10 @@ const WebCLI = ({
   }, [controllerWSHost, modelUUID, protocol]);
 
   useEffect(() => {
+    if (!wsAddress) {
+      console.error("no websocket address provided");
+      return;
+    }
     const conn = new Connection({
       address: wsAddress,
       onopen: () => {},
@@ -102,6 +106,11 @@ const WebCLI = ({
   const showHelp = () => {
     setShouldShowHelp(true);
   };
+
+  // If we do not have an address then do not try and render the UI.
+  if (!wsAddress) {
+    return null;
+  }
 
   return (
     <div className="webcli">


### PR DESCRIPTION
## Done

If the WebCLI component isn't passed the necessary data to contruct the websocket address then do not try and render the WebCLI. This is a bandaid for the root cause, which can be seen in #1170.

## QA

- Contact me to get access to a known broken model.
- View the demo link and view the model details, the app shouldn't 💥 .