### PR TITLE
Parse and load the cs: icons from charmhub

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -249,8 +249,32 @@ export const generateIconPath = (charmId) => {
     return defaultCharmIcon;
   }
   if (charmId.indexOf("cs:") === 0) {
+    // Strip unnessesary prefixes
+    // before: cs:~containers/lxd-container-47
+    // after:  containers/lxd-container-47
+    charmId = charmId.replace("cs:~", "");
     charmId = charmId.replace("cs:", "");
-    return `https://api.jujucharms.com/charmstore/v5/${charmId}/icon.svg`;
+
+    // Remove release from the charmId
+    // before: containers/trusty/lxd-container-47
+    // after:  containers/lxd-container-47
+    charmId = charmId.replace("precise/", "");
+    charmId = charmId.replace("trusty/", "");
+    charmId = charmId.replace("xenial/", "");
+    charmId = charmId.replace("bionic/", "");
+    charmId = charmId.replace("focal/", "");
+
+    // Combine owner and charm name
+    // before: containers/lxd-container-47
+    // after:  containers-lxd-container-47
+    charmId = charmId.replace("/", "-");
+
+    // Strip the revision number from the end
+    // before: containers-lxd-container-47
+    // after:  containers-lxd-container
+    charmId = charmId.substr(0, charmId.lastIndexOf("-", charmId.length));
+
+    return `https://charmhub.io/${charmId}/icon`;
   }
   if (charmId.indexOf("ch:") === 0) {
     // Regex explanation:

--- a/src/app/utils/utils.test.js
+++ b/src/app/utils/utils.test.js
@@ -2,6 +2,7 @@ import {
   pluralize,
   formatFriendlyDateToNow,
   canAdministerModelAccess,
+  generateIconPath,
 } from "./utils";
 
 describe("pluralize", () => {
@@ -61,5 +62,45 @@ describe("canAdministerModelAccess", () => {
     expect(canAdministerModelAccess(userName, modelData.info.users)).toBe(
       false
     );
+  });
+});
+
+describe("generateIconPath", () => {
+  it("should return a icon URI for a promulated charm", () => {
+    const charmId = "cs:mysql-12";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe("https://charmhub.io/mysql/icon");
+  });
+
+  it("should return a icon URI for a promulated charm with dash", () => {
+    const charmId = "cs:hadoop-client-12";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe("https://charmhub.io/hadoop-client/icon");
+  });
+
+  it("should return a icon URI for a none promulated charm", () => {
+    const charmId = "cs:~containers/kubernetes-master-1106";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe(
+      "https://charmhub.io/containers-kubernetes-master/icon"
+    );
+  });
+
+  it("should return a icon URI for a none promulated charm with release", () => {
+    const charmId = "cs:~hatch/precise/failtester-7";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe("https://charmhub.io/hatch-failtester/icon");
+  });
+
+  it("should return default charm icon if the charm is local", () => {
+    const charmId = "local:my-charm";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe("default-charm-icon.svg");
+  });
+
+  it("should return a icon URI for a charmhub charm path", () => {
+    const charmId = "ch:amd64/xenial/content-cache-425";
+    const iconPath = generateIconPath(charmId);
+    expect(iconPath).toBe("https://charmhub.io/content-cache/icon");
   });
 });


### PR DESCRIPTION
## Done
If loading a `cs:` charm. Parse and generate the charmhub icon URL to load the image from 

## QA
- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://localhost:3001/
- Go to a model and see the icons load from charmhub.io
- _Not that etcd is not in charmhub and so will 404_

## Details
Fixes https://github.com/canonical-web-and-design/jaas-dashboard/issues/1210

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/160660890-c43948a8-7999-443b-8174-403bbd80aaef.png)

