### PR TITLE
Update the docker image to the node LTS from circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,15 +41,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - run:
           name: Run linter
           command: yarn run eslint-check
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
   check-stylelint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,30 +11,20 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - run:
           name: Run tests
           command: yarn test
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
   check-prettier:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - run:
           name: Run tests
           command: yarn prettier --check 'src/**/*'
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
   check-eslint:
@@ -51,30 +41,20 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - run:
           name: Run linter
           command: yarn run stylelint-check
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
   check-types:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
       - run: yarn
       - run:
           name: Run Typescript build
           command: yarn run typescript-build
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 defaults: &defaults
   docker:
-    - image: canonicalwebteam/dev:1.6.8
+    - image: cimg/node:lts
   environment:
   working_directory: ~/project
 


### PR DESCRIPTION
## Done

The dev image that we've been using is pretty out of date, we're going to move towards using the circle ci images when appropriate across the projects so this one updates to the LTS version of node.

## QA

- CI should pass
